### PR TITLE
chore: add codeowners file for review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# CODEOWNERS for agentic-coding-quickstart
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @GSA-TTS/hello-ato-team
+
+# Security-sensitive files require explicit review
+AGENTS.md @GSA-TTS/hello-ato-team
+SECURITY.md @GSA-TTS/hello-ato-team
+.github/ @GSA-TTS/hello-ato-team


### PR DESCRIPTION
## Summary
Adds CODEOWNERS file to ensure PRs are automatically assigned to the appropriate team for review.

## Changes
- Creates `.github/CODEOWNERS` with `@GSA-TTS/hello-ato-team` as default owners
- Security-sensitive files (AGENTS.md, SECURITY.md, .github/) explicitly require team review

## Why
- Improves review routing and ownership clarity
- Aligns with playbook repository standards
- Addresses gap identified in repository analysis

Closes #22

---
*PR created by AI agent per AGENTS.md PR-level attribution policy.*