### PR TITLE
fix(docs): correct broken related_files links in frontmatter

### DIFF
--- a/checklists/pre-deployment.md
+++ b/checklists/pre-deployment.md
@@ -8,7 +8,7 @@ nist_controls: ["SA-11", "SA-12", "CM-2", "SI-10", "IA-5", "SC-13", "AU-2"]
 frameworks: ["NIST SP 800-53 Rev 5.2", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026"]
 audience: "developers"
 keywords: ["checklist", "pre-deployment", "security-review", "sign-off"]
-related_files: ["docs/CODING_PRACTICES.md", "docs/SECURITY-CONTROLS.md"]
+related_files: ["docs/CODING_PRACTICES.md", "AGENTS.md"]
 load_priority: "reference-only"
 review_cycle: "semi-annually"
 ---

--- a/docs/CODING_PRACTICES.md
+++ b/docs/CODING_PRACTICES.md
@@ -8,7 +8,7 @@ nist_controls: ["SA-8", "SA-11", "SA-12", "SA-15", "SA-17", "SI-2", "SI-4", "SI-
 frameworks: ["NIST SP 800-53 Rev 5.2", "NIST SP 800-218A", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026", "CISA Secure by Design"]
 audience: "developers"
 keywords: ["secure-coding", "input-validation", "secrets-management", "supply-chain", "SBOM", "OWASP", "SSDF", "TDD", "SOLID", "YAGNI", "DRY", "ADR", "design-by-contract", "bias-testing", "fairness", "model-evaluation", "continuous-monitoring", "model-drift"]
-related_files: ["AGENTS.md", "docs/SECURITY-CONTROLS.md", "checklists/pre-deployment.md"]
+related_files: ["AGENTS.md", "checklists/pre-deployment.md"]
 load_priority: "always"
 review_cycle: "quarterly"
 ---

--- a/docs/risk-assessment.md
+++ b/docs/risk-assessment.md
@@ -8,7 +8,7 @@ nist_controls: ["RA-3", "RA-5"]
 frameworks: ["NIST AI RMF 1.0", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026"]
 audience: "isso"
 keywords: ["risk-assessment", "AI-RMF", "threat-analysis", "OWASP", "ATO"]
-related_files: ["docs/SECURITY-CONTROLS.md", "docs/AGENT-IDENTITY.md"]
+related_files: ["docs/CODING_PRACTICES.md", "AGENTS.md"]
 load_priority: "reference-only"
 review_cycle: "semi-annually"
 ---

--- a/templates/AGENTS_SBX_ADDENDUM.md
+++ b/templates/AGENTS_SBX_ADDENDUM.md
@@ -81,7 +81,7 @@ Agents should:
 > USAi and GitLab are **not built-in sbx services**. You must use `sbx secret set-custom` with the `--host` parameter.
 > After changing secrets, **delete and recreate** the sandbox for changes to take effect.
 
-See `docs/SBX_PATTERNS.md` for detailed credential injection patterns.
+See `templates/SBX_PATTERNS.md` for detailed credential injection patterns.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes broken links in YAML frontmatter `related_files` arrays. These files were referencing docs that don't exist in quickstart.

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `docs/risk-assessment.md` | Referenced `docs/SECURITY-CONTROLS.md`, `docs/AGENT-IDENTITY.md` | Changed to `docs/CODING_PRACTICES.md`, `AGENTS.md` |
| `docs/CODING_PRACTICES.md` | Referenced `docs/SECURITY-CONTROLS.md` | Removed (only exists in playbook) |
| `checklists/pre-deployment.md` | Referenced `docs/SECURITY-CONTROLS.md` | Changed to `AGENTS.md` |
| `templates/AGENTS_SBX_ADDENDUM.md` | Referenced `docs/SBX_PATTERNS.md` | Changed to `templates/SBX_PATTERNS.md` |

## Context

These files were copied from playbook where SECURITY-CONTROLS.md and AGENT-IDENTITY.md exist. Quickstart has a lighter documentation set, so the frontmatter needs to reference files that actually exist.

## Testing

- All referenced files now exist
- No broken cross-references in frontmatter