### PR TITLE
docs: add sbx policy set-default balanced to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for 
 
 ### Step 1: Configure Network Policy (Required)
 
-When you first run a sandbox command, you'll be prompted to choose a network policy. **Do not choose "Open"** — it allows access to internal GSA resources, which is a security risk on GFE.
+When you first run a sandbox command, you need to choose a network policy. **Do not choose "Open"** — it allows access to internal GSA resources, which is a security risk on GFE.
 
 Choose **"Balanced"** or **"Locked Down"**, then add the USAi endpoint:
 
 ```bash
+# Set default network policy to "balanced"
+sbx policy set-default balanced
 # Allow USAi API endpoint (required for both methods)
 sbx policy allow network "api.gsa.usai.gov"
 ```


### PR DESCRIPTION
## Summary

Add step to set default network policy to "balanced" to quickstart.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ x] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ x] I have tested my changes locally
- [ x] I have updated documentation as needed
- [ x] I have not included any secrets, API keys, or sensitive information


