### PR TITLE
docs: add network policy config and clarify docker desktop restart requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,37 +73,58 @@ sbx login
 
 See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for full installation details.
 
-## Quick Start (3 Commands)
+## Quick Start
 
-### Using Docker Desktop (`docker sandbox`)
+### Step 1: Configure Network Policy (Required)
+
+When you first run a sandbox command, you'll be prompted to choose a network policy. **Do not choose "Open"** — it allows access to internal GSA resources, which is a security risk on GFE.
+
+Choose **"Balanced"** or **"Locked Down"**, then add the USAi endpoint:
 
 ```bash
-# 1. Set your API key in your shell config (~/.bashrc or ~/.zshrc)
-#    Then source it and restart Docker Desktop
-export USAI_API_KEY="your-api-key-here"
-
-# 2. Clone this repo and create a sandbox
-git clone https://github.com/GSA-TTS/agentic-coding-quickstart.git
-cd agentic-coding-quickstart
-docker sandbox create --name quickstart opencode .
-
-# 3. Run OpenCode
-docker sandbox run quickstart
+# Allow USAi API endpoint (required for both methods)
+sbx policy allow network "api.gsa.usai.gov"
 ```
 
-### Using Standalone CLI (`sbx`)
+> **Why not "Open"?** On GFE machines, "Open" allows the agent to access internal GSA network resources. Always use "Balanced" with explicit allowlist entries.
+
+### Step 2: Set Your API Key
+
+**For sbx CLI:** Export in your current terminal session:
+```bash
+export USAI_API_KEY="your-api-key-here"
+```
+
+**For Docker Desktop:** Add to your shell config AND restart Docker Desktop:
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+echo 'export USAI_API_KEY="your-api-key-here"' >> ~/.zshrc
+source ~/.zshrc
+
+# IMPORTANT: Restart Docker Desktop (Quit and reopen)
+# Docker reads env vars at startup, not from your current shell
+```
+
+> **Common mistake:** Setting the env var in your terminal isn't enough for Docker Desktop. You must add it to your shell config file AND restart Docker Desktop.
+
+### Step 3: Create and Run Sandbox
+
+**Using Standalone CLI (`sbx`) — Recommended:**
 
 ```bash
-# 1. Set your API key (on your host machine)
-export USAI_API_KEY="your-api-key-here"
-
-# 2. Clone this repo and create a sandbox
 git clone https://github.com/GSA-TTS/agentic-coding-quickstart.git
 cd agentic-coding-quickstart
 sbx create --name quickstart opencode .
-
-# 3. Run OpenCode with USAi
 sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) quickstart opencode
