### PR TITLE
docs: clarify docker sandboxes installation with dual-method instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,84 @@ AI coding agents can read files, write code, and execute commands. Running them 
 - **Reproducibility:** Same environment every time
 - **Audit trail:** Clear boundaries for what the agent can do
 
+## What is Docker Sandboxes?
+
+[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) runs AI coding agents in isolated microVM environments. Each sandbox gets its own Docker daemon, filesystem, and network—the agent can build containers, install packages, and modify files without touching your host system.
+
+There are **two ways** to use Docker Sandboxes:
+
+| Method | Install | Command Prefix | Best For |
+|--------|---------|----------------|----------|
+| **Docker Desktop built-in** | None (Docker Desktop 4.58+) | `docker sandbox` | Quick start, GFE Macs with managed Docker |
+| **Standalone sbx CLI** | Homebrew/Winget/apt | `sbx` | Full features, more flexibility |
+
+**Recommended:** Start with `docker sandbox` if you already have Docker Desktop. Upgrade to `sbx` CLI later if you need advanced features.
+
 ## Prerequisites
 
-- **SBX CLI** installed (`sbx --version` to verify)
+- **Docker Desktop 4.58+** (check: `docker --version`) — OR — **sbx CLI** installed (`sbx --version`)
 - **USAi API key** from your agency's pilot program
 - **Docker** running locally
 
+## Installing Docker Sandboxes
+
+### Option A: Docker Desktop Built-in (Recommended for GFE Macs)
+
+If you have **Docker Desktop 4.58 or later**, sandboxes are already built-in. No extra installation needed.
+
+```bash
+# Verify you have the sandbox command
+docker sandbox --help
+```
+
+> **Note:** On some managed Docker installations, the command is `docker sandbox` (two words), not `docker sbx`.
+
+### Option B: Standalone sbx CLI (More Features)
+
+The standalone CLI offers more features and doesn't require Docker Desktop:
+
+**macOS (Homebrew):**
+```bash
+brew install docker/tap/sbx
+sbx login
+```
+
+**Windows (Winget):**
+```powershell
+winget install -h Docker.sbx
+sbx login
+```
+
+**Linux (Ubuntu):**
+```bash
+curl -fsSL https://get.docker.com | sudo REPO_ONLY=1 sh
+sudo apt-get install docker-sbx
+sudo usermod -aG kvm $USER
+newgrp kvm
+sbx login
+```
+
+See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for full installation details.
+
 ## Quick Start (3 Commands)
+
+### Using Docker Desktop (`docker sandbox`)
+
+```bash
+# 1. Set your API key in your shell config (~/.bashrc or ~/.zshrc)
+#    Then source it and restart Docker Desktop
+export USAI_API_KEY="your-api-key-here"
+
+# 2. Clone this repo and create a sandbox
+git clone https://github.com/GSA-TTS/agentic-coding-quickstart.git
+cd agentic-coding-quickstart
+docker sandbox create --name quickstart opencode .
+
+# 3. Run OpenCode
+docker sandbox run quickstart
+```
+
+### Using Standalone CLI (`sbx`)
 
 ```bash
 # 1. Set your API key (on your host machine)
@@ -36,6 +107,17 @@ sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) quickstart opencode
 ```
 
 That's it. You're now running an AI coding agent in an isolated container with USAi access.
+
+### Command Comparison
+
+| Action | Docker Desktop | Standalone sbx CLI |
+|--------|----------------|--------------------|
+| Create sandbox | `docker sandbox create --name NAME opencode .` | `sbx create --name NAME opencode .` |
+| Run/connect | `docker sandbox run NAME` | `sbx run NAME` |
+| Run with env vars | (set in shell config, restart Docker) | `sbx exec -it -e VAR="$VAR" NAME cmd` |
+| List sandboxes | `docker sandbox ls` | `sbx ls` |
+| Remove sandbox | `docker sandbox rm NAME` | `sbx rm NAME` |
+| Set secrets | N/A (use shell config) | `sbx secret set -g SERVICE` |
 
 ## What's in This Repo
 
@@ -77,6 +159,27 @@ If you've bootstrapped your project using the [Agentic Coding Playbook](https://
 - **Quickstart** → USAi configuration, SBX patterns, credential injection
 
 ## Key Commands
