### PR TITLE
Add GitHub token setup for git operations inside sandbox

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,18 @@ OPENAI_COMPAT_BASE_URL=
 OPENAI_COMPAT_API_KEY=
 #
 # ============================================================================
+# RECOMMENDED — GitHub Token (for git operations inside sandbox)
+# ============================================================================
+# Fine-grained PAT with scopes: contents:write, pull_requests:write, actions:read
+# This allows the agent to: clone, commit, push, create PRs, monitor CI
+# This does NOT allow: merging PRs, changing repo settings (human review required)
+#
+# Create one at: https://github.com/settings/personal-access-tokens/new
+# Or run 'make setup-github' to open a pre-configured token creation page
+#
+GITHUB_TOKEN=
+#
+# ============================================================================
 # OPTIONAL — Provider Display Name
 # ============================================================================
 # Human-readable name shown in opencode.json (default: custom-api)

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,16 @@ REPO ?= .
 
 .DEFAULT_GOAL := help
 
-.PHONY: quickstart setup run start validate clean encrypt decrypt models config test smoke unit lint version release-patch release-minor release-major reset-keys help
+.PHONY: quickstart setup setup-github run start validate clean encrypt decrypt models config test smoke unit lint version release-patch release-minor release-major reset-keys help
 
 quickstart:     ## Validate .env, discover models, generate config, encrypt (all-in-one)
 	@./sandbox.sh quickstart
 
 setup:          ## Install prerequisites, generate AGE key, create .sops.yaml
 	@./sandbox.sh setup
+
+setup-github:   ## Open browser to create a GitHub token with correct scopes
+	@./sandbox.sh setup-github
 
 run:            ## Launch sandbox with project (REPO=path)
 	@./sandbox.sh run "$(REPO)"
@@ -77,6 +80,7 @@ help:           ## Show this help
 	@echo ""
 	@echo "Examples:"
 	@echo "  make quickstart                     # All-in-one: setup, models, config, encrypt"
+	@echo "  make setup-github                   # Create GitHub token for git operations"
 	@echo "  make start REPO=~/my-project        # Launch sandbox (alias for 'run')"
 	@echo "  make run REPO=~/my-project          # Launch sandbox"
 	@echo "  make models                         # List available models from API"
@@ -90,5 +94,8 @@ help:           ## Show this help
 	@echo "Required in .env:"
 	@echo "  OPENAI_COMPAT_BASE_URL    API endpoint (e.g., https://api.example.gov/api/v1)"
 	@echo "  OPENAI_COMPAT_API_KEY     API key for the provider"
+	@echo ""
+	@echo "Recommended in .env:"
+	@echo "  GITHUB_TOKEN              Fine-grained PAT for git operations (run 'make setup-github')"
 	@echo ""
 	@echo "Docs: https://github.com/cloud-gov/agent-sandbox"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ See [docs/SECURITY.md](docs/SECURITY.md) for the full threat model.
 |---------|-------------|
 | `make quickstart` | Auto-setup, discover models, generate config, encrypt (all-in-one) |
 | `make setup` | Install prerequisites, generate AGE key |
+| `make setup-github` | Create GitHub token for git operations (opens browser) |
 | `make start REPO=path` | Launch sandbox with project (alias for `run`) |
 | `make run REPO=path` | Launch sandbox with project |
 | `make validate` | Check configuration |
@@ -90,6 +91,18 @@ See [docs/SECURITY.md](docs/SECURITY.md) for the full threat model.
 | `make release-minor` | Release minor version (x.Y+1.0) |
 | `make release-major` | Release major version (X+1.0.0) |
 | `make test` | Run all test suites (requires macOS with sops/age) |
