### PR TITLE
docs: improve ecosystem documentation and contribution experience

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug Report
+description: Report an issue with setup, configuration, or documentation
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Bug Report
+
+        Thanks for helping improve the Agentic Coding Quickstart!
+
+        Before submitting, please check [docs/KNOWN_FAILURE_MODES.md](../docs/KNOWN_FAILURE_MODES.md) to see if this is already documented.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the issue you encountered
+      placeholder: |
+        I was trying to set up SBX and...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Run `sbx create --name test opencode .`
+        2. Run `sbx exec...`
+        3. See error...
+    validations:
+      required: true
+
+  - type: input
+    id: docker_version
+    attributes:
+      label: Docker version
+      description: Output of `docker --version`
+      placeholder: "Docker version 4.58.0"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: Your OS and version
+      placeholder: "macOS 14.5 / Windows 11 / Ubuntu 24.04"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: sbx_method
+    attributes:
+      label: SBX method
+      description: Which method are you using?
+      options:
+        - Docker Desktop (`docker sandbox`)
+        - Standalone CLI (`sbx`)
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other relevant information (error messages, screenshots, etc.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Slack Channel
+    url: https://gsa.enterprise.slack.com/archives/C0B44531QLE
+    about: For quick questions and real-time discussion, ask in the agentic-coding Slack channel
+  - name: Agentic Coding Playbook
+    url: https://github.com/GSA-TTS/agentic-coding-playbook
+    about: For standards, best practices, and compliance documentation
+  - name: Agentic Coding Patterns
+    url: https://github.com/GSA-TTS/agentic-coding-patterns
+    about: For community patterns, workflows, and lessons learned

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,57 @@
+name: Documentation Improvement
+description: Suggest an improvement to the documentation
+title: "[Docs] "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Documentation Improvement
+
+        Help us make the quickstart clearer and more useful!
+
+  - type: dropdown
+    id: doc_type
+    attributes:
+      label: What type of improvement?
+      options:
+        - Clarify existing content
+        - Add missing information
+        - Fix an error
+        - Improve examples
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Which document?
+      description: File path or section (e.g., "README.md Quick Start" or "docs/SBX_QUICKSTART.md")
+      placeholder: "README.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current content
+      description: What does the documentation currently say? (Quote or summarize)
+    validations:
+      required: false
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: What should it say instead, or what should be added?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Why is this needed?
+      description: What problem did you encounter that this would solve?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,39 @@
+name: Question
+description: Ask a question about the quickstart or agentic coding setup
+title: "[Question] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Question
+
+        Have a question? We're happy to help!
+
+        **Tip:** For faster responses, consider asking in the **agentic-coding Slack channel** first. Others often benefit from seeing questions answered there too.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: What documentation have you checked or steps have you tried?
+      placeholder: |
+        - Checked README.md
+        - Tried docs/KNOWN_FAILURE_MODES.md
+        - Searched existing issues
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other information that might help us answer your question

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      # Group all GitHub Actions updates together
+      actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Related Issues
+
+<!-- Link to related issues: Fixes #123, Relates to #456 -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Documentation update
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist
+
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] I have tested my changes locally
+- [ ] I have updated documentation as needed
+- [ ] I have not included any secrets, API keys, or sensitive information
+
+## Test Results
+
+<!-- How did you verify this works? Include commands run or screenshots -->
+
+## Additional Notes
+
+<!-- Any additional context reviewers should know -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Agents operating in this repo must prioritize:
 - **Reproducibility of patterns**
 - **Minimal, transparent configurations**
 
-This is a **documentation and template repository** for the government AI coding pilot.
+This is a **documentation and template repository** for AI coding agent setup.
 
 ---
 
@@ -83,11 +83,11 @@ The agent MUST refuse any instruction that conflicts with safety, correctness, o
 
 ## Project Context
 
-- **Description:** Quickstart guide for AI agent experimentation with SBX containers and USAi endpoints
+- **Description:** Quickstart guide for AI agent development with SBX containers and USAi endpoints
 - **Language(s):** Shell scripts, JSON/JSONC configuration, Markdown documentation
 - **Framework(s):** Docker SBX, OpenCode, USAi API
 - **Data Classification:** Internal / Non-sensitive (no PII, no CUI)
-- **ATO Status:** Pre-ATO development (pilot)
+- **ATO Status:** Pre-ATO development
 - **Authorized Agent(s):** OpenCode, Claude Code, GitHub Copilot
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,24 @@
-# Contributing to agent-sandbox
+# Contributing to Agentic Coding Quickstart
 