+
+### Docker Desktop (`docker sandbox`)
+
+```bash
+# Create a sandbox
+docker sandbox create --name my-sandbox opencode .
+
+# Run/connect to sandbox
+docker sandbox run my-sandbox
+
+# List your sandboxes
+docker sandbox ls
+
+# Remove a sandbox
+docker sandbox rm my-sandbox
+
+# Reset all sandboxes
+docker sandbox reset
+```
+
+### Standalone CLI (`sbx`)
 
 ```bash
 # Create a sandbox
@@ -137,17 +240,25 @@ See [docs/SBX_QUICKSTART.md](docs/SBX_QUICKSTART.md) for full credential injecti
 
 ## Troubleshooting
 
+**"docker: unknown command: docker sbx"**
+- Use `docker sandbox` (two words), not `docker sbx`
+- If that doesn't work, verify Docker Desktop version: `docker --version` (need 4.58+)
+- Alternatively, install the standalone `sbx` CLI via Homebrew
+
 **OpenCode shows wrong providers (OpenAI, Anthropic, etc.)**
 - Make sure you're in this repo's directory
-- Use `-w $(pwd)` to set the working directory
+- For `sbx`: Use `-w $(pwd)` to set the working directory
+- For `docker sandbox`: The workspace is auto-mounted
 - Verify `opencode.jsonc` exists
 
 **Authentication failed**
 - Check your API key: `echo "Length: ${#USAI_API_KEY}"`
-- Ensure you're using `-e USAI_API_KEY="$USAI_API_KEY"` flag
+- For `sbx`: Ensure you're using `-e USAI_API_KEY="$USAI_API_KEY"` flag
+- For `docker sandbox`: Set the key in `~/.bashrc` or `~/.zshrc`, source it, and restart Docker Desktop
 
 **"Unknown agent" error**
-- Use: `sbx create --name NAME opencode .` (note the `opencode .` at the end)
+- Use: `docker sandbox create --name NAME opencode .` or `sbx create --name NAME opencode .`
+- Note the `opencode .` at the end (agent type and workspace path)
 
 See `docs/KNOWN_FAILURE_MODES.md` for more troubleshooting help.
 

--- a/docs/SBX_QUICKSTART.md
+++ b/docs/SBX_QUICKSTART.md
@@ -1,16 +1,91 @@
-# SBX + USAi Quick Start
+# Docker Sandboxes + USAi Quick Start
 
-This guide gets you from zero to running an AI agent inside SBX with USAi in under 5 minutes.
+This guide gets you from zero to running an AI agent inside Docker Sandboxes with USAi in under 5 minutes.
+
+## What is Docker Sandboxes?
+
+[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) runs AI coding agents in isolated microVM environments. Each sandbox gets its own Docker daemon, filesystem, and network—the agent can build containers, install packages, and modify files without touching your host system.
+
+There are **two ways** to use Docker Sandboxes:
+
+| Method | Install | Command Prefix | Best For |
+|--------|---------|----------------|----------|
+| **Docker Desktop built-in** | None (Docker Desktop 4.58+) | `docker sandbox` | Quick start, GFE Macs with managed Docker |
+| **Standalone sbx CLI** | Homebrew/Winget/apt | `sbx` | Full features, secret proxy, more flexibility |
+
+> **Which should I use?** Start with `docker sandbox` if you already have Docker Desktop 4.58+. The standalone `sbx` CLI offers additional features like the secret proxy (for GitHub tokens) and more granular control. Both work for basic USAi usage.
 
 ## Prerequisites
 
-- SBX CLI installed (`sbx --version`)
+**Choose one:**
+- **Docker Desktop 4.58+** (`docker --version` to check) — sandboxes built-in, no extra install
+- **Standalone sbx CLI** (`sbx --version` to check) — install via Homebrew/Winget/apt
+
+**Plus:**
 - USAi API key (set as `USAI_API_KEY` environment variable on host)
 - This repository cloned locally
 - (Optional) GitHub CLI logged in (`gh auth status`)
 - (Optional) GitLab CLI logged in (`glab auth status`)
 
+## Installing Docker Sandboxes
+
+### Option A: Docker Desktop Built-in (No Extra Install)
+
+If you have **Docker Desktop 4.58 or later**, sandboxes are already included. Verify:
+
+```bash
+docker sandbox --help
+```
+
+> **Note:** On some managed Docker installations (like GSA GFE Macs), the command is `docker sandbox` (two words), not `docker sbx`. If `docker sbx` returns "unknown command", try `docker sandbox`.
+
+### Option B: Standalone sbx CLI (More Features)
+
+The standalone CLI offers additional features (secret proxy, network policies) and doesn't require Docker Desktop.
+
+**macOS (Homebrew):**
+```bash
+brew install docker/tap/sbx
+sbx login
+```
+
+**Windows (Winget):**
+```powershell
+winget install -h Docker.sbx
+sbx login
+```
+
+**Linux (Ubuntu):**
+```bash
+curl -fsSL https://get.docker.com | sudo REPO_ONLY=1 sh
+sudo apt-get install docker-sbx
+sudo usermod -aG kvm $USER
+newgrp kvm
+sbx login
+```
+
+See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for full details.
+
 ## Quick Start (3 Commands)
+
+### Using Docker Desktop (`docker sandbox`)
+
+```bash
+# 1. Set your API key in your shell config file (~/.bashrc or ~/.zshrc)
+echo 'export USAI_API_KEY="your-api-key-here"' >> ~/.zshrc
+source ~/.zshrc
+# IMPORTANT: Restart Docker Desktop so it picks up the new variable
+
+# 2. Create a sandbox for OpenCode in current directory
+docker sandbox create --name usai-test opencode .
+
+# 3. Run OpenCode (connects to the sandbox)
+docker sandbox run usai-test
+```
+
+> **Important:** Docker Desktop reads environment variables from your shell config at startup. After adding `USAI_API_KEY` to `~/.bashrc` or `~/.zshrc`, you must restart Docker Desktop for it to take effect.
+
+### Using Standalone CLI (`sbx`)
 
 ```bash
 # 1. Verify your API key is set on the HOST (should show key length, not the key itself)