+
+## GitHub Token Setup
+
+For git operations inside the sandbox (clone, commit, push, create PRs), you need a GitHub Personal Access Token:
+
+```bash
+make setup-github    # Opens browser with pre-configured token scopes
+```
+
+The token allows the agent to push code and create PRs, but **cannot merge** (requires human review). Add the token to your `.env` as `GITHUB_TOKEN=github_pat_...` before running `make quickstart`.
+
+See [docs/QUICKSTART.md](docs/QUICKSTART.md#github-token-setup) for details.
 
 ## Model Discovery
 

--- a/config.sh
+++ b/config.sh
@@ -61,3 +61,17 @@ readonly MAX_MODELS_RESPONSE_SIZE=1048576 # 1 MB
 
 # curl timeout for model discovery (seconds)
 readonly MODELS_FETCH_TIMEOUT=30
+
+# --- GitHub Token Setup ---
+
+# Pre-filled URL for creating a fine-grained PAT with correct scopes for AI agents
+# Scopes: contents:write (push), pull_requests:write (create PRs), actions:read (monitor CI)
+# Does NOT include: administration, merge capabilities (enforces human review)
+# URL-encoded description: "AI coding agent. Can push and create PRs but cannot merge."
+readonly GITHUB_TOKEN_URL="https://github.com/settings/personal-access-tokens/new?name=agent-sandbox&description=AI%20coding%20agent.%20Can%20push%20and%20create%20PRs%20but%20cannot%20merge.%20Created%20by%20agent-sandbox.&expires_in=90&contents=write&pull_requests=write&actions=read"
+
+# GitHub token format validation (fine-grained PATs start with github_pat_)
+readonly GITHUB_TOKEN_REGEX='^github_pat_[A-Za-z0-9_]+$'
+
+# GitHub API endpoint for checking token expiration
+readonly GITHUB_API_URL="https://api.github.com"

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -37,6 +37,9 @@ vim .env
 - `OPENAI_COMPAT_BASE_URL` — API endpoint (e.g., `https://api.example.gov/api/v1`)
 - `OPENAI_COMPAT_API_KEY` — API key for your provider
 
+**Recommended settings:**
+- `GITHUB_TOKEN` — Fine-grained PAT for git operations (see [GitHub Token Setup](#github-token-setup) below)
+
 **Optional pass-through keys** (only if your agent needs them):
 - `ANTHROPIC_API_KEY` — for Claude-based agents
 - `OPENAI_API_KEY` — for GPT-based agents
@@ -51,9 +54,10 @@ make quickstart
 This single command automatically:
 1. Generates AGE encryption key (stored in macOS Keychain)
 2. Creates `.sops.yaml` with your public key
-3. Discovers models from your API provider
-4. Generates `opencode.json` config
-5. Encrypts `.env` to `.env.enc` (deletes plaintext)
+3. Validates GitHub token (if configured)
+4. Discovers models from your API provider
+5. Generates `opencode.json` config
+6. Encrypts `.env` to `.env.enc` (deletes plaintext)
 
 ## 4. Launch Sandbox
 
@@ -94,6 +98,51 @@ Verify the sandbox was removed:
 docker sandbox ls  # Should not show agent-sandbox
 ```
 
+## GitHub Token Setup
+
+To enable git operations (clone, commit, push, create PRs) inside the sandbox, you need a GitHub Personal Access Token (PAT) with the correct scopes.
+
+### What the Token Allows
+
+| Operation | Allowed |
+|-----------|---------|
+| Clone repositories | ✅ |
+| Create branches | ✅ |
+| Commit and push | ✅ |
+| Create pull requests | ✅ |
+| Monitor CI status | ✅ |
+| **Merge pull requests** | ❌ (requires human review) |
+| **Change repo settings** | ❌ |
+
+### Creating the Token
+
+```bash
+make setup-github
+```
+
+This opens a pre-configured GitHub token creation page in your browser with:
+- **Name:** `agent-sandbox`
+- **Expiration:** 90 days
+- **Scopes:** `contents:write`, `pull_requests:write`, `actions:read`
+
+After creating the token:
+1. Copy the token (starts with `github_pat_`)
+2. Add it to your `.env` file:
+   ```
+   GITHUB_TOKEN=github_pat_xxxxxxxxxxxx
+   ```
+3. Run `make quickstart` to encrypt
+
+### Adding Token After Initial Setup
+
+If you already ran quickstart without a GitHub token:
+
+```bash
+make decrypt          # Decrypt .env for editing
+vim .env              # Add GITHUB_TOKEN=github_pat_...
+make encrypt          # Re-encrypt
+```
+
 ## Editing Secrets Later
 
 ```bash
@@ -113,3 +162,5 @@ make encrypt    # Re-encrypts and removes plaintext
 | `.sops.yaml has placeholder key` | Run `make quickstart` — AGE key generation may have failed |
 | Sandbox won't start | `make clean` then retry |
 | Network blocks not applying | Check Docker Desktop version supports `docker sandbox network proxy` |
+| Git operations fail | Run `make setup-github` and add token to `.env` |
+| GitHub token invalid | Token may have expired — create a new one with `make setup-github` |

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -552,6 +552,63 @@ cmd_config() {
 	audit "config" "generated ${config_file} with ${model_count} models"
 }
 
+cmd_setup_github() {
+	log "=== GitHub Token Setup ==="
+	echo ""
+	log "This will help you create a GitHub Personal Access Token (PAT) with the correct"
+	log "scopes for AI agent use. The token allows the agent to:"
+	log "  - Clone, commit, and push code"
+	log "  - Create pull requests"
+	log "  - Monitor CI workflow status"
+	echo ""
+	log "The token does NOT allow:"
+	log "  - Merging pull requests (requires human review)"
+	log "  - Changing repository settings"
+	echo ""
+
+	# Open the pre-filled GitHub token creation page
+	log "Opening GitHub token creation page in your browser..."
+	log "URL: ${GITHUB_TOKEN_URL}"
+	echo ""
+
+	if command -v open >/dev/null 2>&1; then
+		open "$GITHUB_TOKEN_URL"
+	else
+		log "Could not open browser automatically. Please visit the URL above."
+	fi
+
+	echo ""
+	log "After creating the token:"
+	log "  1. Copy the token (starts with 'github_pat_')"
+	log "  2. Paste it into your .env file as GITHUB_TOKEN=<your-token>"
+	log "  3. Run 'make quickstart' to continue"
+	echo ""
+	audit "setup-github" "opened token creation page"
+}
+
+check_github_token_expiry() {
+	local token="${1:-}"
+	[[ -z "$token" ]] && return 1
+
+	# Check token validity and get expiration info via GitHub API
+	local response
+	response=$(curl -sf -H "Authorization: Bearer $token" \
+		-H "Accept: application/vnd.github+json" \
+		"${GITHUB_API_URL}/user" 2>/dev/null) || return 1
+
+	# Token is valid if we get here
+	# Note: Fine-grained PAT expiration isn't directly exposed in /user response
+	# We'd need to check /installation/token or parse the token metadata
+	# For now, just validate the token works
+	local username
+	username=$(echo "$response" | jq -r '.login // empty')
+	if [[ -n "$username" ]]; then
+		log "  GitHub token valid (user: ${username})"
+		return 0
+	fi
+	return 1
+}
+
 cmd_quickstart() {
 	log "=== Agent Sandbox Quickstart ==="
 	echo ""
@@ -567,12 +624,12 @@ cmd_quickstart() {
 	local needs_setup=false
 	if ! security find-generic-password -a "$USER" -s "$KEYCHAIN_SERVICE" -w >/dev/null 2>&1; then
 		needs_setup=true
-		log "Step 1/5: Running initial setup (AGE key not found)..."
+		log "Step 1/6: Running initial setup (AGE key not found)..."
 	elif [[ ! -f ".sops.yaml" ]] || grep -q "$PLACEHOLDER_KEY" .sops.yaml 2>/dev/null; then
 		needs_setup=true
-		log "Step 1/5: Running initial setup (.sops.yaml not configured)..."
+		log "Step 1/6: Running initial setup (.sops.yaml not configured)..."
 	else
-		log "Step 1/5: Setup already complete"
+		log "Step 1/6: Setup already complete"
 	fi
 
 	if [[ "$needs_setup" == "true" ]]; then
@@ -595,28 +652,52 @@ cmd_quickstart() {
 	[[ -n "${OPENAI_COMPAT_BASE_URL:-}" ]] || err "OPENAI_COMPAT_BASE_URL not set in ${ENV_FILE}. Edit .env and re-run: make quickstart"
 	[[ -n "${OPENAI_COMPAT_API_KEY:-}" ]] || err "OPENAI_COMPAT_API_KEY not set in ${ENV_FILE}. Edit .env and re-run: make quickstart"
 
-	log "Step 2/5: Settings validated"
+	log "Step 2/6: API settings validated"
 	log "  Provider URL: ${OPENAI_COMPAT_BASE_URL}"
 	log "  Provider name: ${OPENAI_COMPAT_PROVIDER_NAME:-$DEFAULT_PROVIDER_NAME}"
 	echo ""
 
-	# Step 3: Discover models
-	log "Step 3/5: Discovering models..."
+	# Step 3: Check GitHub token (recommended but not required)
+	log "Step 3/6: Checking GitHub token..."
+	if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+		if check_github_token_expiry "$GITHUB_TOKEN"; then
+			log "  GitHub token: OK"
+		else
+			log "  WARNING: GitHub token is set but could not be validated"
+			log "  Git operations may fail. Run 'make setup-github' to create a new token."
+		fi
+	else
+		log "  GitHub token: Not configured (optional)"
+		log "  For git operations, run 'make setup-github' and add GITHUB_TOKEN to .env"
+	fi
+	echo ""
+
+	# Step 4: Discover models
+	log "Step 4/6: Discovering models..."
 	cmd_models
 	echo ""
 
-	# Step 4: Generate config
-	log "Step 4/5: Generating opencode.json..."
+	# Step 5: Generate config
+	log "Step 5/6: Generating opencode.json..."
 	cmd_config
 	echo ""
 
-	# Step 5: Encrypt .env
-	log "Step 5/5: Encrypting .env..."
+	# Step 6: Encrypt .env
+	log "Step 6/6: Encrypting .env..."
 	cmd_encrypt
 
 	echo ""
 	log "=== Quickstart complete ==="
-	log "Next: make run REPO=~/your-project"
+	if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+		log ""
+		log "NOTE: No GitHub token configured. To enable git operations:"
+		log "  1. Run 'make setup-github' to create a token"
+		log "  2. Run 'make decrypt' to edit .env"
+		log "  3. Add your token as GITHUB_TOKEN=github_pat_..."
+		log "  4. Run 'make encrypt' to re-encrypt"
+	fi
+	log ""
+	log "Next: make start REPO=~/your-project"
 	audit "quickstart" "completed"
 }
 
@@ -624,6 +705,7 @@ cmd_quickstart() {
 
 case "${1:-help}" in
 setup) cmd_setup ;;
+setup-github) cmd_setup_github ;;
 run) cmd_run "${2:-}" ;;
 validate) cmd_validate ;;
 clean) cmd_clean ;;
@@ -641,20 +723,21 @@ version | --version | -V)
 	fi
 	;;
 help | --help | -h)
