### PR TITLE
chore(ci): bump the actions group with 2 updates

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       
       - name: Set up Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple


### PR DESCRIPTION
## Summary

Dependency updates from Dependabot (originally PR #28, recreated after commitlint config update).

## Updates

- **actions/setup-node:** 4.1.0 → 6.4.0 (major version bump)
- **googleapis/release-please-action:** 4.4.1 → 5.0.0 (major version bump)

## Changes

```
.github/workflows/commitlint.yml | 2 +-
.github/workflows/release.yml    | 2 +-
```

## Rationale

These are grouped Dependabot updates for GitHub Actions. Major version bumps reviewed for breaking changes:
- setup-node 6.x: Compatible with Node.js 20 (used in workflow)
- release-please-action 5.x: Compatible with existing config

## Testing

CI will validate:
- ✅ Commitlint passes (with new commitlint.config.js from PR #29)
- Workflows parse and validate

## Closes

Supersedes: #28 (closed to pick up new commitlint config)

## Attribution

Original commit by: dependabot[bot]
Recreated by: OpenCode Agent

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: OpenCode Agent <agent@gsa.gov>