### PR TITLE
fix: use `sbx secret set-custom` for USAI_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ sbx policy set-default balanced
 # 2. Allow USAi endpoint
 sbx policy allow network -g "api.gsa.usai.gov"
 
-# 3. Store your USAi API key securely
-sbx secret set -g anthropic
-# When prompted, enter your USAi API key
+# 3. Store your USAi API key securely (USAi is a custom endpoint, not built-in)
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
 
 # 4. Store GitHub token (for code access)
 sbx secret set -g github
@@ -42,6 +41,10 @@ sbx secret set -g github
 cd /path/to/your/project
 sbx run opencode .
 ```
+
+> [!NOTE]
+> USAi is not a built-in sbx service, so we use `sbx secret set-custom` instead of `sbx secret set -g`.
+> If you change the secret, you must **delete and recreate** the sandbox for it to take effect.
 
 That's it. You're now running an AI coding agent in an isolated container with USAi access.
 

--- a/docs/QUICKSTART_DOCKER_DESKTOP.md
+++ b/docs/QUICKSTART_DOCKER_DESKTOP.md
@@ -117,17 +117,18 @@ source ~/.zshrc  # or ~/.bashrc
 Even when using Docker Desktop UI, you can use `sbx secret` for better security:
 
 ```bash
-# Store USAi key securely in keychain
-sbx secret set -g anthropic
-# Enter your key when prompted
+# Store USAi key securely (USAi is a custom endpoint)
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
 
-# Store GitHub token
-sbx secret set -g github
-# Enter token when prompted
+# Store GitHub token (built-in service)
+gh auth token | sbx secret set -g github
 
 # Verify
 sbx secret ls
 ```
+
+> [!NOTE]
+> After setting secrets, you must **delete and recreate** the sandbox for changes to take effect.
 
 **Why `sbx secret` is better:**
 

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -80,14 +80,22 @@ sbx policy ls
 
 Docker Sandboxes uses a secure secret store to inject credentials. Your API keys are stored in the **system keychain** and **auto-injected into sandboxes**.
 
-### Store USAi API Key (Custom Variable - NEW!)
+### Store USAi API Key (Custom Endpoint)
+
+USAi (`api.gsa.usai.gov`) is **not a built-in sbx service**, so you must use `sbx secret set-custom`:
 
 ```bash
-sbx secret set -g USAI_API_KEY
-# Enter your key when prompted
+# Store USAi API key for the custom endpoint
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
 ```
 
+> [!IMPORTANT]
+> After setting or changing a custom secret, you must **delete and recreate** the sandbox for it to take effect.
+> The `set-custom` command is experimental and may change in future sbx versions.
+
 ### Store Using Built-in Service Names
+
+For built-in services (anthropic, github, openai, etc.), use the simpler syntax:
 
 ```bash
 # For standard Anthropic endpoint (if not using USAi)
@@ -146,22 +154,18 @@ SCOPE      SERVICE        SECRET
 | `groq` | `GROQ_API_KEY` | Groq inference |
 | `mistral` | `MISTRAL_API_KEY` | Mistral models |
 
-**Custom variables (NEW!)** — any variable name works:
+### Custom Endpoints (like USAi)
 
-| Variable | Use Case |
-|----------|----------|
-| `USAI_API_KEY` | USAi API endpoint |
-| `GITLAB_TOKEN` | GitLab access |
-| `MY_CUSTOM_SECRET` | Any custom credential |
+For custom API endpoints that aren't built-in services, use `sbx secret set-custom`:
 
