### PR TITLE
docs: add GPT-5.x max_tokens failure mode

### DIFF
--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -540,6 +540,71 @@ When something fails, work through this list:
 
 ---
 
+## 18. GPT-5.x Models Fail with "Unsupported parameter: max_tokens"
+
+### Symptoms
+
+- OpenCode fails silently when using USAi GPT-5.x models
+- No error message displayed in the UI
+- Direct API calls with `max_tokens` return:
+  ```json
+  {"detail":"400: Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."}
+  ```
+
+### Affected Models
+
+- `gpt-5.4-latest-guardrails-defaultv2`
+- `gpt-5.2-latest-guardrails-defaultv2`
+
+### Root Cause
+
+OpenAI's GPT-5.x series models have deprecated the `max_tokens` parameter in favor of `max_completion_tokens`. The `@ai-sdk/openai-compatible` package (used by OpenCode for USAi) always sends `max_tokens`, which these models reject.
+
+Unlike the primary `@ai-sdk/openai` package, the OpenAI-compatible provider does **not** have reasoning model detection that converts `max_tokens → max_completion_tokens` for GPT-5.x models.
+
+### Status
+
+**USAi team is aware and working on a proxy-level fix** to translate `max_tokens → max_completion_tokens` for affected models. No ETA currently.
+
+Tracked in: [Issue #62](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/62)
+
+### Workaround
+
+Use Claude or Gemini models instead of GPT-5.x until the fix is deployed:
+
+```jsonc
+// In opencode.jsonc
+"model": "usai/claude_4_5_sonnet",  // Works correctly
+// "model": "usai/gpt-5.4-latest-guardrails-defaultv2",  // Broken until fix
+```
+
+**Working models:**
+- `usai/claude_4_5_opus`
+- `usai/claude_4_5_sonnet`
+- `usai/claude_3_5_haiku`
+- `usai/gemini-2.5-pro`
+- `usai/gemini-2.5-flash`
+
+### Verification
+
+Test directly with curl:
+
+```bash
+# This FAILS with max_tokens
+curl -s "https://api.gsa.usai.gov/api/v1/chat/completions" \
+  -H "Authorization: Bearer $USAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-5.4-latest-guardrails-defaultv2","messages":[{"role":"user","content":"hello"}],"max_tokens":10}'
+
+# This SUCCEEDS without max_tokens
+curl -s "https://api.gsa.usai.gov/api/v1/chat/completions" \
+  -H "Authorization: Bearer $USAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-5.4-latest-guardrails-defaultv2","messages":[{"role":"user","content":"hello"}]}'
+```
+
+---
+
 ## Contributing
 
 When you discover a new failure mode:


### PR DESCRIPTION
## Summary

Documents the known issue where USAi GPT-5.x models reject the `max_tokens` parameter.

## Root Cause

The `@ai-sdk/openai-compatible` package (used by OpenCode for USAi) always sends `max_tokens`, but GPT-5.x models (served via AWS Bedrock GovCloud) require `max_completion_tokens` instead.

Unlike the primary `@ai-sdk/openai` package, the OpenAI-compatible provider does not have reasoning model detection that converts `max_tokens → max_completion_tokens`.

## USAi Team Response

The USAi team is aware and working on a proxy-level fix:

> "Yeah, we already have some logic around this. I think all of our models already honor `max_completion_tokens` so maybe we can route everything to make `max_tokens -> max_completion_tokens`."
> — Mark Meyer, USAi IBD

**Status:** Fix in progress. No ETA currently.

## Documentation Added

Added Section 18 to `docs/KNOWN_FAILURE_MODES.md`:
- Symptoms and affected models
- Root cause explanation
- Current status and tracking
- Workaround (use Claude/Gemini models)
- Verification commands

Refs: #62

Co-authored-by: OpenCode Agent <agent@gsa.gov>