@@ -27,16 +102,46 @@ That's it. You're now running an AI agent in an isolated container with USAi acc
 
 > **Important:** USAi requires manual API key injection because it uses a custom endpoint. SBX's built-in secret proxy only works with standard provider endpoints (OpenAI, Anthropic, etc.).
 
+### Command Comparison Reference
+
+| Action | Docker Desktop | Standalone sbx CLI |
+|--------|----------------|--------------------|
+| Create sandbox | `docker sandbox create --name NAME opencode .` | `sbx create --name NAME opencode .` |
+| Run/connect | `docker sandbox run NAME` | `sbx run NAME` |
+| Run with env vars | Set in shell config + restart Docker | `sbx exec -it -e VAR="$VAR" NAME cmd` |
+| List sandboxes | `docker sandbox ls` | `sbx ls` |
+| Stop sandbox | (sandboxes auto-stop) | `sbx stop NAME` |
+| Remove sandbox | `docker sandbox rm NAME` | `sbx rm NAME` |
+| Set secrets | N/A (use shell config) | `sbx secret set -g SERVICE` |
+| Reset all | `docker sandbox reset` | (remove individually) |
+
 ## Credential Injection Overview
 
-SBX supports two methods for injecting credentials:
+How credentials are handled differs between Docker Desktop and the standalone CLI:
+
+### Docker Desktop (`docker sandbox`)
+
+Docker Desktop reads environment variables from your shell configuration file (`~/.bashrc`, `~/.zshrc`) at startup. The sandbox proxy injects credentials into API requests, so keys stay on your host.
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export USAI_API_KEY="your-api-key"
+export ANTHROPIC_API_KEY="your-key"  # if using Claude directly
+export GH_TOKEN="your-github-token"  # for GitHub access
+```
+
+After adding variables, **source your config and restart Docker Desktop**.
+
+### Standalone CLI (`sbx`)
+
+The `sbx` CLI supports two methods:
 
 | Method | Security | Use Case | Supported Services |
 |--------|----------|----------|-------------------|
 | **SBX Proxy** (recommended) | High - agent never sees token | Standard API endpoints | `anthropic`, `aws`, `cursor`, `github`, `google`, `groq`, `mistral`, `nebius`, `openai`, `xai` |
 | **Direct Injection** (`-e`) | Medium - token in container env | Custom endpoints (USAi, GitLab) | Any service |
 
-**Rule of thumb:** Use SBX proxy when available; use direct injection for custom endpoints.
+**Rule of thumb:** Use SBX proxy when available; use direct injection for custom endpoints like USAi.
 
 ---
 
@@ -45,6 +150,19 @@ SBX supports two methods for injecting credentials:
 Agents often need git credentials for cloning private repos, creating PRs, or pushing changes. Here's how to inject them securely.
 
 ### GitHub (github.com)
+
+#### Using Docker Desktop
+
+Add to your shell config and restart Docker Desktop:
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export GH_TOKEN="$(gh auth token)"
+# Or use a personal access token directly
+export GITHUB_TOKEN="your-github-pat"
+```
+
+#### Using Standalone sbx CLI
 
 GitHub is a **built-in SBX service**, so the proxy method works:
 
@@ -81,7 +199,17 @@ sbx exec SANDBOX_NAME sh -c 'curl -s -H "Authorization: Bearer test" https://api
 
 ### GitLab (Custom Instances)
 
-GitLab is **NOT a built-in SBX service**, so you must use direct injection:
+GitLab is **NOT a built-in service** for either method, so you must use direct injection/shell config:
+
+#### Using Docker Desktop
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export GITLAB_TOKEN="your-gitlab-token"
+export GITLAB_HOST="workshop.cloud.gov"  # for self-hosted
+```
+
+#### Using Standalone sbx CLI
 
 ```bash
 # For gitlab.com
@@ -104,7 +232,7 @@ sbx exec -it \
 sbx exec SANDBOX_NAME sh -c 'curl -s -H "PRIVATE-TOKEN: $GITLAB_TOKEN" https://$GITLAB_HOST/api/v4/user | jq .username'
 ```
 
-### Combined: USAi + GitHub + GitLab
+### Combined: USAi + GitHub + GitLab (sbx CLI)
 
 For agents that need all three:
 
@@ -122,11 +250,11 @@ sbx exec -it \
 
 ### Git Credential Summary
 
-| Provider | SBX Proxy | Direct Injection | CLI to Extract Token |
-|----------|-----------|------------------|---------------------|
-| GitHub (github.com) | `sbx secret set -g github` | `-e GH_TOKEN="$(gh auth token)"` | `gh auth token` |
-| GitLab.com | Not supported | `-e GITLAB_TOKEN="..."` | `glab config get token` |
-| GitLab (self-hosted) | Not supported | `-e GITLAB_TOKEN="..." -e GITLAB_HOST="..."` | `glab config get --host HOST token` |
+| Provider | Docker Desktop | sbx CLI (Proxy) | sbx CLI (Direct) |
+|----------|----------------|-----------------|------------------|
+| GitHub | `GH_TOKEN` in shell config | `sbx secret set -g github` | `-e GH_TOKEN="$(gh auth token)"` |
+| GitLab.com | `GITLAB_TOKEN` in shell config | Not supported | `-e GITLAB_TOKEN="..."` |
+| GitLab (self-hosted) | `GITLAB_TOKEN` + `GITLAB_HOST` | Not supported | `-e GITLAB_TOKEN="..." -e GITLAB_HOST="..."` |
 
 ---
 
@@ -137,17 +265,20 @@ sbx exec -it \
 **On your host machine** (not inside the container):
 
 ```bash
