### PR TITLE
docs: deprecate Docker Desktop `docker sandbox` in favor of sbx CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -64,10 +64,10 @@ body:
     id: sbx_method
     attributes:
       label: SBX method
-      description: Which method are you using?
+      description: "Which method are you using? (Note: Docker Desktop docker sandbox is deprecated)"
       options:
-        - Docker Desktop (`docker sandbox`)
-        - Standalone CLI (`sbx`)
+        - "Standalone CLI (sbx) - Recommended"
+        - "Docker Desktop (docker sandbox) - Deprecated"
         - Not sure
     validations:
       required: true

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,14 @@ help:
 	@echo "  make setup                 - Set up your workspace (clone playbook, check dependencies)"
 	@echo "  make doctor                - Run health checks on your environment"
 	@echo "  make new-project           - Create a new project directory"
-	@echo "  make create-sandbox        - Create SBX sandbox 'quickstart' (standalone sbx CLI)"
-	@echo "  make create-sandbox-desktop- Create SBX sandbox 'quickstart' (Docker Desktop)"
-	@echo "  make run-agent             - Run OpenCode agent in SBX (standalone sbx CLI)"
-	@echo "  make run-agent-desktop     - Run OpenCode agent in SBX (Docker Desktop)"
+	@echo "  make create-sandbox        - Create SBX sandbox 'quickstart' (sbx CLI)"
+	@echo "  make run-agent             - Run OpenCode agent in SBX (sbx CLI)"
 	@echo "  make install-hooks         - [OPTIONAL] Install pre-commit hooks"
 	@echo "  make clean                 - Remove generated files"
+	@echo ""
+	@echo "Deprecated targets (will be removed in future release):"
+	@echo "  make create-sandbox-desktop- DEPRECATED: use 'make create-sandbox'"
+	@echo "  make run-agent-desktop     - DEPRECATED: use 'make run-agent'"
 	@echo ""
 	@echo "First time? Run: make setup"
 
@@ -102,35 +104,45 @@ new-project:
 clean:
 	@echo "Nothing to clean (this repo doesn't generate files)"
 
-# Create SBX sandbox 'quickstart' using standalone CLI (sbx)
+# Create SBX sandbox 'quickstart' using sbx CLI
 create-sandbox:
-	@echo "Creating SBX sandbox 'quickstart' using standalone CLI..."
+	@echo "Creating SBX sandbox 'quickstart'..."
 	@if sbx ls | grep -q "quickstart"; then \
 		echo "Sandbox 'quickstart' already exists. Skipping creation."; \
 	else \
 		sbx create --name quickstart opencode .; \
 	fi
 
-# Create SBX sandbox 'quickstart' using Docker Desktop
+# DEPRECATED: Create SBX sandbox using Docker Desktop
+# Docker has deprecated 'docker sandbox' commands. Use 'make create-sandbox' instead.
 create-sandbox-desktop:
-	@echo "Creating SBX sandbox 'quickstart' using Docker Desktop..."
+	@echo ""
+	@echo "WARNING: 'docker sandbox' commands are DEPRECATED by Docker."
+	@echo "         Use 'make create-sandbox' (sbx CLI) instead."
+	@echo "         See: https://docs.docker.com/reference/cli/docker/sandbox/"
+	@echo ""
 	@if docker sandbox ls 2>/dev/null | grep -q "quickstart"; then \
 		echo "Sandbox 'quickstart' already exists. Skipping creation."; \
 	else \
 		docker sandbox create --name quickstart opencode .; \
 	fi
 
-# Run OpenCode agent in sandbox 'quickstart' using standalone CLI (sbx)
+# Run OpenCode agent in sandbox 'quickstart' using sbx CLI
 run-agent: _check-usai-key
-	@echo "Running OpenCode agent in SBX sandbox 'quickstart' (standalone CLI)..."
+	@echo "Running OpenCode agent in SBX sandbox 'quickstart'..."
 	@sbx exec -it \
 		-e USAI_API_KEY="$(USAI_API_KEY)" \
 		$(if $(NODE_TLS_REJECT_UNAUTHORIZED),-e NODE_TLS_REJECT_UNAUTHORIZED="$(NODE_TLS_REJECT_UNAUTHORIZED)",) \
 		-w "$(shell pwd)" quickstart opencode
 
-# Run OpenCode agent in sandbox 'quickstart' using Docker Desktop
+# DEPRECATED: Run agent using Docker Desktop
+# Docker has deprecated 'docker sandbox' commands. Use 'make run-agent' instead.
 run-agent-desktop:
-	@echo "Running OpenCode agent in SBX sandbox 'quickstart' (Docker Desktop)..."
+	@echo ""
+	@echo "WARNING: 'docker sandbox' commands are DEPRECATED by Docker."
+	@echo "         Use 'make run-agent' (sbx CLI) instead."
+	@echo "         See: https://docs.docker.com/reference/cli/docker/sandbox/"
+	@echo ""
 	@docker sandbox run quickstart
 
 _check-usai-key:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ That's it. You're now running an AI coding agent in an isolated container with U
 
 **Need more details?** See the [Full sbx CLI Guide](docs/QUICKSTART_SBX.md).
 