-> **Note:** Custom variable support was added based on community feedback. See [docker/sbx-releases#7](https://github.com/docker/sbx-releases/issues/7) for details. This feature may still be marked as experimental.
+| Endpoint | Command |
+|----------|---------|
+| USAi (`api.gsa.usai.gov`) | `sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"` |
+| GitLab (self-hosted) | `sbx secret set-custom -g --host gitlab.example.com --env GITLAB_TOKEN --value "$GITLAB_TOKEN"` |
 
-```bash
-# Store any custom variable
-sbx secret set -g USAI_API_KEY
-sbx secret set -g GITLAB_TOKEN
-sbx secret set -g MY_CUSTOM_SECRET
-```
+> [!WARNING]
+> The `sbx secret set -g VARNAME` syntax does **not** work for custom variables like `USAI_API_KEY`.
+> You must use `sbx secret set-custom` with the `--host` parameter.
 
 ### Managing Secrets
 
@@ -174,10 +178,10 @@ sbx secret ls -g
 
 # Remove a secret
 sbx secret rm -g anthropic
-sbx secret rm -g USAI_API_KEY
 
-# Update a secret (just set it again)
-sbx secret set -g anthropic
+# Update a secret (set it again, then recreate sandbox)
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$NEW_KEY"
+sbx rm my-sandbox && sbx create --name my-sandbox opencode .
 ```
 
 ---

--- a/docs/SBX_QUICKSTART.md
+++ b/docs/SBX_QUICKSTART.md
@@ -142,9 +142,8 @@ The "Balanced" policy already includes common package managers (npm, pypi) and c
 ### Using Standalone CLI (`sbx`) — Recommended
 
 ```bash
-# 1. Store your API key securely in system keychain (NEW!)
-sbx secret set -g USAI_API_KEY
-# Enter your key when prompted - stored in system keychain, auto-injected
+# 1. Store your USAi API key securely (USAi is a custom endpoint)
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
 
 # 2. Configure network policy (first run will prompt - choose "Balanced")
 #    Then add USAi to the allowlist:
@@ -159,7 +158,9 @@ sbx run usai-test
 
 That's it. You're now running an AI agent in an isolated container with USAi access.
 
-> **New in sbx CLI:** Custom environment variables like `USAI_API_KEY` can now be stored with `sbx secret set -g VARNAME`. The secret is stored in your system keychain and auto-injected into sandboxes — no more manual `-e` flags!
+> [!IMPORTANT]
+> USAi (`api.gsa.usai.gov`) is **not a built-in sbx service**. You must use `sbx secret set-custom` with the `--host` parameter.
+> After changing secrets, **delete and recreate** the sandbox for changes to take effect.
 
 ### Using Docker Desktop (`docker sandbox`) — DEPRECATED
 
@@ -420,11 +421,18 @@ docker sandbox run my-sandbox
 
 ```bash
 # One-time setup: store your secrets in system keychain
-sbx secret set -g USAI_API_KEY    # Enter when prompted
-sbx secret set -g GITLAB_TOKEN    # If using GitLab
-gh auth token | sbx secret set -g github  # Pipe from gh cli
 
-# Then just run (secrets auto-injected!)
+# USAi requires set-custom (not a built-in service)
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
+
+# GitLab also requires set-custom for self-hosted instances
+sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN --value "$GITLAB_TOKEN"
+
+# GitHub uses built-in service
+gh auth token | sbx secret set -g github
+
+# Then recreate sandbox and run (secrets auto-injected!)
+sbx rm my-sandbox 2>/dev/null; sbx create --name my-sandbox opencode .
 sbx run my-sandbox
 ```
 
@@ -442,17 +450,16 @@ sbx exec -it \
   -w $(pwd) my-sandbox opencode
 ```
 
-> **💡 Zed Editor Users:** If you are using the Zed editor, you can automate this entire walkthrough—including sandbox creation and agent launching—using the built-in tasks defined in `.zed/tasks.json`. Check out the **[Zed Editor Setup Guide](ZED_SETUP.md)** to get started.
+> **Zed Editor Users:** If you are using the Zed editor, you can automate this entire walkthrough—including sandbox creation and agent launching—using the built-in tasks defined in `.zed/tasks.json`. Check out the **[Zed Editor Setup Guide](ZED_SETUP.md)** to get started.
 
-### Custom Variables in sbx secret (NEW!)
+### Custom Endpoints (set-custom)
 
-The `sbx secret set -g VARNAME` command now supports **any variable name**, not just built-in services. This means you can store USAi API keys, GitLab tokens, or any custom secret in your system keychain:
+For custom API endpoints (like USAi at `api.gsa.usai.gov`), you must use `sbx secret set-custom` instead of `sbx secret set -g`:
 
 ```bash
-# Store custom variables
-sbx secret set -g USAI_API_KEY
-sbx secret set -g GITLAB_TOKEN
-sbx secret set -g MY_CUSTOM_SECRET
+# Store custom endpoint secrets
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
+sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN --value "$GITLAB_TOKEN"
 
 # List all stored secrets (values masked)
 sbx secret ls
@@ -462,9 +469,13 @@ sbx secret ls
 # (global)   GITLAB_TOKEN     glpat-******...******xYz1
 ```
 
-This is the **recommended approach** for any credential you use regularly — it's more secure than environment variables and persists across terminal sessions.
+> [!WARNING]
+> The `sbx secret set -g VARNAME` syntax does **not** work for custom variables.
+> You must use `sbx secret set-custom` with the `--host` parameter for non-built-in services.
 
-> **Reference:** This feature was added in response to community feedback. See [docker/sbx-releases#7](https://github.com/docker/sbx-releases/issues/7) for the original feature request and implementation details. Note: This feature may still be marked as experimental in `sbx secret --help`.
+> [!NOTE]
+> After setting or changing a custom secret, you must **delete and recreate** the sandbox for changes to take effect.
+> The `set-custom` command is experimental and may change. See [Docker docs on credentials](https://docs.docker.com/ai/sandboxes/security/credentials/).
 
 ---
 
@@ -519,20 +530,21 @@ sbx rm SANDBOX_NAME
 ```bash
 # Set a secret globally (prompts for value)
 # Built-in services: anthropic|aws|cursor|github|google|groq|mistral|nebius|openai|xai
-# Custom variables: any VARNAME (NEW!)
-sbx secret set -g SERVICE_OR_VARNAME
+sbx secret set -g SERVICE_NAME
 
-# Examples:
-sbx secret set -g USAI_API_KEY        # Custom variable for USAi
+# Examples of built-in services:
 sbx secret set -g github              # Built-in service
-sbx secret set -g GITLAB_TOKEN        # Custom variable for GitLab
+sbx secret set -g anthropic           # Built-in service
+
+# For custom endpoints (like USAi), use set-custom:
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
+sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN --value "$GITLAB_TOKEN"
 
 # Set a secret for a specific sandbox only
-sbx secret set SANDBOX_NAME SERVICE_OR_VARNAME
+sbx secret set SANDBOX_NAME SERVICE_NAME
 
 # Pipe from CLI tools (recommended - avoids shell history)
 gh auth token | sbx secret set -g github
-echo "$USAI_KEY" | sbx secret set -g USAI_API_KEY
 
 # List configured secrets (values are masked)
 sbx secret ls
@@ -543,8 +555,12 @@ sbx secret ls
 # (global)   openai         api-ke******...******lieO
 
 # Remove a secret
-sbx secret rm SERVICE_OR_VARNAME
+sbx secret rm SERVICE_NAME
 ```
+
+> [!IMPORTANT]
+> `sbx secret set -g VARNAME` does **not** work for custom variables like `USAI_API_KEY`.
+> Use `sbx secret set-custom -g --host HOSTNAME --env VARNAME --value VALUE` for custom endpoints.
 
 > **How it works:** Secrets are stored in your system keychain (macOS Keychain, Windows Credential Manager, or Linux secret service). When you run a sandbox, sbx auto-injects stored secrets as environment variables. The secret never appears in your shell history or process list.
 
@@ -822,13 +838,20 @@ sbx create opencode .
 ### One-Time Setup (Recommended)
 
 ```bash
-# Store all your secrets in system keychain
-sbx secret set -g USAI_API_KEY              # USAi API key
-gh auth token | sbx secret set -g github    # GitHub token
-sbx secret set -g GITLAB_TOKEN              # GitLab token (if needed)
+# Store USAi API key (custom endpoint - requires set-custom)
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
+
+# Store GitHub token (built-in service)
+gh auth token | sbx secret set -g github
+
+# Store GitLab token (custom endpoint - if needed)
+sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN --value "$GITLAB_TOKEN"
 
 # Verify secrets are stored
 sbx secret ls
+
+# Recreate sandbox to pick up new secrets
+sbx rm my-sandbox 2>/dev/null; sbx create --name my-sandbox opencode .
 ```
 
 ### Running Sandboxes

--- a/docs/ZED_SETUP.md
+++ b/docs/ZED_SETUP.md
@@ -28,11 +28,11 @@ Using [Zed](https://zed.dev) with Docker Sandboxes and USAi provides a robust, f
    # Windows
    winget install Docker.sbx
    ```
-3. **USAi API Key** stored securely:
+3. **USAi API Key** stored securely (USAi is a custom endpoint):
    ```bash
-   sbx secret set -g USAI_API_KEY
-   # Enter your key when prompted
+   sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
    ```
+   > After setting the secret, recreate any existing sandbox: `sbx rm quickstart; sbx create --name quickstart opencode .`
 
 ---
 
@@ -141,8 +141,14 @@ run-agent:
 - Alternatively, you can edit your `.zed/tasks.json` and replace the `make` commands with the direct `sbx` command strings.
 
 ### "ERROR: USAI_API_KEY not found"
-- Store your API key using: `sbx secret set -g USAI_API_KEY`
-- Secrets are stored in your system keychain and auto-injected into sandboxes.
+- USAi is a custom endpoint, so you must use `sbx secret set-custom`:
+  ```bash
+  sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
+  ```
+- After setting the secret, **delete and recreate** the sandbox:
+  ```bash
+  sbx rm quickstart; sbx create --name quickstart opencode .
+  ```
 
 ### SSL/TLS Certificate Errors ("unable to get local issuer certificate")
 - If OpenCode launches but fails to connect with an `unable to get local issuer certificate` error, this is due to SSL/TLS interception/decryption on federal GFE (Government Furnished Equipment) networks.

--- a/templates/AGENTS_SBX_ADDENDUM.md
+++ b/templates/AGENTS_SBX_ADDENDUM.md
@@ -71,11 +71,15 @@ Agents should:
 
 ### Credential Injection Methods
 
-| Service | sbx CLI (Secret Store) | sbx CLI (Direct) |
-|---------|------------------------|------------------|
-| USAi | `sbx secret set -g USAI_API_KEY` | `-e USAI_API_KEY="$USAI_API_KEY"` |
-| GitHub | `sbx secret set -g github` | `-e GH_TOKEN="$(gh auth token)"` |
-| GitLab | `sbx secret set -g GITLAB_TOKEN` | `-e GITLAB_TOKEN="..."` |
+| Service | Command | Notes |
+|---------|---------|-------|
+| USAi | `sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"` | Custom endpoint |
+| GitHub | `gh auth token \| sbx secret set -g github` | Built-in service |
+| GitLab | `sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN --value "$GITLAB_TOKEN"` | Custom endpoint |
+
+> [!IMPORTANT]
+> USAi and GitLab are **not built-in sbx services**. You must use `sbx secret set-custom` with the `--host` parameter.
+> After changing secrets, **delete and recreate** the sandbox for changes to take effect.
 
 See `docs/SBX_PATTERNS.md` for detailed credential injection patterns.
 
@@ -88,31 +92,35 @@ See `docs/SBX_PATTERNS.md` for detailed credential injection patterns.
 #### Basic: USAi Only
 
 ```bash
-# Store secret (one-time)
-sbx secret set -g USAI_API_KEY
+# Store secret (one-time) - USAi requires set-custom
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
+
+# Create/recreate sandbox
+sbx rm SANDBOX_NAME 2>/dev/null; sbx create --name SANDBOX_NAME opencode .
 
 # Run (secrets auto-injected)
 sbx run SANDBOX_NAME
 ```
 
-#### With GitHub (via secret store)
+#### With GitHub (built-in service)
 
 ```bash
 # One-time setup
-sbx secret set -g github
-# Enter: output of `gh auth token`
+gh auth token | sbx secret set -g github
 
 # Run (GitHub auth handled automatically)
 sbx run SANDBOX_NAME
 ```
 
-#### With GitLab (direct injection)
+#### With GitLab (custom endpoint)
 
 ```bash
-sbx exec -it \
-  -e GITLAB_TOKEN="$(glab config get --host GITLAB_HOST token)" \
-  -e GITLAB_HOST="GITLAB_HOST" \
-  -w $(pwd) SANDBOX_NAME opencode
+# Store secret
+sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN --value "$GITLAB_TOKEN"
+
+# Recreate sandbox and run
+sbx rm SANDBOX_NAME 2>/dev/null; sbx create --name SANDBOX_NAME opencode .
+sbx run SANDBOX_NAME
 ```
 
 ---

--- a/templates/BOOTSTRAP.md
+++ b/templates/BOOTSTRAP.md
@@ -67,16 +67,14 @@ rm -rf /tmp/quickstart
 
 ### Using sbx CLI (Recommended)
 
-1. **Store your USAi API key securely**:
+1. **Store your USAi API key securely** (USAi is a custom endpoint):
    ```bash
-   sbx secret set -g USAI_API_KEY
-   # Enter your key when prompted
+   sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
    ```
 
-2. **Set up GitHub credentials** (if needed):
+2. **Set up GitHub credentials** (built-in service):
    ```bash
-   sbx secret set -g github
-   # Enter output of: gh auth token
+   gh auth token | sbx secret set -g github
    ```
 
 3. **Create a sandbox** for your project:
@@ -89,6 +87,9 @@ rm -rf /tmp/quickstart
    ```bash
    sbx run my-project
    ```
+
+> [!NOTE]
+> After changing secrets, you must **delete and recreate** the sandbox for changes to take effect.
 
 ### Using Docker Desktop (`docker sandbox`) — DEPRECATED
 

--- a/templates/SBX_PATTERNS.md
+++ b/templates/SBX_PATTERNS.md
@@ -47,25 +47,31 @@ sbx policy allow network "api.gsa.usai.gov"
 
 | Method | Security | Use Case | Supported Services |
 |--------|----------|----------|-------------------|
-| **SBX Secret Store** (recommended) | High - stored in keychain, auto-injected | Any credential | Built-in services + custom vars |
+| **SBX Secret Store** (recommended) | High - stored in keychain, auto-injected | Any credential | Built-in services |
+| **SBX Secret Set-Custom** | High - stored in keychain | Custom endpoints (USAi, GitLab) | Any custom host |
 | **Direct Injection** (`-e`) | Medium - token in container env | One-off testing | Any service |
 
-**Rule of thumb:** Use `sbx secret set -g` for any credential you use regularly; use `-e` only for one-off testing.
+**Rule of thumb:** Use `sbx secret set -g` for built-in services (github, anthropic, etc.); use `sbx secret set-custom` for custom endpoints like USAi.
 
 ---
 
 ## USAi
 
-USAi uses a custom endpoint (`api.gsa.usai.gov`). Store the key using `sbx secret`:
+USAi (`api.gsa.usai.gov`) is **not a built-in sbx service**. You must use `sbx secret set-custom`:
 
 ```bash
-# Store securely in system keychain (recommended)
-sbx secret set -g USAI_API_KEY
-# Enter your key when prompted
+# Store securely in system keychain (required for USAi)
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
+
+# Recreate sandbox to pick up new secret
+sbx rm SANDBOX_NAME 2>/dev/null; sbx create --name SANDBOX_NAME opencode .
 
 # Run - secrets auto-injected
 sbx run SANDBOX_NAME
 ```
+
+> [!IMPORTANT]
+> After setting or changing a custom secret, you must **delete and recreate** the sandbox.
 
 Or for one-off testing:
 ```bash
@@ -82,6 +88,8 @@ sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) SANDBOX_NAME opencode
 
 ### Method 1: SBX Secret Store (Recommended)
 
+GitHub is a **built-in service**, so use the simpler syntax:
+
 ```bash
 # One-time setup - pipe from gh cli (avoids shell history)
 gh auth token | sbx secret set -g github
@@ -90,7 +98,7 @@ gh auth token | sbx secret set -g github
 sbx secret ls
 
 # Run - proxy handles auth automatically
-sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) SANDBOX_NAME opencode
+sbx run SANDBOX_NAME
 ```
 
 #### Method 2: Direct Injection
@@ -114,20 +122,18 @@ sbx exec -e GH_TOKEN="$(gh auth token)" SANDBOX_NAME sh -c 'curl -s -H "Authoriz
 
 ---
 
-## GitLab (Direct Injection Required)
+## GitLab (Custom Endpoint)
 
-GitLab credentials are not auto-injected. Use `sbx secret` or direct injection.
+GitLab (especially self-hosted instances) requires `sbx secret set-custom`:
 
 ### Store in sbx secret (recommended)
 
 ```bash