-# Option A: Export for current session
+# Option A: Export for current session (sbx CLI only)
 export USAI_API_KEY="your-api-key-here"
 
-# Option B: Add to shell profile (bash)
+# Option B: Add to shell profile (required for Docker Desktop, recommended for both)
+# For bash:
 echo 'export USAI_API_KEY="your-api-key-here"' >> ~/.bashrc
 source ~/.bashrc
 
-# Option C: Add to shell profile (zsh)
+# For zsh:
 echo 'export USAI_API_KEY="your-api-key-here"' >> ~/.zshrc
 source ~/.zshrc
 ```
+
+> **Docker Desktop users:** After adding to your shell config, **restart Docker Desktop** so it picks up the new variable.
 
 **Verify it's set** (safe command - only shows length):
 ```bash
@@ -157,15 +288,20 @@ echo "Key length: ${#USAI_API_KEY}"
 
 ### Step 2: Create a Sandbox
 
-SBX requires specifying an agent type and workspace path:
+Both methods require specifying an agent type and workspace path:
 
 ```bash
-# Create a sandbox for OpenCode in current directory
 cd /path/to/your-project
+
+# Docker Desktop
+docker sandbox create --name my-sandbox opencode .
+
+# OR Standalone sbx CLI
 sbx create --name my-sandbox opencode .
 
 # Verify it exists
-sbx ls
+docker sandbox ls   # Docker Desktop
+sbx ls              # Standalone CLI
 ```
 
 **Available agents:** `claude`, `codex`, `copilot`, `docker-agent`, `gemini`, `kiro`, `opencode`, `shell`
@@ -174,6 +310,9 @@ sbx ls
 
 If your agent needs to interact with GitHub:
 
+**Docker Desktop:** Add `GH_TOKEN` to your shell config and restart Docker Desktop.
+
+**Standalone sbx CLI:**
 ```bash
 # Recommended: Use SBX proxy for GitHub
 gh auth token | sbx secret set -g github
@@ -181,7 +320,15 @@ gh auth token | sbx secret set -g github
 
 ### Step 4: Run OpenCode with USAi
 
-**Important:** USAi uses a custom endpoint, so you must inject the API key manually:
+**Docker Desktop:**
+```bash
+# Simply run (environment variables come from shell config)
+docker sandbox run my-sandbox
+```
+
+**Standalone sbx CLI:**
+
+USAi uses a custom endpoint, so you must inject the API key manually:
 
 ```bash
 # Basic: USAi only
@@ -214,6 +361,30 @@ This is still secure because:
 
 ### Sandbox Management
 
+#### Docker Desktop (`docker sandbox`)
+
+```bash
+# Create a sandbox
+docker sandbox create --name my-sandbox opencode .
+
+# Run/connect to sandbox
+docker sandbox run my-sandbox
+
+# List sandboxes
+docker sandbox ls
+
+# Execute a command in sandbox
+docker sandbox exec -it my-sandbox bash
+
+# Remove a sandbox
+docker sandbox rm my-sandbox
+
+# Reset all sandboxes
+docker sandbox reset
+```
+
+#### Standalone CLI (`sbx`)
+
 ```bash
 # Create a sandbox (AGENT = claude|codex|copilot|gemini|kiro|opencode|shell)
 sbx create AGENT PATH
@@ -232,7 +403,7 @@ sbx stop SANDBOX_NAME
 sbx rm SANDBOX_NAME
 ```
 
-### Secret Management
+### Secret Management (sbx CLI only)
 
 ```bash
 # Set a secret globally (prompts for value)
@@ -255,7 +426,7 @@ sbx secret rm SERVICE
 
 > **How it works:** SBX proxies API requests from the agent and injects authentication headers automatically. The agent never sees the raw secret.
 
-### Environment Variable Injection
+### Environment Variable Injection (sbx CLI)
 
 For services not supported by SBX proxy (USAi, GitLab, custom APIs):
 
@@ -272,6 +443,21 @@ sbx exec \
 ```
 
 ### Executing Commands
+
+#### Docker Desktop
+
+```bash
+# Run sandbox (uses env vars from shell config)
+docker sandbox run SANDBOX_NAME
+
+# Execute a command
+docker sandbox exec -it SANDBOX_NAME bash
+
+# Pass agent-specific options (use -- separator)
+docker sandbox run SANDBOX_NAME -- --continue
+```
+
+#### Standalone sbx CLI
 
 ```bash
 # Run OpenCode with USAi (the working pattern)
@@ -297,6 +483,24 @@ sbx exec -e VAR="value" SANDBOX_NAME COMMAND
 
 ### Debugging
 
+#### Docker Desktop
+
+```bash
+# Shell into sandbox
+docker sandbox exec -it SANDBOX_NAME bash
+
+# Check environment variables
+docker sandbox exec -it SANDBOX_NAME bash -c 'echo "USAI key length: ${#USAI_API_KEY}"'
+
+# Check workspace contents
+docker sandbox exec -it SANDBOX_NAME ls -la
+
+# View network activity
+docker sandbox network log
+```
+
+#### Standalone sbx CLI
+
 ```bash
 # Check if secrets are available inside sandbox
 sbx exec SANDBOX_NAME sh -c 'echo "USAI key length: ${#USAI_API_KEY}"'
