### PR TITLE
feat(zed): add zed editor integration and task runner setup

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,32 @@
+[
+  {
+    "label": "OpenCode: Run Agent (Standalone CLI)",
+    "command": "make run-agent",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "OpenCode: Run Agent (Docker Desktop)",
+    "command": "make run-agent-desktop",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "OpenCode: Create Sandbox (Standalone CLI)",
+    "command": "make create-sandbox",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "OpenCode: Create Sandbox (Docker Desktop)",
+    "command": "make create-sandbox-desktop",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "OpenCode: Environment Diagnostics (make doctor)",
+    "command": "make doctor",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  }
+]

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,15 @@ help:
 	@echo "========================="
 	@echo ""
 	@echo "Commands:"
-	@echo "  make setup         - Set up your workspace (clone playbook, check dependencies)"
-	@echo "  make doctor        - Run health checks on your environment"
-	@echo "  make new-project   - Create a new project directory"
-	@echo "  make install-hooks - [OPTIONAL] Install pre-commit hooks"
-	@echo "  make clean         - Remove generated files"
+	@echo "  make setup                 - Set up your workspace (clone playbook, check dependencies)"
+	@echo "  make doctor                - Run health checks on your environment"
+	@echo "  make new-project           - Create a new project directory"
+	@echo "  make create-sandbox        - Create SBX sandbox 'quickstart' (standalone sbx CLI)"
+	@echo "  make create-sandbox-desktop- Create SBX sandbox 'quickstart' (Docker Desktop)"
+	@echo "  make run-agent             - Run OpenCode agent in SBX (standalone sbx CLI)"
+	@echo "  make run-agent-desktop     - Run OpenCode agent in SBX (Docker Desktop)"
+	@echo "  make install-hooks         - [OPTIONAL] Install pre-commit hooks"
+	@echo "  make clean                 - Remove generated files"
 	@echo ""
 	@echo "First time? Run: make setup"
 
@@ -97,6 +101,45 @@ new-project:
 # Clean up
 clean:
 	@echo "Nothing to clean (this repo doesn't generate files)"
+
+# Create SBX sandbox 'quickstart' using standalone CLI (sbx)
+create-sandbox:
+	@echo "Creating SBX sandbox 'quickstart' using standalone CLI..."
+	@if sbx ls | grep -q "quickstart"; then \
+		echo "Sandbox 'quickstart' already exists. Skipping creation."; \
+	else \
+		sbx create --name quickstart opencode .; \
+	fi
+
+# Create SBX sandbox 'quickstart' using Docker Desktop
+create-sandbox-desktop:
+	@echo "Creating SBX sandbox 'quickstart' using Docker Desktop..."
+	@if docker sandbox ls 2>/dev/null | grep -q "quickstart"; then \
+		echo "Sandbox 'quickstart' already exists. Skipping creation."; \
+	else \
+		docker sandbox create --name quickstart opencode .; \
+	fi
+
+# Run OpenCode agent in sandbox 'quickstart' using standalone CLI (sbx)
+run-agent: _check-usai-key
+	@echo "Running OpenCode agent in SBX sandbox 'quickstart' (standalone CLI)..."
+	@sbx exec -it \
+		-e USAI_API_KEY="$(USAI_API_KEY)" \
+		$(if $(NODE_TLS_REJECT_UNAUTHORIZED),-e NODE_TLS_REJECT_UNAUTHORIZED="$(NODE_TLS_REJECT_UNAUTHORIZED)",) \
+		-w "$(shell pwd)" quickstart opencode
+
+# Run OpenCode agent in sandbox 'quickstart' using Docker Desktop
+run-agent-desktop:
+	@echo "Running OpenCode agent in SBX sandbox 'quickstart' (Docker Desktop)..."
+	@docker sandbox run quickstart
+
+_check-usai-key:
+	@if [ -z "$(USAI_API_KEY)" ]; then \
+		echo "ERROR: USAI_API_KEY environment variable is not set on host."; \
+		echo "Please set it before running the agent. Example:"; \
+		echo "  export USAI_API_KEY=\"your-key-here\""; \
+		exit 1; \
+	fi
 
 # Install pre-commit hooks (optional)
 install-hooks:  ## [OPTIONAL] Install pre-commit hooks

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ sbx run opencode .
 
 That's it. You're now running an AI coding agent in an isolated container with USAi access.
 