+```
+
+**Using Docker Desktop (`docker sandbox`):**
+
+```bash
+git clone https://github.com/GSA-TTS/agentic-coding-quickstart.git
+cd agentic-coding-quickstart
+docker sandbox create --name quickstart opencode .
+docker sandbox run quickstart
 ```
 
 That's it. You're now running an AI coding agent in an isolated container with USAi access.
@@ -240,6 +261,10 @@ See [docs/SBX_QUICKSTART.md](docs/SBX_QUICKSTART.md) for full credential injecti
 
 ## Troubleshooting
 
+**Network policy errors / "Balanced" policy blocks USAi**
+- Add the USAi endpoint to your allowlist: `sbx policy allow network "api.gsa.usai.gov"`
+- Do NOT use "Open" policy on GFE — it exposes internal GSA resources to the agent
+
 **"docker: unknown command: docker sbx"**
 - Use `docker sandbox` (two words), not `docker sbx`
 - If that doesn't work, verify Docker Desktop version: `docker --version` (need 4.58+)
@@ -251,10 +276,14 @@ See [docs/SBX_QUICKSTART.md](docs/SBX_QUICKSTART.md) for full credential injecti
 - For `docker sandbox`: The workspace is auto-mounted
 - Verify `opencode.jsonc` exists
 
-**Authentication failed**
+**Authentication failed / Unauthorized errors**
 - Check your API key: `echo "Length: ${#USAI_API_KEY}"`
 - For `sbx`: Ensure you're using `-e USAI_API_KEY="$USAI_API_KEY"` flag
-- For `docker sandbox`: Set the key in `~/.bashrc` or `~/.zshrc`, source it, and restart Docker Desktop
+- For `docker sandbox`: 
+  1. Add the key to `~/.bashrc` or `~/.zshrc` (not just `export` in terminal)
+  2. Run `source ~/.zshrc`
+  3. **Restart Docker Desktop completely** (Quit → Reopen)
+  4. Then run `docker sandbox run quickstart`
 
 **"Unknown agent" error**
 - Use: `docker sandbox create --name NAME opencode .` or `sbx create --name NAME opencode .`

--- a/docs/SBX_QUICKSTART.md
+++ b/docs/SBX_QUICKSTART.md
@@ -66,7 +66,56 @@ sbx login
 
 See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for full details.
 
-## Quick Start (3 Commands)
+## Network Policy Configuration (Important!)
+
+When you first run a sandbox command, you'll be prompted to choose a network policy:
+
+```
+Choose a default network policy:
+     1. Open         — All network traffic allowed, no restrictions.
+     2. Balanced     — Default deny, with common dev sites allowed.
+     3. Locked Down  — All network traffic blocked unless you allow it.
+```
+
+### Recommended: Choose "Balanced" (Option 2)
+
+> **⚠️ Do NOT choose "Open" on GFE machines.** The "Open" policy allows the agent to access internal GSA network resources, which is a security risk.
+
+After selecting "Balanced", you must add the USAi endpoint to the allowlist:
+
+```bash
+# Allow USAi API endpoint (required for USAi to work)
+sbx policy allow network "api.gsa.usai.gov"
+
+# Verify your policy rules
+sbx policy ls
+```
+
+### If You Already Chose "Open"
+
+Reset your policy and reconfigure:
+
+```bash
+# Reset to default (will prompt for policy choice again)
+sbx policy reset
+
+# Choose "Balanced" when prompted, then add USAi
+sbx policy allow network "api.gsa.usai.gov"
+```
+
+### Full Allowlist for USAi Pilot
+
+For the complete pilot experience (USAi + GitHub + package managers):
+
+```bash
+sbx policy allow network "api.gsa.usai.gov"
+sbx policy allow network "api.github.com"
+sbx policy allow network "github.com"
+```
+
+The "Balanced" policy already includes common package managers (npm, pypi) and container registries.
+
+## Quick Start
 
 ### Using Docker Desktop (`docker sandbox`)
 
@@ -74,27 +123,40 @@ See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for 
 # 1. Set your API key in your shell config file (~/.bashrc or ~/.zshrc)
 echo 'export USAI_API_KEY="your-api-key-here"' >> ~/.zshrc
 source ~/.zshrc
-# IMPORTANT: Restart Docker Desktop so it picks up the new variable
 
-# 2. Create a sandbox for OpenCode in current directory
+# 2. IMPORTANT: Restart Docker Desktop completely (Quit → Reopen)
+#    Docker reads env vars at startup, not from your current shell
+
+# 3. Configure network policy (first run will prompt - choose "Balanced")
+#    Then add USAi to the allowlist:
+sbx policy allow network "api.gsa.usai.gov"
+
+# 4. Create a sandbox for OpenCode in current directory
 docker sandbox create --name usai-test opencode .
 
-# 3. Run OpenCode (connects to the sandbox)
+# 5. Run OpenCode (connects to the sandbox)
 docker sandbox run usai-test
 ```
 
-> **Important:** Docker Desktop reads environment variables from your shell config at startup. After adding `USAI_API_KEY` to `~/.bashrc` or `~/.zshrc`, you must restart Docker Desktop for it to take effect.
+> **Common mistake:** Setting `export USAI_API_KEY=...` in your terminal isn't enough for Docker Desktop. You must:
+> 1. Add it to `~/.bashrc` or `~/.zshrc`
+> 2. Source the file
+> 3. **Completely restart Docker Desktop** (not just the terminal)
 
-### Using Standalone CLI (`sbx`)
+### Using Standalone CLI (`sbx`) — Recommended
 
 ```bash
-# 1. Verify your API key is set on the HOST (should show key length, not the key itself)
-echo "USAI_API_KEY length: ${#USAI_API_KEY}"
+# 1. Set your API key (export works for sbx CLI)
+export USAI_API_KEY="your-api-key-here"
 
-# 2. Create a sandbox for OpenCode in current directory
+# 2. Configure network policy (first run will prompt - choose "Balanced")
+#    Then add USAi to the allowlist:
+sbx policy allow network "api.gsa.usai.gov"
+
+# 3. Create a sandbox for OpenCode in current directory
 sbx create --name usai-test opencode .
 
-# 3. Run OpenCode with API key injection
+# 4. Run OpenCode with API key injection
 sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) usai-test opencode
 ```
 