-# Store GitLab token
-sbx secret set -g GITLAB_TOKEN
-# Enter your token when prompted
+# Store GitLab token for self-hosted instance
+sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN --value "$GITLAB_TOKEN"
 
-# For self-hosted, also store the host
-sbx secret set -g GITLAB_HOST
-# Enter: workshop.cloud.gov (or your host)
+# Recreate sandbox to pick up new secret
+sbx rm SANDBOX_NAME 2>/dev/null; sbx create --name SANDBOX_NAME opencode .
 ```
 
 ### Direct injection (one-off)
@@ -136,7 +142,6 @@ sbx secret set -g GITLAB_HOST
 
 ```bash
 sbx exec -it \
-  -e USAI_API_KEY="$USAI_API_KEY" \
   -e GITLAB_TOKEN="your-gitlab-token" \
   -w $(pwd) SANDBOX_NAME opencode
 ```
@@ -145,7 +150,6 @@ sbx exec -it \
 
 ```bash
 sbx exec -it \
-  -e USAI_API_KEY="$USAI_API_KEY" \
   -e GITLAB_TOKEN="$(glab config get --host workshop.cloud.gov token)" \
   -e GITLAB_HOST="workshop.cloud.gov" \
   -w $(pwd) SANDBOX_NAME opencode