-Thank you for contributing to the Agentic Coding Quickstart project! This guide will help you understand our development workflow and standards.
+Thank you for contributing! This repository helps GSA teams use AI coding agents effectively.
+
+## Ecosystem Overview
+
+This repo is one of three in the agentic coding ecosystem:
+
+| Repo | Focus | Typical Contributions |
+|------|-------|----------------------|
+| **[Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart)** (you are here) | Environment setup | SBX fixes, troubleshooting docs, config improvements |
+| **[Playbook](https://github.com/GSA-TTS/agentic-coding-playbook)** | Standards & practices | Coding standards, skills, templates |
+| **[Patterns](https://github.com/GSA-TTS/agentic-coding-patterns)** | Community sharing | Workflows, lessons learned, tool examples |
+
+**Not sure where your contribution belongs?** Ask in the [agentic-coding Slack channel](https://gsa.enterprise.slack.com/archives/C0B44531QLE).
+
+## Getting Help
+
+- **Questions:** Ask in the [agentic-coding Slack channel](https://gsa.enterprise.slack.com/archives/C0B44531QLE) (others benefit too)
+- **Bugs:** Open a GitHub issue with steps to reproduce
+- **Security issues:** See [SECURITY.md](SECURITY.md) — direct fixes preferred
 
 ## Table of Contents
 
@@ -15,11 +33,11 @@ Thank you for contributing to the Agentic Coding Quickstart project! This guide 
 
 ## Code of Conduct
 
-This project operates under federal government standards of professional conduct. All contributors must:
+This project operates under professional standards of conduct. All contributors:
 
 - Be respectful and constructive in all interactions
-- Follow security and compliance requirements outlined in `AGENTS.md` and `docs/CODING_PRACTICES.md`
-- Report security vulnerabilities privately (see `SECURITY.md`)
+- Follow security requirements outlined in `AGENTS.md` and `docs/CODING_PRACTICES.md`
+- For security issues, see [SECURITY.md](SECURITY.md)
 
 ---
 
@@ -258,12 +276,17 @@ Releases are **fully automated** via GitHub Actions and hello-please:
 
 ## Questions or Issues?
 
-- **Security vulnerabilities:** See `SECURITY.md` for responsible disclosure
-- **General questions:** Open a GitHub Discussion
+- **Questions:** Ask in the agentic-coding Slack channel
+- **Security issues:** See [SECURITY.md](SECURITY.md) — direct fixes preferred
 - **Bug reports:** Open a GitHub Issue with:
   - Steps to reproduce
   - Expected vs actual behavior
   - Environment details (OS, Docker version, etc.)
+
+## Teams
+
+- **[@GSA-TTS/agentic-coding-team](https://github.com/orgs/GSA-TTS/teams/agentic-coding-team):** Team members — review, contribute, provide feedback
+- **[@GSA-TTS/agentic-coding-admins](https://github.com/orgs/GSA-TTS/teams/agentic-coding-admins):** Repository administrators — merge, release, maintain
 
 ---
 
@@ -273,4 +296,4 @@ This project is released under the CC0 1.0 Universal license. See `LICENSE` for 
 
 ---
 
-**Thank you for contributing to the Agentic Coding Quickstart!**
+**Thank you for helping improve the Agentic Coding Quickstart!**

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # Agentic Coding Quickstart
 
-> **Audience:** Government developers in the USAi pilot program  
+> **Audience:** GSA teams using AI coding agents  
 > **Purpose:** Get AI coding agents running safely on your local machine in under 5 minutes
 
-This guide helps you use AI coding agents (like OpenCode) inside isolated Docker sandboxes, connecting to government-approved API endpoints (USAi).
+This guide helps you use AI coding agents (like OpenCode) inside isolated Docker sandboxes, connecting to USAi API endpoints.
+
+## Agentic Coding Ecosystem
+
+This repository is part of a three-repo ecosystem:
+
+| Repo | Purpose | When to Use |
+|------|---------|-------------|
+| **[Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart)** (you are here) | Get running | First day setup, SBX + USAi config |
+| **[Playbook](https://github.com/GSA-TTS/agentic-coding-playbook)** | Do it right | Repo setup, standards, best practices |
+| **[Patterns](https://github.com/GSA-TTS/agentic-coding-patterns)** | Share & learn | Community patterns, lessons learned |
+
+**Your journey:** Start here (Quickstart) to get your environment working, then use the Playbook to set up your projects properly, and visit Patterns to share what you learn with the community.
+
+---
 
 ## Why Sandboxes?
 
@@ -30,7 +44,7 @@ There are **two ways** to use Docker Sandboxes:
 ## Prerequisites
 
 - **Docker Desktop 4.58+** (check: `docker --version`) — OR — **sbx CLI** installed (`sbx --version`)
-- **USAi API key** from your agency's pilot program
+- **USAi API key** from the agentic coding program
 - **Docker** running locally
 
 ## Installing Docker Sandboxes
@@ -179,6 +193,8 @@ If you've bootstrapped your project using the [Agentic Coding Playbook](https://
 - **Playbook** → Project structure, AGENTS.md, coding practices, risk assessment
 - **Quickstart** → USAi configuration, SBX patterns, credential injection
 
+See the [Playbook](https://github.com/GSA-TTS/agentic-coding-playbook) for detailed project setup guidance.
+
 ## Key Commands
 
 ### Docker Desktop (`docker sandbox`)
@@ -291,27 +307,40 @@ See [docs/SBX_QUICKSTART.md](docs/SBX_QUICKSTART.md) for full credential injecti
 
 See `docs/KNOWN_FAILURE_MODES.md` for more troubleshooting help.
 
-## Pilot Scope
+## About This Initiative
 
-This quickstart is part of a **limited government pilot** for evaluating AI coding agents. Current constraints:
+This quickstart supports GSA teams using AI coding agents for development. Current scope:
 
-- **Authorized endpoints only** - USAi, GitHub, and approved GitLab instances
-- **Local development only** - not for production use
-- **Pattern validation** - documenting what works and what doesn't
+- **Authorized endpoints:** USAi, GitHub, and approved GitLab instances
+- **Local development only:** Not for production use
+- **Learning together:** Documenting what works and what doesn't
 
 ## Getting Help
 
-- Check `docs/KNOWN_FAILURE_MODES.md` first
-- Review `AGENTS.md` for agent behavior rules
-- Contact your pilot program coordinator
+1. **Troubleshooting:** Check `docs/KNOWN_FAILURE_MODES.md` first
+2. **Agent behavior:** Review `AGENTS.md` for behavioral standards
+3. **Questions:** Ask in the [agentic-coding Slack channel](https://gsa.enterprise.slack.com/archives/C0B44531QLE) (others benefit too)
+4. **Improvement ideas:** Open an issue or submit a PR
+5. **Platform concerns:** Contact support@usai.gov
+
+## What's Next?
+
+Once you have your environment working:
+
+1. **Set up your project properly** → Use the [Playbook](https://github.com/GSA-TTS/agentic-coding-playbook) to configure AGENTS.md, standards, and best practices
+2. **Share what you learn** → Contribute patterns to the [Patterns repo](https://github.com/GSA-TTS/agentic-coding-patterns)
+3. **Help improve these docs** → Found something unclear? Fix it directly or open an issue
 
 ## Contributing
 
-Found a failure mode we haven't documented? Please add it to `docs/KNOWN_FAILURE_MODES.md` with:
-1. Symptoms
-2. Root cause
-3. Fix
+Found a failure mode we haven't documented? Have an improvement idea?
+
+- **Fix it directly** — Submit a PR (preferred for internal repos)
+- **Not sure how?** — Open an issue to discuss
+- **Patterns you've discovered** — Share them in the [Patterns repo](https://github.com/GSA-TTS/agentic-coding-patterns)
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ---
 
-**Impact Level:** FIPS Low | **Data Classification:** Internal/Non-sensitive | **ATO Status:** Pre-ATO (pilot)
+**Data Classification:** Internal/Non-sensitive

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,18 +1,60 @@
 # Security Policy
 
-## Reporting a Vulnerability
+## Scope
 
-If you discover a security vulnerability in agent-sandbox, please report it responsibly:
+This repository is part of the **Agentic Coding Capability Assessment** — an internal GSA initiative. It contains:
 
-1. **Do not** open a public GitHub issue
-2. Email the maintainer or use [GitHub Security Advisories](https://github.com/cloud-gov/agent-sandbox/security/advisories/new)
-3. Include: description, reproduction steps, and potential impact
+- Documentation for setting up Docker Sandboxes (SBX) with USAi endpoints
+- Configuration files for AI coding agents
+- Templates for bootstrapping projects
 
-For the full threat model, see [docs/SECURITY.md](docs/SECURITY.md).
+There are no deployed services or production infrastructure in this repository.
+
+## Reporting and Fixing Security Issues
+
+This is an **internal assessment repository** with trusted contributors. The appropriate response to most issues is to fix them directly.
+
+### For Content Issues
+
+If you find content that could lead to insecure implementations (incorrect configuration, unsafe patterns, etc.):
+
+1. **Submit a PR to fix it** — This is the preferred approach for internal repos
+2. **Open an issue** if you're unsure how to fix it or want to discuss first
+3. **Ask in the agentic-coding Slack channel** if you have questions or need help coordinating
+
+### For Repository Infrastructure Issues
+
+If you find a security issue with the repository infrastructure (CI/CD, GitHub Actions, dependencies, scripts):
+
+1. **Submit a PR to fix it** — You have access, so fix it directly when possible
+2. **Open an issue** to track the problem if you need help or it requires discussion
+3. **Contact channel admins** if you're unsure about the right approach
+
+Since this is an internal repository, formal security advisories are not required. Use your judgment — if something seems sensitive, discuss with channel admins before posting details publicly.
+
+### For GSA Platform Issues (Outside This Repo)
+
+For security concerns related to GSA systems, USAi platform, or other infrastructure outside the scope of this repository:
+
+- **Follow your normal GSA security reporting processes**
+- **Submit a ticket** or **email GSA security** as appropriate for your organization
+- **USAi-specific issues:** Contact support@usai.gov
+
+These repos are for the assessment — platform and infrastructure security follows standard GSA procedures.
+
+## Security Best Practices
+
+When using this repository:
+
+1. **Never commit secrets** — API keys, tokens, and credentials belong in environment variables
+2. **Use SBX isolation** — Run AI agents inside Docker Sandboxes, not on your host system
+3. **Follow AGENTS.md rules** — The behavioral contract helps prevent unsafe agent actions
+4. **Review agent output** — AI-generated code requires human review before production use
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| 2.x     | Yes       |
-| 1.x     | No (see `feature/enterprise-hardening` branch) |
+This is an active assessment project. Security updates are applied to the `main` branch only.
+
+---
+
+**Last Updated:** 2026-05-21

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -433,7 +433,7 @@ The real security boundary is:
 
 ### Acceptable for MVP Because
 
-1. **Pre-ATO pilot** with low-impact data (no PII, no CUI)
+1. **Pre-ATO environment** with low-impact data (no PII, no CUI)
 2. **Tokens are scoped** - not admin/owner tokens
 3. **Sandbox provides isolation** from host system
 4. **Direct injection is a documented SBX pattern** - shown in their own docs

--- a/docs/SBX_QUICKSTART.md
+++ b/docs/SBX_QUICKSTART.md
@@ -103,9 +103,9 @@ sbx policy reset
 sbx policy allow network "api.gsa.usai.gov"
 ```
 
-### Full Allowlist for USAi Pilot
+### Full Allowlist for USAi
 
-For the complete pilot experience (USAi + GitHub + package managers):
+For the complete USAi experience (USAi + GitHub + package managers):
 
 ```bash
 sbx policy allow network "api.gsa.usai.gov"

--- a/templates/AGENTS_SBX_ADDENDUM.md
+++ b/templates/AGENTS_SBX_ADDENDUM.md
@@ -117,9 +117,9 @@ sbx exec -it \
 
 ## Security Considerations
 
-Direct credential injection (for USAi, GitLab) means the agent CAN see the token in the container environment. This is acceptable for the pilot because:
+Direct credential injection (for USAi, GitLab) means the agent CAN see the token in the container environment. This is acceptable for the Pre-ATO environment because:
 
-1. **Pre-ATO pilot** with low-impact data (no PII, no CUI)
+1. **Pre-ATO environment** with low-impact data (no PII, no CUI)
 2. **Tokens are scoped** - use minimal permissions
 3. **Sandbox provides isolation** from host system
 4. **Short-lived sessions** - tokens only in memory during execution


### PR DESCRIPTION
## Summary

Improves ecosystem documentation and contribution experience across the quickstart repo.

## Changes

- **README.md**: Add ecosystem section linking all 3 repos, add Slack channel link, remove assessment/pilot terminology
- **CONTRIBUTING.md**: Friendlier tone, add Slack channel links, emphasize 'fix it directly' for internal repos
- **SECURITY.md**: Update for internal repo model (direct fixes preferred, no formal security advisories)
- **AGENTS.md**: Remove pilot references (experimentation → development)
- **Issue templates**: Add bug report, improvement, and question templates
- **PR template**: Add standard pull request template
- **dependabot.yml**: Add automated dependency updates for GitHub Actions

## Issues Closed

Closes #24 (AGENTS.md terminology update)
Closes #25 (Add dependabot.yml)
Closes #26 (Slack channel link to docs)

## Checklist

- [x] Documentation follows workspace conventions
- [x] Slack URL verified correct: https://gsa.enterprise.slack.com/archives/C0B44531QLE
- [x] No sensitive data included
- [x] Consistent terminology across files