@@ -525,6 +587,34 @@ sbx exec SANDBOX_NAME ls -la
 
 ## Troubleshooting
 
+### Network policy blocks USAi API / Connection errors
+
+**Problem:** Getting connection refused, timeout, or unauthorized errors when trying to reach USAi.
+
+**Root Cause:** The "Balanced" network policy blocks unknown endpoints by default. USAi (`api.gsa.usai.gov`) must be explicitly allowed.
+
+**Fix:**
+```bash
+# Add USAi to the allowlist
+sbx policy allow network "api.gsa.usai.gov"
+
+# Verify it was added
+sbx policy ls
+```
+
+### Chose "Open" policy by mistake
+
+**Problem:** You selected "Open" network policy, which is a security risk on GFE machines (allows access to internal GSA resources).
+
+**Fix:** Reset and reconfigure:
+```bash
+# Reset policy (will prompt for new choice)
+sbx policy reset
+
+# Choose "Balanced" when prompted, then add USAi
+sbx policy allow network "api.gsa.usai.gov"
+```
+
 ### "docker: unknown command: docker sbx"
 
 **Problem:** Running `docker sbx` returns "unknown command".
@@ -563,7 +653,7 @@ sbx create --name usai-test opencode .
 **Fix for Docker Desktop:**
 1. Ensure `USAI_API_KEY` is in `~/.bashrc` or `~/.zshrc`
 2. Source the file: `source ~/.zshrc`
-3. **Restart Docker Desktop** (this is required!)
+3. **Restart Docker Desktop completely** (Quit → Reopen, not just close terminal)
 4. Run: `docker sandbox run usai-test`
 
 **Fix for sbx CLI:**

--- a/templates/SBX_PATTERNS.md
+++ b/templates/SBX_PATTERNS.md
@@ -11,6 +11,30 @@ Quick reference for injecting credentials into Docker Sandboxes (both Docker Des
 
 See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for installation.
 
+## Network Policy Configuration (Required)
+
+When first running sandbox commands, you'll be prompted to choose a network policy.
+
+> **⚠️ Do NOT choose "Open" on GFE machines** — it allows the agent to access internal GSA network resources.
+
+**Recommended setup:**
+```bash
+# Choose "Balanced" when prompted, then add USAi endpoint:
+sbx policy allow network "api.gsa.usai.gov"
+
+# Verify
+sbx policy ls
+```
+
+If you accidentally chose "Open", reset and reconfigure:
+```bash
+sbx policy reset
+# Choose "Balanced", then:
+sbx policy allow network "api.gsa.usai.gov"
+```
+
+---
+
 ## Credential Methods Overview
 
 | Method | Security | Use Case | Supported Services |
@@ -35,7 +59,7 @@ USAi uses a custom endpoint (`api.gsa.usai.gov`) that the SBX proxy doesn't reco
 # Add to ~/.bashrc or ~/.zshrc
 export USAI_API_KEY="your-key-here"
 
-# Source and restart Docker Desktop
+# Source and COMPLETELY restart Docker Desktop (Quit → Reopen)
 source ~/.zshrc
 # Then restart Docker Desktop from menu/taskbar
 


### PR DESCRIPTION
## Summary

Addresses feedback from Mark Meyer regarding network policy and Docker Desktop env var handling.

## Changes

- Add network policy section warning against "Open" policy on GFE machines
- Document `sbx policy allow network "api.gsa.usai.gov"` requirement
- Make Docker Desktop restart requirement more prominent (Quit → Reopen)
- Add troubleshooting for network policy issues

## User Feedback Addressed

> I originally choose "Balanced", but got errors when trying to hit the API. Setting it to "Open" fixed that

**Fix:** Document that "Balanced" requires explicitly adding `api.gsa.usai.gov` to the allowlist.

> "Open" is particularly bad for GFE because that means that the agent can access internal GSA resources.

**Fix:** Add prominent warning against using "Open" on GFE, with instructions to reset if accidentally chosen.

> The docker sandbox commands worked to get OpenCode up and running, but it didn't seem to pick up the USAI_API_KEY env

**Fix:** Make Docker Desktop restart requirement much more prominent (not just "restart" but "Quit → Reopen completely").