@@ -321,14 +525,28 @@ sbx exec SANDBOX_NAME ls -la
 
 ## Troubleshooting
 
+### "docker: unknown command: docker sbx"
+
+**Problem:** Running `docker sbx` returns "unknown command".
+
+**Fix:** The correct command is `docker sandbox` (two words), not `docker sbx`. If that also doesn't work:
+1. Check Docker Desktop version: `docker --version` (need 4.58+)
+2. Verify the plugin exists: `ls ~/.docker/cli-plugins/docker-sandbox`
+3. Alternatively, install the standalone `sbx` CLI via Homebrew:
+   ```bash
+   brew install docker/tap/sbx
+   ```
+
 ### "unknown agent" error
 
-**Problem:** `sbx create usai-test` fails with "unknown agent".
+**Problem:** `docker sandbox create usai-test` or `sbx create usai-test` fails with "unknown agent".
 
-**Fix:** SBX requires an agent type. Use:
+**Fix:** You must specify an agent type. Use:
 ```bash
-sbx create opencode .
-# Or with custom name:
+# Docker Desktop
+docker sandbox create --name usai-test opencode .
+
+# Standalone CLI
 sbx create --name usai-test opencode .
 ```
 
@@ -339,15 +557,26 @@ sbx create --name usai-test opencode .
 **Root Cause:** Either:
 1. API key not injected properly
 2. Config file not found
-3. Working directory not set
+3. Working directory not set (sbx CLI)
+4. Docker Desktop not restarted after setting env var
 
-**Fix:** Use the full command with all flags:
+**Fix for Docker Desktop:**
+1. Ensure `USAI_API_KEY` is in `~/.bashrc` or `~/.zshrc`
+2. Source the file: `source ~/.zshrc`
+3. **Restart Docker Desktop** (this is required!)
+4. Run: `docker sandbox run usai-test`
+
+**Fix for sbx CLI:**
 ```bash
 sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) usai-test opencode
 ```
 
 Verify the config exists:
 ```bash
+# Docker Desktop
+docker sandbox exec -it usai-test cat /path/to/opencode.jsonc
+
+# sbx CLI
 sbx exec usai-test cat $(pwd)/opencode.jsonc
 ```
 
@@ -355,7 +584,11 @@ sbx exec usai-test cat $(pwd)/opencode.jsonc
 
 **Problem:** Agent can't authenticate to USAi.
 
