### PR TITLE
chore: add CODEOWNERS file for security-sensitive paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS for agentic-coding-quickstart
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Security-sensitive files require admin review
+/.github/workflows/         @GSA-TTS/agentic-coding-admins
+/SECURITY.md                @GSA-TTS/agentic-coding-admins
+
+# Documentation
+/docs/                      @GSA-TTS/agentic-coding-team


### PR DESCRIPTION
## Summary
Adds CODEOWNERS file to enforce code review ownership for security-sensitive paths.

## Changes
- `/.github/workflows/` → admin review
- `/SECURITY.md` → admin review
- `/docs/` → maintainer review

## Control Mapping
- NIST CM-3 (Configuration Change Control)
- NIST AC-6 (Least Privilege)

Closes #50