-	echo "Usage: $0 {quickstart|setup|run [repo_path]|validate|clean|encrypt|decrypt|models|config|version|help}"
+	echo "Usage: $0 {quickstart|setup|setup-github|run [repo_path]|validate|clean|encrypt|decrypt|models|config|version|help}"
 	echo ""
 	echo "Commands:"
-	echo "  quickstart  Validate .env, discover models, generate config, encrypt (all-in-one)"
-	echo "  setup       Install prerequisites, generate AGE key, create .sops.yaml"
-	echo "  run         Launch OpenCode in a Docker sandbox with encrypted secrets"
-	echo "  validate    Check all prerequisites are configured"
-	echo "  clean       Stop and remove the sandbox"
-	echo "  encrypt     Encrypt .env → .env.enc (removes plaintext)"
-	echo "  decrypt     Decrypt .env.enc → .env (for editing)"
-	echo "  models      List available models from OpenAI-compatible API"
-	echo "  config      Generate opencode.json from discovered models"
-	echo "  version     Print version"
-	echo "  help        Show this help message"
+	echo "  quickstart     Validate .env, discover models, generate config, encrypt (all-in-one)"
+	echo "  setup          Install prerequisites, generate AGE key, create .sops.yaml"
+	echo "  setup-github   Open browser to create a GitHub token with correct scopes"
+	echo "  run            Launch OpenCode in a Docker sandbox with encrypted secrets"
+	echo "  validate       Check all prerequisites are configured"
+	echo "  clean          Stop and remove the sandbox"
+	echo "  encrypt        Encrypt .env → .env.enc (removes plaintext)"
+	echo "  decrypt        Decrypt .env.enc → .env (for editing)"
+	echo "  models         List available models from OpenAI-compatible API"
+	echo "  config         Generate opencode.json from discovered models"
+	echo "  version        Print version"
+	echo "  help           Show this help message"
 	;;
 *) err "Unknown command: $1. Run '$0 help' for usage." ;;
 esac

