### PR TITLE
docs: clarify sbx CLI is standalone, Docker Desktop not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,31 @@ This repository is part of a three-repo ecosystem:
 
 ---
 
-## 5-Minute Quickstart (sbx CLI) — Recommended
+## 5-Minute Quickstart
 
-Already have Docker Desktop 4.41+? Run these commands:
+### Step 1: Install sbx CLI
+
+The `sbx` CLI is a standalone tool — Docker Desktop is **not required**.
+
+```bash
+# macOS
+brew install docker/tap/sbx && sbx login
+
+# Windows
+winget install -h Docker.sbx && sbx login
+
+# Linux (Ubuntu)
+curl -fsSL https://get.docker.com | sudo REPO_ONLY=1 sh
+sudo apt-get install docker-sbx
+sudo usermod -aG kvm $USER && newgrp kvm
+sbx login
+```
+
+> [!NOTE]
+> `sbx login` requires a Docker account. Docker Desktop is not required, but if you have it,
+> your Docker subscription covers sbx licensing.
+
+### Step 2: Configure and Run
 
 ```bash
 # 1. Set network policy (first-time only)
@@ -34,8 +56,7 @@ sbx policy allow network -g "api.gsa.usai.gov"
 sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
 
 # 4. Store GitHub token (for code access)
-sbx secret set -g github
-# When prompted, paste output of: gh auth token
+gh auth token | sbx secret set -g github
 
 # 5. Start a sandbox in your project
 cd /path/to/your/project
@@ -71,19 +92,9 @@ AI coding agents can read files, write code, and execute commands. Running them 
 
 | Requirement | How to Check | Notes |
 |-------------|--------------|-------|
-| Docker Desktop 4.41+ | `docker --version` | Includes sbx CLI |
+| sbx CLI | `sbx version` | Standalone tool, Docker Desktop not required |
 | USAi API key | From your GSA account | Stored via `sbx secret` |
 | GitHub token | `gh auth status` | Optional, for code access |
-
-**Installing sbx CLI (if not bundled):**
-
-```bash
-# macOS
-brew install docker/tap/sbx && sbx login
-
-# Windows
-winget install -h Docker.sbx && sbx login
-```
 
 ---
 

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -31,24 +31,17 @@ For federal compliance and automation, sbx CLI is the recommended approach.
 
 | Requirement | How to Check | Notes |
 |-------------|--------------|-------|
-| Docker Desktop 4.41+ | `docker --version` | Includes sbx CLI |
+| sbx CLI | `sbx version` | Standalone tool, Docker Desktop not required |
 | USAi API key | From your GSA account | For Anthropic/Claude access |
 | GitHub token | `gh auth token` | Optional, for code access |
 
+> [!NOTE]
+> Docker Desktop is **not required** to use sbx. The sbx CLI is a standalone tool.
+> If you have Docker Desktop, your Docker subscription covers sbx licensing.
+
 ---
 
-## Step 1: Verify Installation
-
-```bash
-# Check sbx is installed
-sbx version
-
-# Expected output:
-# Client Version:  v0.30.0 ...
-# Server Version:  v0.30.0 ...
-```
-
-**Not installed?** Install sbx CLI:
+## Step 1: Install sbx CLI
 
 ```bash
 # macOS
@@ -63,6 +56,16 @@ sudo apt-get install docker-sbx
 sudo usermod -aG kvm $USER
 newgrp kvm
 sbx login
+```
+
+**Verify installation:**
+
+```bash
+sbx version
+
+# Expected output:
+# Client Version:  v0.30.0 ...
+# Server Version:  v0.30.0 ...
 ```
 
 ---


### PR DESCRIPTION
## Summary

Updates the quickstart documentation to clarify that **sbx CLI is a standalone tool** and Docker Desktop is not required.

## Background

From [Docker's official documentation](https://docs.docker.com/ai/sandboxes/get-started/):

> Docker Desktop is not required to use `sbx`.

The previous instructions implied Docker Desktop 4.41+ was a prerequisite, which was misleading.

## Changes

### README.md
- Restructured "5-Minute Quickstart" to lead with sbx installation
- Added all three platform instructions (macOS, Windows, Linux)
- Updated prerequisites table to show `sbx version` instead of `docker --version`
- Added note clarifying Docker Desktop is for licensing only

### docs/QUICKSTART_SBX.md
- Updated prerequisites table
- Added note about Docker Desktop licensing
- Reordered Step 1 to install first, verify second

## Key Points

1. **sbx CLI is standalone** — installs via Homebrew/Winget/apt, not Docker Desktop
2. **Docker Desktop is optional** — only provides licensing if you have a subscription
3. **Linux now documented** — Ubuntu instructions included in main quickstart

Co-authored-by: OpenCode Agent <agent@gsa.gov>