### PR TITLE
docs: add reference to docker/sbx-releases#7 for custom secret feature

### DIFF
--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -154,6 +154,8 @@ SCOPE      SERVICE        SECRET
 | `GITLAB_TOKEN` | GitLab access |
 | `MY_CUSTOM_SECRET` | Any custom credential |
 
+> **Note:** Custom variable support was added based on community feedback. See [docker/sbx-releases#7](https://github.com/docker/sbx-releases/issues/7) for details. This feature may still be marked as experimental.
+
 ```bash
 # Store any custom variable
 sbx secret set -g USAI_API_KEY

--- a/docs/SBX_QUICKSTART.md
+++ b/docs/SBX_QUICKSTART.md
@@ -451,6 +451,8 @@ sbx secret ls
 
 This is the **recommended approach** for any credential you use regularly — it's more secure than environment variables and persists across terminal sessions.
 
+> **Reference:** This feature was added in response to community feedback. See [docker/sbx-releases#7](https://github.com/docker/sbx-releases/issues/7) for the original feature request and implementation details. Note: This feature may still be marked as experimental in `sbx secret --help`.
+
 ---
 
 ## Common Commands Reference


### PR DESCRIPTION
## Summary

Adds a reference link to the upstream Docker sbx-releases issue where custom variable support was requested and implemented.

## Changes

- **docs/SBX_QUICKSTART.md**: Added note linking to [docker/sbx-releases#7](https://github.com/docker/sbx-releases/issues/7)
- **docs/QUICKSTART_SBX.md**: Added same reference note

## Why

Users may want to:
1. Track upstream development of this feature
2. Understand it may still be experimental
3. See the original implementation details and discussion

## Checklist

- [x] Gitleaks passed
- [x] Pre-commit hooks passed
- [x] Links verified