--- a/test/sandbox-unit.sh
+++ b/test/sandbox-unit.sh
@@ -1213,6 +1213,33 @@ check "quickstart: listed in help" bash -c "bash sandbox.sh help 2>&1 | grep -q 
 echo ""
 
 # -----------------------------------------------------------------------
+# 52. GitHub token setup tests
+# -----------------------------------------------------------------------
+echo "GitHub token setup:"
+
+# Test: setup-github command exists and shows help
+check "setup-github: listed in help" bash -c "bash sandbox.sh help 2>&1 | grep -q 'setup-github'"
+
+# Test: GITHUB_TOKEN_URL constant is defined in config.sh
+check "GITHUB_TOKEN_URL: constant defined" bash -c "source config.sh && test -n \"\$GITHUB_TOKEN_URL\""
+
+# Test: GITHUB_TOKEN_URL has correct scopes
+check "GITHUB_TOKEN_URL: has contents=write" bash -c "source config.sh && echo \"\$GITHUB_TOKEN_URL\" | grep -q 'contents=write'"
+check "GITHUB_TOKEN_URL: has pull_requests=write" bash -c "source config.sh && echo \"\$GITHUB_TOKEN_URL\" | grep -q 'pull_requests=write'"
+check "GITHUB_TOKEN_URL: has actions=read" bash -c "source config.sh && echo \"\$GITHUB_TOKEN_URL\" | grep -q 'actions=read'"
+
+# Test: GITHUB_TOKEN_URL does NOT include dangerous scopes
+check "GITHUB_TOKEN_URL: no admin scope" bash -c "source config.sh && ! echo \"\$GITHUB_TOKEN_URL\" | grep -q 'admin'"
+
+# Test: .env.example mentions GITHUB_TOKEN
+check ".env.example: has GITHUB_TOKEN" grep -q "GITHUB_TOKEN" .env.example
+
+# Test: Makefile has setup-github target
+check "Makefile: has setup-github target" grep -q "setup-github:" Makefile
+
+echo ""
+
+# -----------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------
 summary