-**Fix:** USAi requires manual key injection (SBX proxy doesn't work with custom endpoints):
+**Fix for Docker Desktop:**
+1. Add to shell config: `export USAI_API_KEY="your-key"`
+2. Source config and **restart Docker Desktop**
+
+**Fix for sbx CLI:**
 ```bash
 sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) usai-test opencode
 ```
@@ -369,7 +602,10 @@ echo "Key length: ${#USAI_API_KEY}"
 
 **Problem:** GitHub API calls fail despite having `gh` logged in.
 
-**Fix:** Ensure GitHub secret is set in SBX:
+**Fix for Docker Desktop:**
+Add `GH_TOKEN` or `GITHUB_TOKEN` to your shell config and restart Docker Desktop.
+
+**Fix for sbx CLI:**
 ```bash
 # Check if github secret exists
 sbx secret ls

--- a/templates/AGENTS_SBX_ADDENDUM.md
+++ b/templates/AGENTS_SBX_ADDENDUM.md
@@ -1,9 +1,18 @@
-# SBX + USAi Addendum for AGENTS.md
+# Docker Sandboxes + USAi Addendum for AGENTS.md
 
 > **Instructions:** Append this content to your existing AGENTS.md file.
 > If you don't have an AGENTS.md, consider using the [Agentic Coding Playbook](https://github.com/GSA-TTS/agentic-coding-playbook) to generate one first.
 
 ---
+
+## Docker Sandboxes Overview
+
+[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) runs AI coding agents in isolated microVM environments. There are two ways to use it:
+
+| Method | Command Prefix | Best For |
+|--------|----------------|----------|
+| **Docker Desktop built-in** | `docker sandbox` | GFE Macs with managed Docker (4.58+) |
+| **Standalone sbx CLI** | `sbx` | Full features, secret proxy |
 
 ## SBX-Specific Rules (Non-Negotiable)
 
@@ -16,8 +25,8 @@ The agent MUST NEVER:
 - Include secrets in commit messages, comments, or documentation
 
 All secrets MUST be accessed via:
-- SBX secret management (for supported services like GitHub)
-- Environment variables injected at runtime via `-e` flag (not persisted)
+- Docker Desktop: Environment variables set in shell config (read by Docker at startup)
+- sbx CLI: Secret management (`sbx secret set`) or runtime injection (`-e` flag)
 
 ### 2. Assume You Are Untrusted
 
@@ -26,10 +35,10 @@ Agents must behave as if:
 - Outputs may be logged and reviewed
 - Any exposed secret is considered compromised
 
-### 3. SBX Is the Security Boundary
+### 3. Sandbox Is the Security Boundary
 
 All agent execution MUST:
-- Occur inside Docker SBX containers when working with USAi endpoints
+- Occur inside Docker Sandboxes when working with USAi endpoints
 - Avoid direct host interaction unless explicitly required
 - Avoid writing outside the working directory
 - Respect container filesystem boundaries
@@ -44,35 +53,47 @@ Agents should:
 
 ---
 
-## Network Access (SBX)
+## Network Access
 
 - **Authorized external endpoints:**
   - `https://api.gsa.usai.gov/api/v1` (USAi API)
-  - `https://api.github.com` (GitHub API - via SBX proxy)
+  - `https://api.github.com` (GitHub API - via proxy)
   - `https://workshop.cloud.gov` (GitLab API - GSA workshop instance, if applicable)
 - **TLS requirement:** TLS 1.2+ for all connections
 
 ### Credential Injection Methods
 
-| Service | Method | Notes |
-|---------|--------|-------|
-| USAi | Direct injection (`-e USAI_API_KEY`) | Custom endpoint not supported by SBX proxy |
-| GitHub | SBX proxy (`sbx secret set -g github`) | Recommended; agent never sees token |
-| GitLab | Direct injection (`-e GITLAB_TOKEN`) | Not a built-in SBX service |
+| Service | Docker Desktop | sbx CLI |
+|---------|----------------|---------|
+| USAi | `USAI_API_KEY` in shell config | `-e USAI_API_KEY="$USAI_API_KEY"` |
+| GitHub | `GH_TOKEN` in shell config | `sbx secret set -g github` (recommended) |
+| GitLab | `GITLAB_TOKEN` in shell config | `-e GITLAB_TOKEN="..."` |
 
 See `docs/SBX_PATTERNS.md` for detailed credential injection patterns.
 
 ---
 
-## SBX Execution Patterns
+## Execution Patterns
 
-### Basic: USAi Only
+### Docker Desktop
+
+```bash
+# Create sandbox
+docker sandbox create --name SANDBOX_NAME opencode .
+
+# Run (environment variables come from shell config)
+docker sandbox run SANDBOX_NAME
+```
+
+### Standalone sbx CLI
+
+#### Basic: USAi Only
 
 ```bash
 sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) SANDBOX_NAME opencode
 ```
 
-### With GitHub (via proxy - recommended)
+#### With GitHub (via proxy - recommended)
 
 ```bash
 # One-time setup
@@ -82,7 +103,7 @@ gh auth token | sbx secret set -g github
 sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) SANDBOX_NAME opencode
 ```
 
-### With GitLab (direct injection)
+#### With GitLab (direct injection)
 
 ```bash
 sbx exec -it \

--- a/templates/BOOTSTRAP.md
+++ b/templates/BOOTSTRAP.md
@@ -1,6 +1,14 @@
-# Bootstrap Your Project for SBX + USAi
+# Bootstrap Your Project for Docker Sandboxes + USAi
 
-Copy the template files from this quickstart into your target repository to enable AI agent execution with Docker SBX and USAi.
+Copy the template files from this quickstart into your target repository to enable AI agent execution with Docker Sandboxes and USAi.
+
+## Prerequisites
+
+**Choose one:**
+- **Docker Desktop 4.58+** — sandboxes built-in, no extra install
+- **Standalone sbx CLI** — install via `brew install docker/tap/sbx`
+
+See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for details.
 
 ## What Gets Copied
 
@@ -8,7 +16,7 @@ Copy the template files from this quickstart into your target repository to enab
 |------|---------|-----------|
 | `opencode.jsonc` | OpenCode configuration with USAi provider | Yes |
 | `docs/SBX_PATTERNS.md` | Credential injection quick reference | Recommended |
-| `AGENTS_SBX_ADDENDUM.md` | SBX rules to append to your AGENTS.md | If you have AGENTS.md |
+| `AGENTS_SBX_ADDENDUM.md` | Sandbox rules to append to your AGENTS.md | If you have AGENTS.md |
 
 ## Quick Bootstrap
 
@@ -29,9 +37,9 @@ cp /tmp/quickstart/templates/SBX_PATTERNS.md "$TARGET_REPO/docs/"
 # If you have an existing AGENTS.md, append the SBX addendum (skip header instructions)
 if [ -f "$TARGET_REPO/AGENTS.md" ]; then
   echo "" >> "$TARGET_REPO/AGENTS.md"
-  echo "<!-- SBX + USAi Addendum -->" >> "$TARGET_REPO/AGENTS.md"
+  echo "<!-- Docker Sandboxes + USAi Addendum -->" >> "$TARGET_REPO/AGENTS.md"
   tail -n +6 /tmp/quickstart/templates/AGENTS_SBX_ADDENDUM.md >> "$TARGET_REPO/AGENTS.md"
-  echo "Appended SBX rules to AGENTS.md"
+  echo "Appended sandbox rules to AGENTS.md"
 else
   echo "No AGENTS.md found. Consider using the Agentic Coding Playbook to generate one:"
   echo "https://github.com/GSA-TTS/agentic-coding-playbook"
@@ -42,6 +50,29 @@ rm -rf /tmp/quickstart
 ```
 
 ## After Bootstrap
+
+### Option A: Using Docker Desktop (`docker sandbox`)
+
+1. **Set your USAi API key** in your shell config (`~/.bashrc` or `~/.zshrc`):
+   ```bash
+   echo 'export USAI_API_KEY="your-key-here"' >> ~/.zshrc
+   source ~/.zshrc
+   ```
+
+2. **Restart Docker Desktop** (required for it to read the new env var)
+
+3. **Create a sandbox** for your project:
+   ```bash
+   cd "$TARGET_REPO"
+   docker sandbox create --name my-project opencode .
+   ```
+
+4. **Run the agent**:
+   ```bash
+   docker sandbox run my-project
+   ```
+
+### Option B: Using Standalone CLI (`sbx`)
 
 1. **Set your USAi API key** on the host:
    ```bash
@@ -69,7 +100,7 @@ rm -rf /tmp/quickstart
 If you've already bootstrapped your project using the [Agentic Coding Playbook](https://github.com/GSA-TTS/agentic-coding-playbook), you already have an `AGENTS.md`. The quickstart adds:
 
 1. **`opencode.jsonc`** - USAi-specific configuration (the playbook doesn't include this)
-2. **SBX addendum** - Appended to your existing `AGENTS.md` with SBX-specific rules
+2. **Sandbox addendum** - Appended to your existing `AGENTS.md` with sandbox-specific rules
 3. **`docs/SBX_PATTERNS.md`** - Quick reference for credential injection
 
 The addendum is designed to complement, not conflict with, the playbook's AGENTS.md content.

--- a/templates/SBX_PATTERNS.md
+++ b/templates/SBX_PATTERNS.md
@@ -1,21 +1,49 @@
-# SBX Credential Injection Patterns
+# Docker Sandboxes Credential Injection Patterns
 
-Quick reference for injecting credentials into Docker SBX sandboxes.
+Quick reference for injecting credentials into Docker Sandboxes (both Docker Desktop and standalone sbx CLI).
 
-## Overview
+## Two Ways to Use Docker Sandboxes
+
+| Method | Install | Command Prefix | Credential Handling |
+|--------|---------|----------------|---------------------|
+| **Docker Desktop built-in** | None (Docker Desktop 4.58+) | `docker sandbox` | Shell config + restart Docker |
+| **Standalone sbx CLI** | Homebrew/Winget/apt | `sbx` | `-e` flags or `sbx secret set` |
+
+See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for installation.
+
+## Credential Methods Overview
 
 | Method | Security | Use Case | Supported Services |
 |--------|----------|----------|-------------------|
-| **SBX Proxy** (recommended) | High - agent never sees token | Standard API endpoints | `anthropic`, `aws`, `cursor`, `github`, `google`, `groq`, `mistral`, `nebius`, `openai`, `xai` |
+| **Shell Config** (Docker Desktop) | Medium - Docker reads from shell | All services | Any environment variable |
+| **SBX Proxy** (sbx CLI) | High - agent never sees token | Standard API endpoints | `anthropic`, `aws`, `cursor`, `github`, `google`, `groq`, `mistral`, `nebius`, `openai`, `xai` |
 | **Direct Injection** (`-e`) | Medium - token in container env | Custom endpoints | Any service (USAi, GitLab, etc.) |
 
-**Rule of thumb:** Use SBX proxy when available; use direct injection for custom endpoints.
+**Rule of thumb:** 
+- Docker Desktop: Add to shell config, restart Docker
+- sbx CLI: Use proxy when available; use `-e` for custom endpoints
 
 ---
 
-## USAi (Direct Injection Required)
+## USAi
 
 USAi uses a custom endpoint (`api.gsa.usai.gov`) that the SBX proxy doesn't recognize.
+
+### Docker Desktop
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export USAI_API_KEY="your-key-here"
+
+# Source and restart Docker Desktop
+source ~/.zshrc
+# Then restart Docker Desktop from menu/taskbar
+
+# Run
+docker sandbox run SANDBOX_NAME
+```
+
+### Standalone sbx CLI
 
 ```bash
 # Set on host
@@ -29,7 +57,19 @@ sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) SANDBOX_NAME opencode
 
 ## GitHub
 
-### Method 1: SBX Proxy (Recommended)
+### Docker Desktop
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export GH_TOKEN="$(gh auth token)"
+# Or: export GITHUB_TOKEN="your-pat"
+
+# Source and restart Docker Desktop
+```
+
+### Standalone sbx CLI
+
+#### Method 1: SBX Proxy (Recommended)
 
 ```bash
 # One-time setup - pipe from gh cli (avoids shell history)
@@ -42,7 +82,7 @@ sbx secret ls
 sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) SANDBOX_NAME opencode
 ```
 
-### Method 2: Direct Injection
+#### Method 2: Direct Injection
 
 ```bash
 sbx exec -it \
@@ -65,9 +105,21 @@ sbx exec -e GH_TOKEN="$(gh auth token)" SANDBOX_NAME sh -c 'curl -s -H "Authoriz
 
 ## GitLab (Direct Injection Required)
 
-GitLab is NOT a built-in SBX service.
+GitLab is NOT a built-in service for either method.
 
-### gitlab.com
+### Docker Desktop
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export GITLAB_TOKEN="your-gitlab-token"
+export GITLAB_HOST="workshop.cloud.gov"  # for self-hosted
+
+# Source and restart Docker Desktop
+```
+
+### Standalone sbx CLI
+
+#### gitlab.com
 
 ```bash
 sbx exec -it \
@@ -76,7 +128,7 @@ sbx exec -it \
   -w $(pwd) SANDBOX_NAME opencode
 ```
 
-### Self-Hosted GitLab (e.g., workshop.cloud.gov)
+#### Self-Hosted GitLab (e.g., workshop.cloud.gov)
 
 ```bash
 sbx exec -it \
@@ -97,6 +149,21 @@ sbx exec -e GITLAB_TOKEN="$GITLAB_TOKEN" -e GITLAB_HOST="workshop.cloud.gov" SAN
 
 ## Combined: All Services
 
+### Docker Desktop
+
+Add all variables to shell config:
+```bash
+# ~/.bashrc or ~/.zshrc
+export USAI_API_KEY="your-usai-key"
+export GH_TOKEN="$(gh auth token)"
+export GITLAB_TOKEN="your-gitlab-token"
+export GITLAB_HOST="workshop.cloud.gov"
+```
+
+Then restart Docker Desktop and run: `docker sandbox run SANDBOX_NAME`
+
+### Standalone sbx CLI
+
 For agents needing USAi + GitHub + GitLab:
 
 ```bash
@@ -115,21 +182,22 @@ sbx exec -it \
 
 ## Quick Reference
 
-| Provider | SBX Proxy | Direct Injection | CLI to Extract Token |
-|----------|-----------|------------------|---------------------|
-| USAi | Not supported | `-e USAI_API_KEY="$USAI_API_KEY"` | N/A (manual) |
-| GitHub | `sbx secret set -g github` | `-e GH_TOKEN="$(gh auth token)"` | `gh auth token` |
-| GitLab.com | Not supported | `-e GITLAB_TOKEN="..."` | `glab config get token` |
-| GitLab (self-hosted) | Not supported | `-e GITLAB_TOKEN="..." -e GITLAB_HOST="..."` | `glab config get --host HOST token` |
+| Provider | Docker Desktop | sbx CLI (Proxy) | sbx CLI (Direct) |
+|----------|----------------|-----------------|------------------|
+| USAi | `USAI_API_KEY` in shell config | N/A | `-e USAI_API_KEY="$USAI_API_KEY"` |
+| GitHub | `GH_TOKEN` in shell config | `sbx secret set -g github` | `-e GH_TOKEN="$(gh auth token)"` |
+| GitLab.com | `GITLAB_TOKEN` in shell config | N/A | `-e GITLAB_TOKEN="..."` |
+| GitLab (self-hosted) | `GITLAB_TOKEN` + `GITLAB_HOST` | N/A | `-e GITLAB_TOKEN="..." -e GITLAB_HOST="..."` |
 
 ---
 
 ## Security Notes
 
-1. **Prefer SBX proxy when available** - more secure, agent never sees token
-2. **Pipe tokens from CLI tools** - avoids shell history (`gh auth token | sbx secret set -g github`)
-3. **Scope tokens minimally** - only grant permissions the agent needs
-4. **Tokens exist only in memory** - never written to disk inside container
-5. **Review agent output** - before sharing logs, ensure no tokens leaked
+1. **Docker Desktop:** Restart required after changing shell config
+2. **Prefer SBX proxy when available** (sbx CLI) - more secure, agent never sees token
+3. **Pipe tokens from CLI tools** - avoids shell history (`gh auth token | sbx secret set -g github`)
+4. **Scope tokens minimally** - only grant permissions the agent needs
+5. **Tokens exist only in memory** - never written to disk inside container
+6. **Review agent output** - before sharing logs, ensure no tokens leaked
 
 For full security analysis, see [KNOWN_FAILURE_MODES.md Section 15](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/KNOWN_FAILURE_MODES.md#15-direct-credential-injection-for-git-providers-security-consideration).


### PR DESCRIPTION
## Summary

- Adds clear guidance for both **Docker Desktop built-in** (`docker sandbox`) and **standalone sbx CLI** installation methods
- Addresses user confusion where `docker sbx` returned "unknown command" on GFE Macs (user feedback from Mark Meyer)
- Updates all documentation with side-by-side instructions for both approaches

## Changes

| File | Changes |
|------|---------|
| `README.md` | Added "What is Docker Sandboxes?" section, installation options, command comparison table |
| `docs/SBX_QUICKSTART.md` | Full dual-method walkthrough, updated troubleshooting |
| `templates/SBX_PATTERNS.md` | Side-by-side credential injection for both methods |
| `templates/AGENTS_SBX_ADDENDUM.md` | Updated to reference both methods |
| `templates/BOOTSTRAP.md` | Split setup into Docker Desktop vs sbx CLI options |

## Key Clarifications

1. **`docker sandbox`** (two words) — Docker Desktop 4.58+ built-in, no extra install
2. **`sbx`** — Standalone CLI via Homebrew, more features (secret proxy)
3. **`docker sbx`** — Does NOT exist (this was the user's confusion)

## Testing

- [ ] Verify `docker sandbox --help` works on Docker Desktop 4.58+
- [ ] Verify `brew install docker/tap/sbx` installs correctly
- [ ] Review documentation for clarity