-**Need more details?** See the [Full sbx CLI Guide](docs/SBX_QUICKSTART.md).
+**Need more details?** See the [Full sbx CLI Guide](docs/QUICKSTART_SBX.md).
 
-**Prefer Docker Desktop UI?** Use `docker sandbox` commands instead of `sbx`. See the [full guide](docs/SBX_QUICKSTART.md#option-a-docker-desktop-built-in-no-extra-install) for details.
+**Prefer Docker Desktop UI?** See the [Docker Desktop Guide](docs/QUICKSTART_DOCKER_DESKTOP.md).
 
 ---
 
@@ -87,11 +87,26 @@ winget install -h Docker.sbx && sbx login
 | File/Directory | Purpose |
 |----------------|---------|
 | `opencode.jsonc` | Pre-configured for USAi endpoints |
+| `.zed/tasks.json` | Pre-configured tasks for **Zed Editor** |
+| `.pre-commit-config.yaml` | Optional pre-commit hooks (secret detection, file hygiene) |
 | `AGENTS.md` | Behavioral rules the agent follows |
-| `docs/SBX_QUICKSTART.md` | Detailed setup walkthrough |
+| `docs/QUICKSTART_SBX.md` | Full sbx CLI setup guide |
+| `docs/QUICKSTART_DOCKER_DESKTOP.md` | Docker Desktop setup guide |
+| `docs/ZED_SETUP.md` | **Zed Editor** integration guide |
 | `docs/KNOWN_FAILURE_MODES.md` | Troubleshooting guide |
-| `docs/CODING_PRACTICES.md` | Secure coding standards |
 | `templates/` | Files to copy into your own projects |
+
+---
+
+## Zed Editor Integration (Optional)
+
+If you use the **Zed Editor**, pre-configured tasks are available in `.zed/tasks.json`:
+
+- **OpenCode: Run Agent** — Launch the agent in your sandbox
+- **OpenCode: Create Sandbox** — Create a new sandbox
+- **OpenCode: Environment Diagnostics** — Run `make doctor`
+
+See the **[Zed Editor Setup Guide](docs/ZED_SETUP.md)** for detailed instructions.
 
 ---
 
@@ -145,6 +160,10 @@ Want to use sbx + USAi in your own repository?
 ```bash
 # Copy essential files from templates/
 cp templates/opencode.jsonc /path/to/your/project/
+
+# Copy Zed tasks (optional, if using Zed Editor)
+mkdir -p /path/to/your/project/.zed
+cp templates/zed-tasks.json /path/to/your/project/.zed/tasks.json
 ```
 
 See [templates/BOOTSTRAP.md](templates/BOOTSTRAP.md) for detailed instructions.

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -458,6 +458,43 @@ See also: [Section 14 - SBX Proxy Doesn't Work with Custom baseURL](#14-sbx-prox
 
 ---
 
+## 16. SSL/TLS Certificate Error: "unable to get local issuer certificate"
+
+### Symptoms
+
+- OpenCode crashes or fails to connect to USAi
+- Error: `unable to get local issuer certificate`
+- Occurs on GFE (Government Furnished Equipment) networks
+
+### Root Cause
+
+On federal/GFE networks, secure internet traffic is often intercepted and decrypted using a custom Root Certificate Authority (CA) for security inspection.
+
+Because the sandboxed container runs a vanilla Linux environment, it does not automatically trust your host's GFE custom root certificate. When Node.js tries to establish a TLS connection to `https://api.gsa.usai.gov/api/v1`, it rejects the connection because it cannot verify the custom certificate chain.
+
+### Fix
+
+To resolve this during local development, you can tell Node.js to ignore TLS validation errors inside the sandbox using `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+
+#### Option A: Run-Time Flag (Standalone CLI)
+Run your agent with the environment variable set:
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED=0 make run-agent
+```
+*(The `Makefile` is configured to automatically pass this variable into the container if it's set on your host).*
+
+#### Option B: Global Shell Profile (Works for both Standalone CLI and Docker Desktop)
+Add the variable to your shell configuration (`~/.zshrc` or `~/.bashrc`):
+```bash
+echo 'export NODE_TLS_REJECT_UNAUTHORIZED="0"' >> ~/.zshrc
+source ~/.zshrc
+```
+*(Docker Desktop users: Remember to completely **restart Docker Desktop** after saving this so that sandboxes inherit the variable).*
+
+> **⚠️ Security Warning:** Bypassing TLS validation should only be used in isolated local development sandbox environments. Never disable certificate validation in production application code.
+
+---
+
 ## Debugging Checklist
 
 When something fails, work through this list:

--- a/docs/SBX_QUICKSTART.md
+++ b/docs/SBX_QUICKSTART.md
@@ -414,6 +414,8 @@ sbx exec -it \
 
 The `-e` flag injects environment variables, and `-w` sets the working directory so OpenCode finds the `opencode.jsonc` config.
 
+> **💡 Zed Editor Users:** If you are using the Zed editor, you can automate this entire walkthrough—including sandbox creation and agent launching—using the built-in tasks defined in `.zed/tasks.json`. Check out the **[Zed Editor Setup Guide](ZED_SETUP.md)** to get started.
+
 ### Why Not Use SBX Secret Management for USAi?
 
 SBX's `sbx secret set` command works great for standard providers (OpenAI, Anthropic, GitHub, etc.) because SBX proxies requests to known endpoints and injects authentication automatically.

--- a/docs/ZED_SETUP.md
+++ b/docs/ZED_SETUP.md
@@ -1,0 +1,178 @@
+# Setting up Zed Editor with OpenCode and Docker Sandboxes (SBX)
+
+This guide documents how to set up and run the containerized OpenCode agent inside a sandboxed Docker environment (SBX) while developing on your host machine using the **Zed editor**.
+
+## Why Use Zed with Docker Sandboxes?
+
+Using [Zed](https://zed.dev) with Docker Sandboxes and USAi provides a robust, fast developer workflow:
+
+- **Instant Sync:** Since the SBX container mounts your project workspace directory, any code the agent generates or modifies inside the isolated sandbox is instantly reflected in Zed on your host machine.
+- **PTY/TTY-Compliant Tasks:** Zed's integrated task runner provides a fully interactive pseudo-TTY, enabling you to respond to OpenCode's confirmation prompts (e.g., confirming file edits) right within your editor pane.
+- **Secure Secret Boundary:** Zed and your host files are protected. The agent executes commands and runs tests purely inside the container, keeping your host system safe.
+
+---
+
+## Prerequisites
+
+1. **Zed Editor** installed on your host machine.
+2. **Docker Desktop 4.58+** OR standalone **`sbx` CLI** running.
+3. **USAi API Key** set in your host shell profile (required so Zed's terminal can read it):
+
+   **For macOS/Linux (zsh):**
+   ```bash
+   echo 'export USAI_API_KEY="your-api-key-here"' >> ~/.zshrc
+   source ~/.zshrc
+   ```
+
+   **For macOS/Linux (bash):**
+   ```bash
+   echo 'export USAI_API_KEY="your-api-key-here"' >> ~/.bashrc
+   source ~/.bashrc
+   ```
+
+   *(Docker Desktop users: Remember to completely **restart Docker Desktop** after setting this variable so that the background service picks it up).*
+
+---
+
+## One-Command Setup & Run with Zed Tasks
+
+This repository is pre-configured with a `.zed/tasks.json` file. This integrates with Zed's task runner, giving you one-click access to sandbox creation, health checks, and running the agent.
+
+### 1. Open the Tasks Palette
+
+In Zed, you can trigger tasks via the command palette:
+1. Press `Cmd+Shift+P` (macOS) or `Ctrl+Shift+P` (Windows/Linux) to open the Command Palette.
+2. Type `task: spawn` and press `Enter`.
+3. *(Alternative shortcut: Press `Cmd+Alt+T` on macOS or `Ctrl+Alt+T` on Windows/Linux).*
+
+### 2. Available Tasks
+
+You will see several tasks preconfigured for this workspace:
+
+| Task Label | Description | Underlying Command |
+|------------|-------------|--------------------|
+| `OpenCode: Create Sandbox (Standalone CLI)` | Creates the `quickstart` sandbox using `sbx` CLI | `make create-sandbox` |
+| `OpenCode: Create Sandbox (Docker Desktop)` | Creates the `quickstart` sandbox using Docker Desktop | `make create-sandbox-desktop` |
+| `OpenCode: Run Agent (Standalone CLI)` | Launches OpenCode inside SBX and injects your USAi key | `make run-agent` |
+| `OpenCode: Run Agent (Docker Desktop)` | Launches OpenCode in SBX using Docker Desktop | `make run-agent-desktop` |
+| `OpenCode: Environment Diagnostics` | Performs health checks on your Docker & SBX setup | `make doctor` |
+
+### 3. Step-by-Step Workflow inside Zed
+
+1. **Run Diagnostics:** Open the tasks palette and select `OpenCode: Environment Diagnostics (make doctor)`. It will open a panel in Zed and verify your Docker and setup states.
+2. **Create Sandbox:** Select `OpenCode: Create Sandbox (Standalone CLI)` (or the Docker Desktop equivalent). This prepares your microVM.
+3. **Launch OpenCode Agent:** Select `OpenCode: Run Agent (Standalone CLI)` (or Docker Desktop equivalent).
+4. **Interact with the Agent:** The agent will boot inside a terminal panel in Zed. You can type prompts directly to the agent (e.g. *"Analyze the directory structure and check for AGENTS.md"*).
+5. **Interactive Approvals:** Because our `opencode.jsonc` is configured with `"edit": "ask"` and `"bash": "ask"` for safety, the agent will prompt you in the terminal for approval before making file changes or running mutating shell commands. Type `y` or `n` directly into the Zed terminal tab to respond.
+
+---
+
+## Alternative: Integrated Terminal (Makefile Shortcuts)
+
+If you prefer to run commands manually, you can open Zed's integrated terminal (`Ctrl + ~`) and use the following Makefile shortcuts:
+
+```bash
+# Check if your host has USAI_API_KEY set and everything is healthy
+make doctor
+
+# Option A: Standalone sbx CLI
+make create-sandbox
+make run-agent
+
+# Option B: Docker Desktop built-in
+make create-sandbox-desktop
+make run-agent-desktop
+```
+
+---
+
+## Bootstrapping a New Project with Zed Integration
+
+If you want to configure a new or existing repository to use the OpenCode agent in SBX with Zed support:
+
+### Step 1: Copy Templates
+
+Use the quickstart bootstrap files to copy configurations over to your repository:
+
+```bash
+TARGET_REPO="/path/to/your/project"
+
+# Copy OpenCode config
+cp templates/opencode.jsonc "$TARGET_REPO/"
+
+# Copy Zed Tasks configuration
+mkdir -p "$TARGET_REPO/.zed"
+cp templates/zed-tasks.json "$TARGET_REPO/.zed/tasks.json"
+
+# Copy SBX patterns reference
+mkdir -p "$TARGET_REPO/docs"
+cp templates/SBX_PATTERNS.md "$TARGET_REPO/docs/"
+
+# Append Sandbox Rules to AGENTS.md
+tail -n +6 templates/AGENTS_SBX_ADDENDUM.md >> "$TARGET_REPO/AGENTS.md"
+```
+
+### Step 2: Configure your `Makefile`
+
+Add these targets to your target repository's `Makefile` so that the Zed tasks function properly:
+
+```makefile
+# Create SBX sandbox using standalone CLI (sbx)
+create-sandbox:
+	@echo "Creating SBX sandbox using standalone CLI..."
+	@if sbx ls | grep -q "my-sandbox"; then \
+		echo "Sandbox already exists. Skipping creation."; \
+	else \
+		sbx create --name my-sandbox opencode .; \
+	fi
+
+# Create SBX sandbox using Docker Desktop
+create-sandbox-desktop:
+	@echo "Creating SBX sandbox using Docker Desktop..."
+	@if docker sandbox ls 2>/dev/null | grep -q "my-sandbox"; then \
+		echo "Sandbox already exists. Skipping creation."; \
+	else \
+		docker sandbox create --name my-sandbox opencode .; \
+	fi
+
+# Run OpenCode agent in sandbox using standalone CLI (sbx)
+run-agent: _check-usai-key
+	@echo "Running OpenCode agent in SBX sandbox (standalone CLI)..."
+	@sbx exec -it -e USAI_API_KEY="$(USAI_API_KEY)" -w "$(shell pwd)" my-sandbox opencode
+
+# Run OpenCode agent in sandbox using Docker Desktop
+run-agent-desktop:
+	@echo "Running OpenCode agent in SBX sandbox (Docker Desktop)..."
+	@docker sandbox run my-sandbox
+
+_check-usai-key:
+	@if [ -z "$(USAI_API_KEY)" ]; then \
+		echo "ERROR: USAI_API_KEY environment variable is not set on host."; \
+		echo "Please set it before running the agent. Example:"; \
+		echo "  export USAI_API_KEY=\"your-key-here\""; \
+		exit 1; \
+	fi
+```
+
+*(Note: If your sandbox name is different than `my-sandbox`, make sure to update the name in the `Makefile` and `.zed/tasks.json` to match!)*
+
+---
+
+## Troubleshooting Zed Integration
+
+### "Task Command Not Found: make"
+- Ensure that `make` is installed on your host machine (included by default on macOS, installable on Linux via `build-essential`, or Windows via Chocolatey/Scoop).
+- Alternatively, you can edit your `.zed/tasks.json` and replace the `make` commands with the direct `sbx` or `docker sandbox` command strings.
+
+### "ERROR: USAI_API_KEY environment variable is not set on host"
+- Zed inherits environment variables from the parent shell that launched it.
+- If you set `USAI_API_KEY` in `.zshrc` or `.bashrc` after launching Zed, you **must completely restart Zed** (or relaunch it from your terminal using `zed .`) so it picks up the newly exported variable.
+
+### SSL/TLS Certificate Errors ("unable to get local issuer certificate")
+- If OpenCode launches but fails to connect with an `unable to get local issuer certificate` error, this is due to SSL/TLS interception/decryption on federal GFE (Government Furnished Equipment) networks.
+- **To fix this:** Add `export NODE_TLS_REJECT_UNAUTHORIZED="0"` to your host's shell profile (`~/.zshrc` or `~/.bashrc`) and restart Zed (and completely restart Docker Desktop if you are using it). This allows Node.js inside the isolated sandbox container to securely bypass GFE network decrypt validation.
+- Alternatively, you can run from your host terminal using: `NODE_TLS_REJECT_UNAUTHORIZED=0 make run-agent`
+
+### Terminal Output is Frozen or Unresponsive
+- If a task runs and does not respond to keystrokes, close the terminal pane (`Cmd + W`) and trigger the task again via the tasks palette.
+- Standard interactive shells are fully supported, but if you run into environment issues, run `make run-agent` directly in Zed's integrated terminal (`Ctrl + ~`) instead of the task runner.

--- a/templates/BOOTSTRAP.md
+++ b/templates/BOOTSTRAP.md
@@ -15,6 +15,7 @@ See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for 
 | File | Purpose | Required? |
 |------|---------|-----------|
 | `opencode.jsonc` | OpenCode configuration with USAi provider | Yes |
+| `.zed/tasks.json` | Pre-configured Tasks for the Zed editor | Recommended (if using Zed) |
 | `docs/SBX_PATTERNS.md` | Credential injection quick reference | Recommended |
 | `AGENTS_SBX_ADDENDUM.md` | Sandbox rules to append to your AGENTS.md | If you have AGENTS.md |
 
@@ -29,6 +30,10 @@ git clone https://github.com/GSA-TTS/agentic-coding-quickstart.git /tmp/quicksta
 
 # Copy the OpenCode config
 cp /tmp/quickstart/templates/opencode.jsonc "$TARGET_REPO/"
+
+# Copy Zed editor tasks configuration (optional, recommended if using Zed)
+mkdir -p "$TARGET_REPO/.zed"
+cp /tmp/quickstart/templates/zed-tasks.json "$TARGET_REPO/.zed/tasks.json"
 
 # Copy the SBX patterns reference
 mkdir -p "$TARGET_REPO/docs"

--- a/templates/zed-tasks.json
+++ b/templates/zed-tasks.json
@@ -1,0 +1,32 @@
+[
+  {
+    "label": "OpenCode: Run Agent (Standalone CLI)",
+    "command": "make run-agent",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "OpenCode: Run Agent (Docker Desktop)",
+    "command": "make run-agent-desktop",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "OpenCode: Create Sandbox (Standalone CLI)",
+    "command": "make create-sandbox",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "OpenCode: Create Sandbox (Docker Desktop)",
+    "command": "make create-sandbox-desktop",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "OpenCode: Environment Diagnostics (make doctor)",
+    "command": "make doctor",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  }
+]


### PR DESCRIPTION
### Summary
This PR adds comprehensive integration for the **Zed Editor** to launch and manage containerized OpenCode agents running inside isolated Docker Sandboxes (SBX) with GSA USAi API endpoints.

### Key Changes
1. **Unified CLI/Editor Tasks in `Makefile`**:
   - Added targets: `create-sandbox`, `create-sandbox-desktop`, `run-agent`, and `run-agent-desktop`.
   - Enabled robust, idempotent checks to avoid crashing if a sandbox already exists.
   - Fixed macOS-to-Linux path case-sensitivity bug by utilizing `-w "$(shell pwd)"` inside the sandbox mounting system.
   - Automatically detects and forwards the host's `NODE_TLS_REJECT_UNAUTHORIZED` flag to support GFE networks.

2. **Pre-configured Zed Tasks (`.zed/tasks.json` & Templates)**:
   - Configured tasks for automated environment diagnostics, sandbox creation, and interactive agent launch.
   - Avoided task list duplication inside Zed by storing the template in `templates/zed-tasks.json` instead of a nested `.zed` folder.

3. **Bootstrap Updates**:
   - Integrated the Zed tasks config into the standard bootstrap copy scripts inside `README.md` and `templates/BOOTSTRAP.md`.

4. **New Setup Guide (`docs/ZED_SETUP.md`) & Troubleshooting Guide**:
   - Created a comprehensive guide explaining how to launch and interact with the agent from within Zed.
   - Documented the `unable to get local issuer certificate` GFE SSL decryption issue under **Section 16** of `docs/KNOWN_FAILURE_MODES.md` with remediation steps.

### Validation Performed
- Checked environment and verified standalone `sbx` and Docker Desktop commands operate properly.
- Validated that the container successfully resolves host mounts and contacts GSA USAi API endpoints to list available models.

Co-Authored-By: AI Agent <ai-agent@gsa.gov>