### PR DESCRIPTION
## Summary

Adds `make setup-github` command that opens a pre-configured GitHub token creation page with the correct fine-grained PAT scopes for AI agents.

## What the Token Allows

| Operation | Allowed |
|-----------|---------|
| Clone repositories | ✅ |
| Create branches | ✅ |
| Commit and push | ✅ |
| Create pull requests | ✅ |
| Monitor CI status | ✅ |
| **Merge pull requests** | ❌ (requires human review) |
| **Change repo settings** | ❌ |

## Token Scopes

The pre-filled URL creates a token with:
- `contents:write` — push code
- `pull_requests:write` — create PRs
- `actions:read` — monitor CI
- 90-day expiration

## Changes

| File | Change |
|------|--------|
| `.env.example` | Add `GITHUB_TOKEN` with documentation |
| `config.sh` | Add `GITHUB_TOKEN_URL` constant |
| `sandbox.sh` | Add `cmd_setup_github()` and `check_github_token_expiry()` |
| `sandbox.sh` | Update `cmd_quickstart()` to validate token (step 3/6) |
| `Makefile` | Add `setup-github` target |
| `README.md` | Add GitHub Token Setup section |
| `docs/QUICKSTART.md` | Comprehensive GitHub token documentation |
| `test/sandbox-unit.sh` | Tests for GitHub token functionality |

## User Flow

```bash
# Option 1: Set up token before quickstart
make setup-github     # Opens browser with pre-configured token page
vim .env              # Add GITHUB_TOKEN=github_pat_...
make quickstart       # Validates token during setup

# Option 2: Add token after quickstart
make quickstart       # Shows helpful message about missing token
make setup-github     # Create token
make decrypt          # Edit .env
vim .env              # Add GITHUB_TOKEN
make encrypt          # Re-encrypt
```

## Testing

- [x] ShellCheck passes
- [x] CI should pass (new tests for GitHub token functionality)