@@ -164,38 +168,43 @@ sbx exec -e GITLAB_TOKEN="$GITLAB_TOKEN" -e GITLAB_HOST="workshop.cloud.gov" SAN
 
 ### sbx CLI (Recommended)
 
-For agents needing USAi + GitHub + GitLab:
+For agents needing USAi + GitHub + GitLab, first set up all secrets:
 
 ```bash
-# Assumes: gh logged in, glab logged in, secrets stored in sbx
+# One-time setup
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
+sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN --value "$GITLAB_TOKEN"
+gh auth token | sbx secret set -g github
 
-sbx exec -it \
-  -e GITLAB_TOKEN="$(glab config get --host workshop.cloud.gov token)" \
-  -e GITLAB_HOST="workshop.cloud.gov" \
-  -w $(pwd) SANDBOX_NAME opencode
+# Recreate sandbox
+sbx rm SANDBOX_NAME 2>/dev/null; sbx create --name SANDBOX_NAME opencode .
+
+# Run - all secrets auto-injected
+sbx run SANDBOX_NAME
 ```
-
-> **Note:** If you've set secrets via `sbx secret set -g`, they are auto-injected.
 
 ---
 
 ## Quick Reference
 
-| Provider | sbx CLI (Secret Store) | sbx CLI (Direct) |
-|----------|------------------------|------------------|
-| USAi | `sbx secret set -g USAI_API_KEY` | `-e USAI_API_KEY="$USAI_API_KEY"` |
-| GitHub | `sbx secret set -g github` | `-e GH_TOKEN="$(gh auth token)"` |
-| GitLab.com | `sbx secret set -g GITLAB_TOKEN` | `-e GITLAB_TOKEN="..."` |
-| GitLab (self-hosted) | + `sbx secret set -g GITLAB_HOST` | + `-e GITLAB_HOST="..."` |
+| Provider | Command | Notes |
+|----------|---------|-------|
+| USAi | `sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"` | Custom endpoint |
+| GitHub | `gh auth token \| sbx secret set -g github` | Built-in service |
+| GitLab (self-hosted) | `sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN --value "$GITLAB_TOKEN"` | Custom endpoint |
+
+> [!IMPORTANT]
+> After setting custom secrets, **delete and recreate** the sandbox for changes to take effect.
 
 ---
 
 ## Security Notes
 