-**Prefer Docker Desktop UI?** See the [Docker Desktop Guide](docs/QUICKSTART_DOCKER_DESKTOP.md).
+> [!WARNING]
+> **Docker Desktop `docker sandbox` commands are deprecated.** Use the `sbx` CLI instead.
+> See [Docker's deprecation notice](https://docs.docker.com/reference/cli/docker/sandbox/).
 
 ---
 
@@ -91,7 +93,7 @@ winget install -h Docker.sbx && sbx login
 | `.pre-commit-config.yaml` | Optional pre-commit hooks (secret detection, file hygiene) |
 | `AGENTS.md` | Behavioral rules the agent follows |
 | `docs/QUICKSTART_SBX.md` | Full sbx CLI setup guide |
-| `docs/QUICKSTART_DOCKER_DESKTOP.md` | Docker Desktop setup guide |
+| `docs/QUICKSTART_DOCKER_DESKTOP.md` | ~~Docker Desktop setup guide~~ (deprecated) |
 | `docs/ZED_SETUP.md` | **Zed Editor** integration guide |
 | `docs/KNOWN_FAILURE_MODES.md` | Troubleshooting guide |
 | `templates/` | Files to copy into your own projects |
@@ -131,9 +133,19 @@ sbx policy allow network -g "api.gsa.usai.gov"
 
 > Do NOT use "Open" policy on GFE — it exposes internal GSA resources to the agent.
 
-### "docker: unknown command: docker sbx"
+### "docker: unknown command: docker sbx" or "docker sandbox deprecated"
 
-Use `docker sandbox` (two words), not `docker sbx`. Or install the standalone `sbx` CLI.
+The `docker sandbox` command is deprecated. Install and use the standalone `sbx` CLI instead:
+
+```bash
+# macOS
+brew install docker/tap/sbx
+
+# Windows
+winget install Docker.sbx
+```
+
+Then use `sbx` commands directly (e.g., `sbx run opencode .` instead of `docker sandbox run opencode .`).
 
 ### OpenCode shows wrong providers
 

--- a/docs/QUICKSTART_DOCKER_DESKTOP.md
+++ b/docs/QUICKSTART_DOCKER_DESKTOP.md
@@ -1,8 +1,47 @@
 # Docker Desktop Quickstart Guide
 
-> **Alternative approach** — For users who prefer graphical interfaces.
+> [!CAUTION]
+> **DEPRECATED:** The Docker Desktop-integrated `docker sandbox` commands are deprecated by Docker.
+> Please use the standalone **[sbx CLI Guide](QUICKSTART_SBX.md)** instead.
 >
-> **Recommended:** If you're comfortable with command line, use the [sbx CLI Guide](QUICKSTART_SBX.md) instead for better security and automation.
+> See [Docker's deprecation notice](https://docs.docker.com/reference/cli/docker/sandbox/).
+
+---
+
+## Migration to sbx CLI
+
+If you're currently using `docker sandbox` commands, migrate to `sbx`:
+
+| Deprecated Command | New Command |
+|-------------------|-------------|
+| `docker sandbox create` | `sbx create` |
+| `docker sandbox run opencode .` | `sbx run opencode .` |
+| `docker sandbox exec` | `sbx exec` |
+| `docker sandbox ls` | `sbx ls` |
+| `docker sandbox rm` | `sbx rm` |
+| `docker sandbox stop` | `sbx stop` |
+
+**Install sbx CLI:**
+
+```bash
+# macOS
+brew install docker/tap/sbx
+
+# Windows
+winget install Docker.sbx
+```
+
+**Your existing sandboxes and secrets will continue to work with the `sbx` CLI.**
+
+**[Continue to sbx CLI Guide](QUICKSTART_SBX.md)**
+
+---
+
+## Legacy Documentation (Deprecated)
+
+> [!WARNING]
+> The following documentation is preserved for reference only.
+> The `docker sandbox` commands will stop working in a future Docker Desktop release.
 
 This guide covers using Docker Desktop's graphical interface to run AI coding agents with USAi.
 

--- a/docs/SBX_QUICKSTART.md
+++ b/docs/SBX_QUICKSTART.md
@@ -1,8 +1,17 @@
 # Docker Sandboxes + USAi Quick Start
 
+> [!IMPORTANT]
+> **Docker Desktop `docker sandbox` commands are deprecated.**
+> Docker has deprecated the Docker Desktop-integrated `docker sandbox` commands in favor of the standalone `sbx` CLI.
+> See [Docker's deprecation notice](https://docs.docker.com/reference/cli/docker/sandbox/).
+>
+> **Use the [sbx CLI Guide](QUICKSTART_SBX.md) for the recommended setup.**
+
+---
+
 > **Looking for a faster start?**
-> - [sbx CLI Guide](QUICKSTART_SBX.md) — **Recommended** for federal users (better security, automation)
-> - [Docker Desktop Guide](QUICKSTART_DOCKER_DESKTOP.md) — Alternative for GUI preference
+> - [sbx CLI Guide](QUICKSTART_SBX.md) — **Recommended** for all users
+> - [Docker Desktop Guide](QUICKSTART_DOCKER_DESKTOP.md) — **Deprecated** (legacy reference only)
 >
 > This document is the **comprehensive reference** covering both approaches in detail.
 
@@ -14,19 +23,18 @@ This guide gets you from zero to running an AI agent inside Docker Sandboxes wit
 
 [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) runs AI coding agents in isolated microVM environments. Each sandbox gets its own Docker daemon, filesystem, and network—the agent can build containers, install packages, and modify files without touching your host system.
 
-There are **two ways** to use Docker Sandboxes:
+> [!CAUTION]
+> **Deprecation Notice:** The Docker Desktop-integrated `docker sandbox` command is deprecated.
+> Use the standalone `sbx` CLI instead. See the [migration guide](#migrating-from-docker-sandbox-to-sbx).
 
-| Method | Install | Command Prefix | Best For |
-|--------|---------|----------------|----------|
-| **Docker Desktop built-in** | None (Docker Desktop 4.58+) | `docker sandbox` | Quick start, GFE Macs with managed Docker |
-| **Standalone sbx CLI** | Homebrew/Winget/apt | `sbx` | Full features, secret proxy, more flexibility |
-
-> **Which should I use?** Start with `docker sandbox` if you already have Docker Desktop 4.58+. The standalone `sbx` CLI offers additional features like the secret proxy (for GitHub tokens) and more granular control. Both work for basic USAi usage.
+| Method | Status | Install | Command Prefix | Best For |
+|--------|--------|---------|----------------|----------|
+| **Standalone sbx CLI** | **Recommended** | Homebrew/Winget/apt | `sbx` | All users, full features, secret proxy |
+| ~~Docker Desktop built-in~~ | **Deprecated** | ~~None (Docker Desktop 4.58+)~~ | ~~`docker sandbox`~~ | ~~Legacy only~~ |
 
 ## Prerequisites
 
-**Choose one:**
-- **Docker Desktop 4.58+** (`docker --version` to check) — sandboxes built-in, no extra install
+**Required:**
 - **Standalone sbx CLI** (`sbx --version` to check) — install via Homebrew/Winget/apt
 
 **Plus:**
@@ -37,19 +45,9 @@ There are **two ways** to use Docker Sandboxes:
 
 ## Installing Docker Sandboxes
 
-### Option A: Docker Desktop Built-in (No Extra Install)
+### Standalone sbx CLI (Recommended)
 
-If you have **Docker Desktop 4.58 or later**, sandboxes are already included. Verify:
-
-```bash
-docker sandbox --help
-```
-
-> **Note:** On some managed Docker installations (like GSA GFE Macs), the command is `docker sandbox` (two words), not `docker sbx`. If `docker sbx` returns "unknown command", try `docker sandbox`.
-
-### Option B: Standalone sbx CLI (More Features)
-
-The standalone CLI offers additional features (secret proxy, network policies) and doesn't require Docker Desktop.
+The standalone CLI offers full features (secret proxy, network policies) and is the only supported method going forward.
 
 **macOS (Homebrew):**
 ```bash
@@ -73,6 +71,22 @@ sbx login
 ```
 
 See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for full details.
+
+## Migrating from `docker sandbox` to `sbx`
+
+If you're currently using the deprecated `docker sandbox` commands, migrate to `sbx`:
+
+| Deprecated Command | New Command |
+|-------------------|-------------|
+| `docker sandbox create --name NAME opencode .` | `sbx create --name NAME opencode .` |
+| `docker sandbox run NAME` | `sbx run NAME` |
+| `docker sandbox exec NAME cmd` | `sbx exec NAME cmd` |
+| `docker sandbox ls` | `sbx ls` |
+| `docker sandbox rm NAME` | `sbx rm NAME` |
+| `docker sandbox stop NAME` | `sbx stop NAME` |
+| `docker sandbox reset` | (remove individually with `sbx rm`) |
+
+**Your existing sandboxes and secrets will continue to work with the `sbx` CLI.**
 
 ## Network Policy Configuration (Important!)
 
@@ -125,7 +139,36 @@ The "Balanced" policy already includes common package managers (npm, pypi) and c
 
 ## Quick Start
 
-### Using Docker Desktop (`docker sandbox`)
+### Using Standalone CLI (`sbx`) — Recommended
+
+```bash
+# 1. Store your API key securely in system keychain (NEW!)
+sbx secret set -g USAI_API_KEY
+# Enter your key when prompted - stored in system keychain, auto-injected
+
+# 2. Configure network policy (first run will prompt - choose "Balanced")
+#    Then add USAi to the allowlist:
+sbx policy allow network "api.gsa.usai.gov"
+
+# 3. Create a sandbox for OpenCode in current directory
+sbx create --name usai-test opencode .
+
+# 4. Run OpenCode (secrets auto-injected from keychain)
+sbx run usai-test
+```
+
+That's it. You're now running an AI agent in an isolated container with USAi access.
+
+> **New in sbx CLI:** Custom environment variables like `USAI_API_KEY` can now be stored with `sbx secret set -g VARNAME`. The secret is stored in your system keychain and auto-injected into sandboxes — no more manual `-e` flags!
+
+### Using Docker Desktop (`docker sandbox`) — DEPRECATED
+
+> [!WARNING]
+> **Deprecated:** The `docker sandbox` command is deprecated by Docker.
+> Migrate to the `sbx` CLI above. See the [migration guide](#migrating-from-docker-sandbox-to-sbx).
+
+<details>
+<summary>Legacy instructions (click to expand)</summary>
 
 ```bash
 # 1. Set your API key in your shell config file (~/.bashrc or ~/.zshrc)
@@ -151,59 +194,29 @@ docker sandbox run usai-test
 > 2. Source the file
 > 3. **Completely restart Docker Desktop** (not just the terminal)
 
-### Using Standalone CLI (`sbx`) — Recommended
-
-```bash
-# 1. Store your API key securely in system keychain (NEW!)
-sbx secret set -g USAI_API_KEY
-# Enter your key when prompted - stored in system keychain, auto-injected
-
-# 2. Configure network policy (first run will prompt - choose "Balanced")
-#    Then add USAi to the allowlist:
-sbx policy allow network "api.gsa.usai.gov"
-
-# 3. Create a sandbox for OpenCode in current directory
-sbx create --name usai-test opencode .
-
-# 4. Run OpenCode (secrets auto-injected from keychain)
-sbx run usai-test
-```
-
-That's it. You're now running an AI agent in an isolated container with USAi access.
-
-> **New in sbx CLI:** Custom environment variables like `USAI_API_KEY` can now be stored with `sbx secret set -g VARNAME`. The secret is stored in your system keychain and auto-injected into sandboxes — no more manual `-e` flags!
+</details>
 
 ### Command Comparison Reference
 
-| Action | Docker Desktop | Standalone sbx CLI |
+> [!NOTE]
+> The `docker sandbox` commands in the left column are **deprecated**. Use `sbx` commands instead.
+
+| Action | ~~Docker Desktop~~ (Deprecated) | Standalone sbx CLI |
 |--------|----------------|--------------------|
-| Create sandbox | `docker sandbox create --name NAME opencode .` | `sbx create --name NAME opencode .` |
-| Run/connect | `docker sandbox run NAME` | `sbx run NAME` |
-| Run with env vars | Set in shell config + restart Docker | `sbx exec -it -e VAR="$VAR" NAME cmd` |
-| List sandboxes | `docker sandbox ls` | `sbx ls` |
-| Stop sandbox | (sandboxes auto-stop) | `sbx stop NAME` |
-| Remove sandbox | `docker sandbox rm NAME` | `sbx rm NAME` |
-| Set secrets | N/A (use shell config) | `sbx secret set -g SERVICE` |
-| Reset all | `docker sandbox reset` | (remove individually) |
+| Create sandbox | ~~`docker sandbox create --name NAME opencode .`~~ | `sbx create --name NAME opencode .` |
+| Run/connect | ~~`docker sandbox run NAME`~~ | `sbx run NAME` |
+| Run with env vars | ~~Set in shell config + restart Docker~~ | `sbx exec -it -e VAR="$VAR" NAME cmd` |
+| List sandboxes | ~~`docker sandbox ls`~~ | `sbx ls` |
+| Stop sandbox | ~~(sandboxes auto-stop)~~ | `sbx stop NAME` |
+| Remove sandbox | ~~`docker sandbox rm NAME`~~ | `sbx rm NAME` |
+| Set secrets | ~~N/A (use shell config)~~ | `sbx secret set -g SERVICE` |
+| Reset all | ~~`docker sandbox reset`~~ | (remove individually) |
 
 ## Credential Injection Overview
 
-How credentials are handled differs between Docker Desktop and the standalone CLI:
+The `sbx` CLI provides secure credential injection via the system keychain.
 
-### Docker Desktop (`docker sandbox`)
-
-Docker Desktop reads environment variables from your shell configuration file (`~/.bashrc`, `~/.zshrc`) at startup. The sandbox proxy injects credentials into API requests, so keys stay on your host.
-
-```bash
-# Add to ~/.bashrc or ~/.zshrc
-export USAI_API_KEY="your-api-key"
-export ANTHROPIC_API_KEY="your-key"  # if using Claude directly
-export GH_TOKEN="your-github-token"  # for GitHub access
-```
-
-After adding variables, **source your config and restart Docker Desktop**.
-
-### Standalone CLI (`sbx`)
+### Standalone CLI (`sbx`) — Recommended
 
 The `sbx` CLI supports two methods:
 

--- a/docs/ZED_SETUP.md
+++ b/docs/ZED_SETUP.md
@@ -2,6 +2,11 @@
 
 This guide documents how to set up and run the containerized OpenCode agent inside a sandboxed Docker environment (SBX) while developing on your host machine using the **Zed editor**.
 
+> [!IMPORTANT]
+> The Docker Desktop-integrated `docker sandbox` commands are **deprecated**.
+> Use the standalone `sbx` CLI instead.
+> See [Docker's deprecation notice](https://docs.docker.com/reference/cli/docker/sandbox/).
+
 ## Why Use Zed with Docker Sandboxes?
 
 Using [Zed](https://zed.dev) with Docker Sandboxes and USAi provides a robust, fast developer workflow:
@@ -15,22 +20,19 @@ Using [Zed](https://zed.dev) with Docker Sandboxes and USAi provides a robust, f
 ## Prerequisites
 
 1. **Zed Editor** installed on your host machine.
-2. **Docker Desktop 4.58+** OR standalone **`sbx` CLI** running.
-3. **USAi API Key** set in your host shell profile (required so Zed's terminal can read it):
-
-   **For macOS/Linux (zsh):**
+2. **Standalone `sbx` CLI** installed:
    ```bash
-   echo 'export USAI_API_KEY="your-api-key-here"' >> ~/.zshrc
-   source ~/.zshrc
-   ```
+   # macOS
+   brew install docker/tap/sbx
 
-   **For macOS/Linux (bash):**
+   # Windows
+   winget install Docker.sbx
+   ```
+3. **USAi API Key** stored securely:
    ```bash
-   echo 'export USAI_API_KEY="your-api-key-here"' >> ~/.bashrc
-   source ~/.bashrc
+   sbx secret set -g USAI_API_KEY
+   # Enter your key when prompted
    ```
-
-   *(Docker Desktop users: Remember to completely **restart Docker Desktop** after setting this variable so that the background service picks it up).*
 
 ---
 
@@ -51,17 +53,17 @@ You will see several tasks preconfigured for this workspace:
 
 | Task Label | Description | Underlying Command |
 |------------|-------------|--------------------|
-| `OpenCode: Create Sandbox (Standalone CLI)` | Creates the `quickstart` sandbox using `sbx` CLI | `make create-sandbox` |
-| `OpenCode: Create Sandbox (Docker Desktop)` | Creates the `quickstart` sandbox using Docker Desktop | `make create-sandbox-desktop` |
-| `OpenCode: Run Agent (Standalone CLI)` | Launches OpenCode inside SBX and injects your USAi key | `make run-agent` |
-| `OpenCode: Run Agent (Docker Desktop)` | Launches OpenCode in SBX using Docker Desktop | `make run-agent-desktop` |
+| `OpenCode: Create Sandbox` | Creates the `quickstart` sandbox using `sbx` CLI | `make create-sandbox` |
+| `OpenCode: Run Agent` | Launches OpenCode inside SBX (secrets auto-injected) | `make run-agent` |
 | `OpenCode: Environment Diagnostics` | Performs health checks on your Docker & SBX setup | `make doctor` |
+
+> **Note:** The deprecated Docker Desktop tasks have been removed. Use the `sbx` CLI tasks above.
 
 ### 3. Step-by-Step Workflow inside Zed
 
 1. **Run Diagnostics:** Open the tasks palette and select `OpenCode: Environment Diagnostics (make doctor)`. It will open a panel in Zed and verify your Docker and setup states.
-2. **Create Sandbox:** Select `OpenCode: Create Sandbox (Standalone CLI)` (or the Docker Desktop equivalent). This prepares your microVM.
-3. **Launch OpenCode Agent:** Select `OpenCode: Run Agent (Standalone CLI)` (or Docker Desktop equivalent).
+2. **Create Sandbox:** Select `OpenCode: Create Sandbox`. This prepares your microVM.
+3. **Launch OpenCode Agent:** Select `OpenCode: Run Agent`.
 4. **Interact with the Agent:** The agent will boot inside a terminal panel in Zed. You can type prompts directly to the agent (e.g. *"Analyze the directory structure and check for AGENTS.md"*).
 5. **Interactive Approvals:** Because our `opencode.jsonc` is configured with `"edit": "ask"` and `"bash": "ask"` for safety, the agent will prompt you in the terminal for approval before making file changes or running mutating shell commands. Type `y` or `n` directly into the Zed terminal tab to respond.
 
@@ -72,16 +74,12 @@ You will see several tasks preconfigured for this workspace:
 If you prefer to run commands manually, you can open Zed's integrated terminal (`Ctrl + ~`) and use the following Makefile shortcuts:
 
 ```bash
-# Check if your host has USAI_API_KEY set and everything is healthy
+# Check if your environment is healthy
 make doctor
 
-# Option A: Standalone sbx CLI
+# Create sandbox and run agent
 make create-sandbox
 make run-agent
-
-# Option B: Docker Desktop built-in
-make create-sandbox-desktop
-make run-agent-desktop
 ```
 
 ---
@@ -117,41 +115,19 @@ tail -n +6 templates/AGENTS_SBX_ADDENDUM.md >> "$TARGET_REPO/AGENTS.md"
 Add these targets to your target repository's `Makefile` so that the Zed tasks function properly:
 
 ```makefile
-# Create SBX sandbox using standalone CLI (sbx)
+# Create SBX sandbox using sbx CLI
 create-sandbox:
-	@echo "Creating SBX sandbox using standalone CLI..."
+	@echo "Creating SBX sandbox..."
 	@if sbx ls | grep -q "my-sandbox"; then \
 		echo "Sandbox already exists. Skipping creation."; \
 	else \
 		sbx create --name my-sandbox opencode .; \
 	fi
 
-# Create SBX sandbox using Docker Desktop
-create-sandbox-desktop:
-	@echo "Creating SBX sandbox using Docker Desktop..."
-	@if docker sandbox ls 2>/dev/null | grep -q "my-sandbox"; then \
-		echo "Sandbox already exists. Skipping creation."; \
-	else \
-		docker sandbox create --name my-sandbox opencode .; \
-	fi
-
-# Run OpenCode agent in sandbox using standalone CLI (sbx)
-run-agent: _check-usai-key
-	@echo "Running OpenCode agent in SBX sandbox (standalone CLI)..."
-	@sbx exec -it -e USAI_API_KEY="$(USAI_API_KEY)" -w "$(shell pwd)" my-sandbox opencode
-
-# Run OpenCode agent in sandbox using Docker Desktop
-run-agent-desktop:
-	@echo "Running OpenCode agent in SBX sandbox (Docker Desktop)..."
-	@docker sandbox run my-sandbox
-
-_check-usai-key:
-	@if [ -z "$(USAI_API_KEY)" ]; then \
-		echo "ERROR: USAI_API_KEY environment variable is not set on host."; \
-		echo "Please set it before running the agent. Example:"; \
-		echo "  export USAI_API_KEY=\"your-key-here\""; \
-		exit 1; \
-	fi
+# Run OpenCode agent in sandbox using sbx CLI
+run-agent:
+	@echo "Running OpenCode agent in SBX sandbox..."
+	@sbx run my-sandbox
 ```
 
 *(Note: If your sandbox name is different than `my-sandbox`, make sure to update the name in the `Makefile` and `.zed/tasks.json` to match!)*
@@ -162,16 +138,15 @@ _check-usai-key:
 
 ### "Task Command Not Found: make"
 - Ensure that `make` is installed on your host machine (included by default on macOS, installable on Linux via `build-essential`, or Windows via Chocolatey/Scoop).
-- Alternatively, you can edit your `.zed/tasks.json` and replace the `make` commands with the direct `sbx` or `docker sandbox` command strings.
+- Alternatively, you can edit your `.zed/tasks.json` and replace the `make` commands with the direct `sbx` command strings.
 
-### "ERROR: USAI_API_KEY environment variable is not set on host"
-- Zed inherits environment variables from the parent shell that launched it.
-- If you set `USAI_API_KEY` in `.zshrc` or `.bashrc` after launching Zed, you **must completely restart Zed** (or relaunch it from your terminal using `zed .`) so it picks up the newly exported variable.
+### "ERROR: USAI_API_KEY not found"
+- Store your API key using: `sbx secret set -g USAI_API_KEY`
+- Secrets are stored in your system keychain and auto-injected into sandboxes.
 
 ### SSL/TLS Certificate Errors ("unable to get local issuer certificate")
 - If OpenCode launches but fails to connect with an `unable to get local issuer certificate` error, this is due to SSL/TLS interception/decryption on federal GFE (Government Furnished Equipment) networks.
-- **To fix this:** Add `export NODE_TLS_REJECT_UNAUTHORIZED="0"` to your host's shell profile (`~/.zshrc` or `~/.bashrc`) and restart Zed (and completely restart Docker Desktop if you are using it). This allows Node.js inside the isolated sandbox container to securely bypass GFE network decrypt validation.
-- Alternatively, you can run from your host terminal using: `NODE_TLS_REJECT_UNAUTHORIZED=0 make run-agent`
+- **To fix this:** Set the environment variable when running: `sbx exec -e NODE_TLS_REJECT_UNAUTHORIZED=0 SANDBOX_NAME opencode`
 
 ### Terminal Output is Frozen or Unresponsive
 - If a task runs and does not respond to keystrokes, close the terminal pane (`Cmd + W`) and trigger the task again via the tasks palette.

--- a/templates/AGENTS_SBX_ADDENDUM.md
+++ b/templates/AGENTS_SBX_ADDENDUM.md
@@ -7,12 +7,21 @@
 
 ## Docker Sandboxes Overview
 
-[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) runs AI coding agents in isolated microVM environments. There are two ways to use it:
+[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) runs AI coding agents in isolated microVM environments.
 
-| Method | Command Prefix | Best For |
-|--------|----------------|----------|
-| **Docker Desktop built-in** | `docker sandbox` | GFE Macs with managed Docker (4.58+) |
-| **Standalone sbx CLI** | `sbx` | Full features, secret proxy |
+> [!IMPORTANT]
+> The Docker Desktop-integrated `docker sandbox` commands are **deprecated**.
+> Use the standalone `sbx` CLI instead.
+> See [Docker's deprecation notice](https://docs.docker.com/reference/cli/docker/sandbox/).
+
+**Install sbx CLI:**
+```bash
+# macOS
+brew install docker/tap/sbx
+
+# Windows
+winget install Docker.sbx
+```
 
 ## SBX-Specific Rules (Non-Negotiable)
 
@@ -25,8 +34,7 @@ The agent MUST NEVER:
 - Include secrets in commit messages, comments, or documentation
 
 All secrets MUST be accessed via:
-- Docker Desktop: Environment variables set in shell config (read by Docker at startup)
-- sbx CLI: Secret management (`sbx secret set`) or runtime injection (`-e` flag)
+- sbx CLI: Secret management (`sbx secret set -g`) or runtime injection (`-e` flag)
 
 ### 2. Assume You Are Untrusted
 
@@ -63,11 +71,11 @@ Agents should:
 
 ### Credential Injection Methods
 
-| Service | Docker Desktop | sbx CLI |
-|---------|----------------|---------|
-| USAi | `USAI_API_KEY` in shell config | `-e USAI_API_KEY="$USAI_API_KEY"` |
-| GitHub | `GH_TOKEN` in shell config | `sbx secret set -g github` (recommended) |
-| GitLab | `GITLAB_TOKEN` in shell config | `-e GITLAB_TOKEN="..."` |
+| Service | sbx CLI (Secret Store) | sbx CLI (Direct) |
+|---------|------------------------|------------------|
+| USAi | `sbx secret set -g USAI_API_KEY` | `-e USAI_API_KEY="$USAI_API_KEY"` |
+| GitHub | `sbx secret set -g github` | `-e GH_TOKEN="$(gh auth token)"` |
+| GitLab | `sbx secret set -g GITLAB_TOKEN` | `-e GITLAB_TOKEN="..."` |
 
 See `docs/SBX_PATTERNS.md` for detailed credential injection patterns.
 
@@ -75,39 +83,33 @@ See `docs/SBX_PATTERNS.md` for detailed credential injection patterns.
 
 ## Execution Patterns
 
-### Docker Desktop
-
-```bash
-# Create sandbox
-docker sandbox create --name SANDBOX_NAME opencode .
-
-# Run (environment variables come from shell config)
-docker sandbox run SANDBOX_NAME
-```
-
-### Standalone sbx CLI
+### sbx CLI (Recommended)
 
 #### Basic: USAi Only
 
 ```bash
-sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) SANDBOX_NAME opencode
+# Store secret (one-time)
+sbx secret set -g USAI_API_KEY
+
+# Run (secrets auto-injected)
+sbx run SANDBOX_NAME
 ```
 
-#### With GitHub (via proxy - recommended)
+#### With GitHub (via secret store)
 
 ```bash
 # One-time setup
-gh auth token | sbx secret set -g github
+sbx secret set -g github
+# Enter: output of `gh auth token`
 
-# Run (GitHub auth handled by proxy)
-sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) SANDBOX_NAME opencode
+# Run (GitHub auth handled automatically)
+sbx run SANDBOX_NAME
 ```
 
 #### With GitLab (direct injection)
 
 ```bash
 sbx exec -it \
-  -e USAI_API_KEY="$USAI_API_KEY" \
   -e GITLAB_TOKEN="$(glab config get --host GITLAB_HOST token)" \
   -e GITLAB_HOST="GITLAB_HOST" \
   -w $(pwd) SANDBOX_NAME opencode

--- a/templates/BOOTSTRAP.md
+++ b/templates/BOOTSTRAP.md
@@ -4,9 +4,18 @@ Copy the template files from this quickstart into your target repository to enab
 
 ## Prerequisites
 
-**Choose one:**
-- **Docker Desktop 4.58+** — sandboxes built-in, no extra install
-- **Standalone sbx CLI** — install via `brew install docker/tap/sbx`
+> [!IMPORTANT]
+> The Docker Desktop-integrated `docker sandbox` commands are **deprecated**.
+> Use the standalone `sbx` CLI instead.
+
+**Install sbx CLI:**
+```bash
+# macOS
+brew install docker/tap/sbx
+
+# Windows
+winget install Docker.sbx
+```
 
 See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for details.
 
@@ -56,7 +65,39 @@ rm -rf /tmp/quickstart
 
 ## After Bootstrap
 
-### Option A: Using Docker Desktop (`docker sandbox`)
+### Using sbx CLI (Recommended)
+
+1. **Store your USAi API key securely**:
+   ```bash
+   sbx secret set -g USAI_API_KEY
+   # Enter your key when prompted
+   ```
+
+2. **Set up GitHub credentials** (if needed):
+   ```bash
+   sbx secret set -g github
+   # Enter output of: gh auth token
+   ```
+
+3. **Create a sandbox** for your project:
+   ```bash
+   cd "$TARGET_REPO"
+   sbx create --name my-project opencode .
+   ```
+
+4. **Run the agent** (secrets auto-injected from keychain):
+   ```bash
+   sbx run my-project
+   ```
+
+### Using Docker Desktop (`docker sandbox`) — DEPRECATED
+
+> [!WARNING]
+> The `docker sandbox` command is deprecated by Docker.
+> Migrate to the `sbx` CLI above.
+
+<details>
+<summary>Legacy instructions (click to expand)</summary>
 
 1. **Set your USAi API key** in your shell config (`~/.bashrc` or `~/.zshrc`):
    ```bash
@@ -77,28 +118,7 @@ rm -rf /tmp/quickstart
    docker sandbox run my-project
    ```
 
-### Option B: Using Standalone CLI (`sbx`)
-
-1. **Set your USAi API key** on the host:
-   ```bash
-   export USAI_API_KEY="your-key-here"
-   ```
-
-2. **Set up GitHub credentials** (if needed):
-   ```bash
-   gh auth token | sbx secret set -g github
-   ```
-
-3. **Create a sandbox** for your project:
-   ```bash
-   cd "$TARGET_REPO"
-   sbx create --name my-project opencode .
-   ```
-
-4. **Run the agent**:
-   ```bash
-   sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) my-project opencode
-   ```
+</details>
 
 ## For Playbook Users
 

--- a/templates/SBX_PATTERNS.md
+++ b/templates/SBX_PATTERNS.md
@@ -1,15 +1,23 @@
 # Docker Sandboxes Credential Injection Patterns
 
-Quick reference for injecting credentials into Docker Sandboxes (both Docker Desktop and standalone sbx CLI).
+Quick reference for injecting credentials into Docker Sandboxes using the standalone `sbx` CLI.
 
-## Two Ways to Use Docker Sandboxes
+> [!IMPORTANT]
+> The Docker Desktop-integrated `docker sandbox` commands are **deprecated**.
+> Use the standalone `sbx` CLI instead.
+> See [Docker's deprecation notice](https://docs.docker.com/reference/cli/docker/sandbox/).
 
-| Method | Install | Command Prefix | Credential Handling |
-|--------|---------|----------------|---------------------|
-| **Docker Desktop built-in** | None (Docker Desktop 4.58+) | `docker sandbox` | Shell config + restart Docker |
-| **Standalone sbx CLI** | Homebrew/Winget/apt | `sbx` | `-e` flags or `sbx secret set` |
+## Installing sbx CLI
 
-See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for installation.
+```bash
+# macOS
+brew install docker/tap/sbx
+
+# Windows
+winget install Docker.sbx
+```
+
+See [Docker Sandboxes documentation](https://docs.docker.com/ai/sandboxes/) for full details.
 
 ## Network Policy Configuration (Required)
 
@@ -39,36 +47,27 @@ sbx policy allow network "api.gsa.usai.gov"
 
 | Method | Security | Use Case | Supported Services |
 |--------|----------|----------|-------------------|
-| **Shell Config** (Docker Desktop) | Medium - Docker reads from shell | All services | Any environment variable |
-| **SBX Proxy** (sbx CLI) | High - agent never sees token | Standard API endpoints | `anthropic`, `aws`, `cursor`, `github`, `google`, `groq`, `mistral`, `nebius`, `openai`, `xai` |
-| **Direct Injection** (`-e`) | Medium - token in container env | Custom endpoints | Any service (USAi, GitLab, etc.) |
+| **SBX Secret Store** (recommended) | High - stored in keychain, auto-injected | Any credential | Built-in services + custom vars |
+| **Direct Injection** (`-e`) | Medium - token in container env | One-off testing | Any service |
 
-**Rule of thumb:**
-- Docker Desktop: Add to shell config, restart Docker
-- sbx CLI: Use proxy when available; use `-e` for custom endpoints
+**Rule of thumb:** Use `sbx secret set -g` for any credential you use regularly; use `-e` only for one-off testing.
 
 ---
 
 ## USAi
 
-USAi uses a custom endpoint (`api.gsa.usai.gov`) that the SBX proxy doesn't recognize.
-
-### Docker Desktop
+USAi uses a custom endpoint (`api.gsa.usai.gov`). Store the key using `sbx secret`:
 
 ```bash
-# Add to ~/.bashrc or ~/.zshrc
-export USAI_API_KEY="your-key-here"
+# Store securely in system keychain (recommended)
+sbx secret set -g USAI_API_KEY
+# Enter your key when prompted
 
-# Source and COMPLETELY restart Docker Desktop (Quit → Reopen)
-source ~/.zshrc
-# Then restart Docker Desktop from menu/taskbar
-
-# Run
-docker sandbox run SANDBOX_NAME
+# Run - secrets auto-injected
+sbx run SANDBOX_NAME
 ```
 
-### Standalone sbx CLI
-
+Or for one-off testing:
 ```bash
 # Set on host
 export USAI_API_KEY="your-key-here"
@@ -81,19 +80,7 @@ sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) SANDBOX_NAME opencode
 
 ## GitHub
 
-### Docker Desktop
-
-```bash
-# Add to ~/.bashrc or ~/.zshrc
-export GH_TOKEN="$(gh auth token)"
-# Or: export GITHUB_TOKEN="your-pat"
-
-# Source and restart Docker Desktop
-```
-
-### Standalone sbx CLI
-
-#### Method 1: SBX Proxy (Recommended)
+### Method 1: SBX Secret Store (Recommended)
 
 ```bash
 # One-time setup - pipe from gh cli (avoids shell history)
@@ -129,19 +116,21 @@ sbx exec -e GH_TOKEN="$(gh auth token)" SANDBOX_NAME sh -c 'curl -s -H "Authoriz
 
 ## GitLab (Direct Injection Required)
 
-GitLab is NOT a built-in service for either method.
+GitLab credentials are not auto-injected. Use `sbx secret` or direct injection.
 
-### Docker Desktop
+### Store in sbx secret (recommended)
 
 ```bash
-# Add to ~/.bashrc or ~/.zshrc
-export GITLAB_TOKEN="your-gitlab-token"
-export GITLAB_HOST="workshop.cloud.gov"  # for self-hosted
+# Store GitLab token
+sbx secret set -g GITLAB_TOKEN
+# Enter your token when prompted
 
-# Source and restart Docker Desktop
+# For self-hosted, also store the host
+sbx secret set -g GITLAB_HOST
+# Enter: workshop.cloud.gov (or your host)
 ```
 
-### Standalone sbx CLI
+### Direct injection (one-off)
 
 #### gitlab.com
 
@@ -173,55 +162,40 @@ sbx exec -e GITLAB_TOKEN="$GITLAB_TOKEN" -e GITLAB_HOST="workshop.cloud.gov" SAN
 
 ## Combined: All Services
 
-### Docker Desktop
-
-Add all variables to shell config:
-```bash
-# ~/.bashrc or ~/.zshrc
-export USAI_API_KEY="your-usai-key"
-export GH_TOKEN="$(gh auth token)"
-export GITLAB_TOKEN="your-gitlab-token"
-export GITLAB_HOST="workshop.cloud.gov"
-```
-
-Then restart Docker Desktop and run: `docker sandbox run SANDBOX_NAME`
-
-### Standalone sbx CLI
+### sbx CLI (Recommended)
 
 For agents needing USAi + GitHub + GitLab:
 
 ```bash
-# Assumes: gh logged in, glab logged in, USAI_API_KEY set, github secret in SBX
+# Assumes: gh logged in, glab logged in, secrets stored in sbx
 
 sbx exec -it \
-  -e USAI_API_KEY="$USAI_API_KEY" \
   -e GITLAB_TOKEN="$(glab config get --host workshop.cloud.gov token)" \
   -e GITLAB_HOST="workshop.cloud.gov" \
   -w $(pwd) SANDBOX_NAME opencode
 ```
 
-> **Note:** If you've set GitHub via `sbx secret set -g github`, omit `-e GH_TOKEN` - the proxy handles it.
+> **Note:** If you've set secrets via `sbx secret set -g`, they are auto-injected.
 
 ---
 
 ## Quick Reference
 
-| Provider | Docker Desktop | sbx CLI (Proxy) | sbx CLI (Direct) |
-|----------|----------------|-----------------|------------------|
-| USAi | `USAI_API_KEY` in shell config | N/A | `-e USAI_API_KEY="$USAI_API_KEY"` |
-| GitHub | `GH_TOKEN` in shell config | `sbx secret set -g github` | `-e GH_TOKEN="$(gh auth token)"` |
-| GitLab.com | `GITLAB_TOKEN` in shell config | N/A | `-e GITLAB_TOKEN="..."` |
-| GitLab (self-hosted) | `GITLAB_TOKEN` + `GITLAB_HOST` | N/A | `-e GITLAB_TOKEN="..." -e GITLAB_HOST="..."` |
+| Provider | sbx CLI (Secret Store) | sbx CLI (Direct) |
+|----------|------------------------|------------------|
+| USAi | `sbx secret set -g USAI_API_KEY` | `-e USAI_API_KEY="$USAI_API_KEY"` |
+| GitHub | `sbx secret set -g github` | `-e GH_TOKEN="$(gh auth token)"` |
+| GitLab.com | `sbx secret set -g GITLAB_TOKEN` | `-e GITLAB_TOKEN="..."` |
+| GitLab (self-hosted) | + `sbx secret set -g GITLAB_HOST` | + `-e GITLAB_HOST="..."` |
 
 ---
 
 ## Security Notes
 
-1. **Docker Desktop:** Restart required after changing shell config
-2. **Prefer SBX proxy when available** (sbx CLI) - more secure, agent never sees token
-3. **Pipe tokens from CLI tools** - avoids shell history (`gh auth token | sbx secret set -g github`)
-4. **Scope tokens minimally** - only grant permissions the agent needs
-5. **Tokens exist only in memory** - never written to disk inside container
-6. **Review agent output** - before sharing logs, ensure no tokens leaked
+1. **Prefer sbx secret store** - more secure, stored in system keychain
+2. **Pipe tokens from CLI tools** - avoids shell history (`gh auth token | sbx secret set -g github`)
+3. **Scope tokens minimally** - only grant permissions the agent needs
+4. **Tokens exist only in memory** - never written to disk inside container
+5. **Review agent output** - before sharing logs, ensure no tokens leaked
 
 For full security analysis, see [KNOWN_FAILURE_MODES.md Section 15](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/KNOWN_FAILURE_MODES.md#15-direct-credential-injection-for-git-providers-security-consideration).


### PR DESCRIPTION
## Summary

Docker has officially deprecated the Docker Desktop-integrated `docker sandbox` commands in favor of the standalone `sbx` CLI.

**Source:** [Docker deprecation notice](https://docs.docker.com/reference/cli/docker/sandbox/)

## Changes

### Critical (User-facing docs)
| File | Change |
|------|--------|
| `QUICKSTART_DOCKER_DESKTOP.md` | Add deprecation banner and migration guide |
| `SBX_QUICKSTART.md` | Make sbx CLI primary, add migration section |
| `README.md` | Add deprecation warning, update troubleshooting |

### Templates
| File | Change |
|------|--------|
| `BOOTSTRAP.md` | Update to sbx CLI only workflow |
| `SBX_PATTERNS.md` | Remove Docker Desktop sections, streamline for sbx |
| `AGENTS_SBX_ADDENDUM.md` | Update credential methods for sbx |

### Internal
| File | Change |
|------|--------|
| `Makefile` | Add deprecation warnings to docker sandbox targets |
| `ZED_SETUP.md` | Update for sbx CLI |
| `bug_report.yml` | Update dropdown to mark deprecated option |

## Security Review

All changes pass security review:
- [x] No credential exposure in examples
- [x] sbx secret store documented as secure option
- [x] Migration improves security posture (keychain vs shell config)
- [x] Deprecated code paths properly marked

## Migration Guide

| Deprecated Command | New Command |
|-------------------|-------------|
| `docker sandbox create` | `sbx create` |
| `docker sandbox run` | `sbx run` |
| `docker sandbox exec` | `sbx exec` |
| `docker sandbox ls` | `sbx ls` |
| `docker sandbox rm` | `sbx rm` |
| `docker sandbox stop` | `sbx stop` |

## Testing

- [x] All pre-commit hooks pass
- [x] Documentation renders correctly
- [x] YAML validation passes

Closes #52

/cc @GSA-TTS/agentic-coding