### PR TITLE
feat(bootstrap): add init-project script for project bootstrapping

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,25 +1,13 @@
 [
   {
-    "label": "OpenCode: Run Agent (Standalone CLI)",
+    "label": "OpenCode: Run Agent",
     "command": "make run-agent",
     "use_new_terminal": true,
     "allow_concurrent_runs": false
   },
   {
-    "label": "OpenCode: Run Agent (Docker Desktop)",
-    "command": "make run-agent-desktop",
-    "use_new_terminal": true,
-    "allow_concurrent_runs": false
-  },
-  {
-    "label": "OpenCode: Create Sandbox (Standalone CLI)",
+    "label": "OpenCode: Create Sandbox",
     "command": "make create-sandbox",
-    "use_new_terminal": true,
-    "allow_concurrent_runs": false
-  },
-  {
-    "label": "OpenCode: Create Sandbox (Docker Desktop)",
-    "command": "make create-sandbox-desktop",
     "use_new_terminal": true,
     "allow_concurrent_runs": false
   },

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Agentic Coding Quickstart - Makefile
 # Simple commands for setting up and managing your AI-assisted development workspace
 
-.PHONY: setup doctor new-project clean install-hooks help
+.PHONY: setup doctor new-project clean install-hooks help init-project create-sandbox run-agent
 
 # Default target
 help:
@@ -11,15 +11,12 @@ help:
 	@echo "Commands:"
 	@echo "  make setup                 - Set up your workspace (clone playbook, check dependencies)"
 	@echo "  make doctor                - Run health checks on your environment"
-	@echo "  make new-project           - Create a new project directory"
-	@echo "  make create-sandbox        - Create SBX sandbox 'quickstart' (sbx CLI)"
-	@echo "  make run-agent             - Run OpenCode agent in SBX (sbx CLI)"
+	@echo "  make new-project           - Create a new project directory (interactive)"
+	@echo "  make init-project TARGET_DIR=/path - Bootstrap a project directory (non-interactive)"
+	@echo "  make create-sandbox        - Create SBX sandbox 'quickstart'"
+	@echo "  make run-agent             - Run OpenCode agent in SBX"
 	@echo "  make install-hooks         - [OPTIONAL] Install pre-commit hooks"
 	@echo "  make clean                 - Remove generated files"
-	@echo ""
-	@echo "Deprecated targets (will be removed in future release):"
-	@echo "  make create-sandbox-desktop- DEPRECATED: use 'make create-sandbox'"
-	@echo "  make run-agent-desktop     - DEPRECATED: use 'make run-agent'"
 	@echo ""
 	@echo "First time? Run: make setup"
 
@@ -68,6 +65,16 @@ doctor:
 	@docker info >/dev/null 2>&1 && echo "[OK] Docker running" || echo "[FAIL] Docker not running"
 	@command -v git >/dev/null 2>&1 && echo "[OK] Git installed" || echo "[FAIL] Git not found"
 	@command -v sbx >/dev/null 2>&1 && echo "[OK] SBX installed" || echo "[WARN] SBX not found (optional)"
+	@if [ -n "$$USAI_API_KEY" ]; then \
+		echo "[OK] USAI_API_KEY is set"; \
+	else \
+		echo "[FAIL] USAI_API_KEY is not set"; \
+		echo ""; \
+		echo "To set your API key, run:"; \
+		echo "  export USAI_API_KEY=\"your-api-key-here\""; \
+		echo ""; \
+		echo "Get your API key at: https://console.gsa.usai.gov/key-management"; \
+	fi
 	@echo ""
 	@echo "Workspace"
 	@echo "---------"
@@ -77,7 +84,7 @@ doctor:
 	@echo ""
 	@echo "Run 'make setup' to fix any issues."
 
-# Create a new project
+# Create a new project (interactive)
 new-project:
 	@echo "Create a new project"
 	@echo "--------------------"
@@ -86,25 +93,64 @@ new-project:
 		echo "ERROR: Project name required"; \
 		exit 1; \
 	fi; \
-	if [ -d "../$$name" ]; then \
-		echo "ERROR: Directory ../$$name already exists"; \
+	$(MAKE) init-project TARGET_DIR="../$$name"
+
+# Initialize a new project from the quickstart (non-interactive)
+init-project: _check-target-dir
+	@echo "Initializing project in $(TARGET_DIR)..."
+	@mkdir -p "$(TARGET_DIR)"
+	@echo "Copying configuration files..."
+	@cp AGENTS.md "$(TARGET_DIR)/" && echo "  [OK] AGENTS.md"
+	@cp opencode.jsonc "$(TARGET_DIR)/" && echo "  [OK] opencode.jsonc"
+	@cp Makefile "$(TARGET_DIR)/" && echo "  [OK] Makefile"
+
+	@# Only create README if it doesn't exist
+	@if [ ! -f "$(TARGET_DIR)/README.md" ]; then \
+		echo "# $$(basename "$(TARGET_DIR)")" > "$(TARGET_DIR)/README.md"; \
+		echo "" >> "$(TARGET_DIR)/README.md"; \
+		echo "Project initialized from agentic-coding-quickstart." >> "$(TARGET_DIR)/README.md"; \
+		echo "" >> "$(TARGET_DIR)/README.md"; \
+		echo "Next: run 'make setup' inside your new project directory." >> "$(TARGET_DIR)/README.md"; \
+		echo "  [OK] README.md (created)"; \
+	else \
+		echo "  [SKIP] README.md (already exists)"; \
+	fi
+
+	@# Create .zed directory and copy tasks.json
+	@mkdir -p "$(TARGET_DIR)/.zed"
+	@cp .zed/tasks.json "$(TARGET_DIR)/.zed/tasks.json" && echo "  [OK] .zed/tasks.json"
+
+	@# Only run git init if it's not already a git repository
+	@if [ ! -d "$(TARGET_DIR)/.git" ]; then \
+		git init "$(TARGET_DIR)" > /dev/null 2>&1; \
+		echo "  [OK] Git repository initialized"; \
+	else \
+		echo "  [SKIP] Git repository (already exists)"; \
+	fi
+	@echo ""
+	@echo "[OK] Project initialized in $(TARGET_DIR)"
+	@echo ""
+	@echo "Next steps:"
+	@echo "  1. cd $(TARGET_DIR)"
+	@echo "  2. make setup"
+
+_check-target-dir:
+	@if [ -z "$(TARGET_DIR)" ]; then \
+		echo "ERROR: TARGET_DIR is not set. Usage: make init-project TARGET_DIR=/path/to/project"; \
 		exit 1; \
-	fi; \
-	mkdir -p "../$$name"; \
-	echo "# $$name" > "../$$name/README.md"; \
-	echo "" >> "../$$name/README.md"; \
-	echo "Project created with agentic-coding-quickstart." >> "../$$name/README.md"; \
-	echo ""; \
-	echo "Created: ../$$name"; \
-	echo ""; \
-	echo "Next: Start your AI agent and ask it to help you set up the project."; \
-	echo "      The agent can use skills from the playbook to scaffold your app."
+	fi
+	@if [ -d "$(TARGET_DIR)" ]; then \
+		echo "--> Provisioning existing directory: $(TARGET_DIR)"; \
+	else \
+		echo "--> Creating new directory: $(TARGET_DIR)"; \
+		mkdir -p "$(TARGET_DIR)"; \
+	fi
 
 # Clean up
 clean:
 	@echo "Nothing to clean (this repo doesn't generate files)"
 
-# Create SBX sandbox 'quickstart' using sbx CLI
+# Create SBX sandbox 'quickstart'
 create-sandbox:
 	@echo "Creating SBX sandbox 'quickstart'..."
 	@if sbx ls | grep -q "quickstart"; then \
@@ -113,37 +159,13 @@ create-sandbox:
 		sbx create --name quickstart opencode .; \
 	fi
 
-# DEPRECATED: Create SBX sandbox using Docker Desktop
-# Docker has deprecated 'docker sandbox' commands. Use 'make create-sandbox' instead.
-create-sandbox-desktop:
-	@echo ""
-	@echo "WARNING: 'docker sandbox' commands are DEPRECATED by Docker."
-	@echo "         Use 'make create-sandbox' (sbx CLI) instead."
-	@echo "         See: https://docs.docker.com/reference/cli/docker/sandbox/"
-	@echo ""
-	@if docker sandbox ls 2>/dev/null | grep -q "quickstart"; then \
-		echo "Sandbox 'quickstart' already exists. Skipping creation."; \
-	else \
-		docker sandbox create --name quickstart opencode .; \
-	fi
-
-# Run OpenCode agent in sandbox 'quickstart' using sbx CLI
+# Run OpenCode agent in sandbox 'quickstart'
 run-agent: _check-usai-key
 	@echo "Running OpenCode agent in SBX sandbox 'quickstart'..."
 	@sbx exec -it \
 		-e USAI_API_KEY="$(USAI_API_KEY)" \
 		$(if $(NODE_TLS_REJECT_UNAUTHORIZED),-e NODE_TLS_REJECT_UNAUTHORIZED="$(NODE_TLS_REJECT_UNAUTHORIZED)",) \
 		-w "$(shell pwd)" quickstart opencode
-
-# DEPRECATED: Run agent using Docker Desktop
-# Docker has deprecated 'docker sandbox' commands. Use 'make run-agent' instead.
-run-agent-desktop:
-	@echo ""
-	@echo "WARNING: 'docker sandbox' commands are DEPRECATED by Docker."
-	@echo "         Use 'make run-agent' (sbx CLI) instead."
-	@echo "         See: https://docs.docker.com/reference/cli/docker/sandbox/"
-	@echo ""
-	@docker sandbox run quickstart
 
 _check-usai-key:
 	@if [ -z "$(USAI_API_KEY)" ]; then \

--- a/README.md
+++ b/README.md
@@ -181,18 +181,58 @@ For more troubleshooting, see [docs/KNOWN_FAILURE_MODES.md](docs/KNOWN_FAILURE_M
 
 ## Bootstrap Your Own Project
 
-Want to use sbx + USAi in your own repository?
+Want to use sbx + USAi in your own repository? Use the `init-project.sh` script to automatically provision any directory (new or existing) with all necessary configuration files.
+
+### Quick Start
 
 ```bash
-# Copy essential files from templates/
-cp templates/opencode.jsonc /path/to/your/project/
-
-# Copy Zed tasks (optional, if using Zed Editor)
-mkdir -p /path/to/your/project/.zed
-cp templates/zed-tasks.json /path/to/your/project/.zed/tasks.json
+# Provision a new or existing project directory
+./init-project.sh /path/to/your/project
 ```
 
-See [templates/BOOTSTRAP.md](templates/BOOTSTRAP.md) for detailed instructions.
+### What Gets Provisioned
+
+The script copies these files to your target directory:
+
+| File | Purpose |
+|------|---------|
+| `AGENTS.md` | Behavioral rules for AI agents |
+| `opencode.jsonc` | Pre-configured USAi endpoints |
+| `Makefile` | Helper commands (`make setup`, `make doctor`, etc.) |
+| `.zed/tasks.json` | Zed Editor task integration |
+| `README.md` | Generated project README (only if it doesn't exist) |
+
+The script also:
+- Initializes a git repository (if not already initialized)
+- Preserves existing files (won't overwrite your README.md)
+- Works with both empty and populated directories
+
+### Example
+
+```bash
+# From the quickstart directory
+cd /path/to/agentic-coding-quickstart
+
+# Provision your project
+./init-project.sh /path/to/my-existing-app
+
+# Result:
+# [OK] AGENTS.md
+# [OK] opencode.jsonc
+# [OK] Makefile
+# [OK] .zed/tasks.json
+# [OK] Git repository initialized (if needed)
+```
+
+### Next Steps After Provisioning
+
+```bash
+cd /path/to/your/project
+make setup    # Clone playbook and check dependencies
+make doctor   # Verify your environment
+```
+
+**Alternative (Manual):** If you prefer manual setup, see [templates/BOOTSTRAP.md](templates/BOOTSTRAP.md) for detailed instructions.
 
 ---
 

--- a/init-project.sh
+++ b/init-project.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Script to initialize/bootstrap a project from the agentic-coding-quickstart
+
+set -e
+
+# --- Configuration ---
+# Get the directory of this script (portable for Linux and macOS)
+QUICKSTART_DIR="$( cd "$( dirname "${BASH_SOURCE[0]:-$0}" )" > /dev/null 2>&1 && pwd )"
+
+# --- Functions ---
+show_usage() {
+    echo "Usage: $0 [OPTIONS] /path/to/project"
+    echo ""
+    echo "Bootstrap a new or existing project directory with agentic-coding configuration."
+    echo ""
+    echo "Options:"
+    echo "  -h, --help    Show this help message and exit"
+    echo ""
+    echo "What gets provisioned:"
+    echo "  - AGENTS.md        Behavioral rules for AI agents"
+    echo "  - opencode.jsonc   Pre-configured USAi endpoints"
+    echo "  - Makefile         Helper commands (make setup, make doctor, etc.)"
+    echo "  - .zed/tasks.json  Zed Editor task integration"
+    echo "  - README.md        Generated project README (only if it doesn't exist)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 /path/to/new-project      # Create and bootstrap a new directory"
+    echo "  $0 /path/to/existing-app     # Bootstrap an existing directory"
+    echo ""
+    echo "The script is idempotent - safe to run multiple times on the same directory."
+}
+
+# --- Argument Parsing ---
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    show_usage
+    exit 0
+fi
+
+# --- Main Logic ---
+# Check if a target directory was provided
+if [ -z "$1" ]; then
+    echo "ERROR: No target directory specified."
+    echo ""
+    show_usage
+    exit 1
+fi
+
+TARGET_DIR="$1"
+
+# Run the make command from the quickstart directory
+echo "Changing to quickstart directory: $QUICKSTART_DIR"
+cd "$QUICKSTART_DIR" || { echo "ERROR: Could not navigate to the quickstart directory."; exit 1; }
+
+echo "Initializing project in: $TARGET_DIR"
+make init-project TARGET_DIR="$TARGET_DIR"


### PR DESCRIPTION
## Summary

Add a streamlined project bootstrapping system for new and existing directories.

> **Note:** This PR supersedes #61 with properly formatted commits. All changes are from @JJediny's original work, rebased onto main with a single conventional commit.

## Changes

### New Files
- `init-project.sh`: Entry point wrapper script with `--help` support

### Makefile Changes
- Add `init-project` target for non-interactive bootstrapping
- Add `USAI_API_KEY` check to `make doctor` with setup instructions
- Remove deprecated Docker Desktop commands (`create-sandbox-desktop`, `run-agent-desktop`)
- Update `new-project` to use `init-project` internally

### Zed Editor Updates
- Remove deprecated Docker Desktop tasks from `.zed/tasks.json`
- Simplify task labels (remove "Standalone CLI" suffix)

### README Updates
- Add Quick Start section with bootstrap instructions
- Document `init-project` usage and provisioned files

## Files Provisioned to Target Directory

| File | Purpose |
|------|---------|
| `AGENTS.md` | AI agent behavioral rules |
| `opencode.jsonc` | USAi endpoint configuration |
| `Makefile` | Helper commands |
| `.zed/tasks.json` | Zed Editor integration |
| `README.md` | Generated only if missing |

## Features

- ✅ Idempotent: safe to run multiple times
- ✅ Preserves existing `README.md` and `.git` directory
- ✅ Creates directories if they don't exist
- ✅ Clear progress output with `[OK]`/`[SKIP]` status

## Usage

```bash
# Interactive mode
make new-project

# Non-interactive mode
make init-project TARGET_DIR=/path/to/project

# Via script
./init-project.sh /path/to/project
```

Supersedes: #61

Co-authored-by: John Jediny <John.Jediny@gsa.gov>
Co-authored-by: OpenCode Agent <agent@gsa.gov>