-1. **Prefer sbx secret store** - more secure, stored in system keychain
-2. **Pipe tokens from CLI tools** - avoids shell history (`gh auth token | sbx secret set -g github`)
-3. **Scope tokens minimally** - only grant permissions the agent needs
-4. **Tokens exist only in memory** - never written to disk inside container
-5. **Review agent output** - before sharing logs, ensure no tokens leaked
+1. **Use `sbx secret set-custom` for custom endpoints** like USAi (not `sbx secret set -g VARNAME`)
+2. **Use `sbx secret set -g SERVICE` for built-in services** like github, anthropic
+3. **Pipe tokens from CLI tools** - avoids shell history (`gh auth token | sbx secret set -g github`)
+4. **Scope tokens minimally** - only grant permissions the agent needs
+5. **Tokens exist only in memory** - never written to disk inside container
+6. **Review agent output** - before sharing logs, ensure no tokens leaked
 
 For full security analysis, see [KNOWN_FAILURE_MODES.md Section 15](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/KNOWN_FAILURE_MODES.md#15-direct-credential-injection-for-git-providers-security-consideration).


### PR DESCRIPTION
## Summary

Fixes critical documentation error where all quickstart docs incorrectly instructed users to use `sbx secret set -g USAI_API_KEY`.

**Problem:** USAi (api.gsa.usai.gov) is NOT a built-in sbx service, so `sbx secret set -g USAI_API_KEY` silently fails to inject the secret.

**Solution:** Use the `set-custom` command for custom endpoints:

```bash
sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
```

## Key Changes

1. **Corrected all USAi secret commands** across 8 documentation files
2. **Added notes about sandbox recreation** - custom secrets require deleting and recreating the sandbox
3. **Clarified built-in vs custom services**:
   - Built-in (`sbx secret set -g SERVICE`): anthropic, aws, github, google, groq, mistral, nebius, openai, xai
   - Custom (`sbx secret set-custom`): USAi, self-hosted GitLab

## Files Changed

- `README.md`
- `docs/QUICKSTART_SBX.md`
- `docs/SBX_QUICKSTART.md`
- `docs/QUICKSTART_DOCKER_DESKTOP.md`
- `docs/ZED_SETUP.md`
- `templates/BOOTSTRAP.md`
- `templates/SBX_PATTERNS.md`
- `templates/AGENTS_SBX_ADDENDUM.md`

## Testing

Verified correct syntax against `sbx secret --help` output:

```
sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
```

Closes #56

Co-authored-by: OpenCode Agent <agent@gsa.gov>