### PR TITLE
chore: enhance pre-commit hooks for consistency with sibling repos

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,60 @@
+# markdownlint-cli2 configuration
+# Aligned with playbook standards for consistency
+# See: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+config:
+  # MD003 - Heading style (disabled — mixed styles OK)
+  MD003: false
+  # MD007 - Unordered list indent (allow 2-space, frontmatter false positives)
+  MD007: false
+  # MD004 - Unordered list style (disabled — mixed markers OK)
+  MD004: false
+  # MD013 - Line length (disabled — long lines OK in docs)
+  MD013: false
+  # MD022 - Headings should be surrounded by blank lines
+  MD022: false
+  # MD024 - No duplicate heading names (disabled — repeated names OK)
+  MD024: false
+  # MD025 - Single top-level heading (disabled — multiple H1 OK)
+  MD025: false
+  # MD026 - No trailing punctuation in headings
+  MD026: false
+  # MD031 - Fenced code blocks surrounded by blank lines
+  MD031: false
+  # MD032 - Lists surrounded by blank lines
+  MD032: false
+  # MD033 - No inline HTML (disabled — HTML allowed)
+  MD033: false
+  # MD034 - No bare URLs
+  MD034: false
+  # MD036 - No emphasis used instead of heading
+  MD036: false
+  # MD040 - Fenced code blocks should have language
+  MD040: false
+  # MD041 - First line in file should be H1
+  MD041: false
+  # MD051 - Link fragments should be valid
+  MD051: false
+  # MD056 - Table column count
+  MD056: false
+  # MD058 - Tables should be surrounded by blank lines
+  MD058: false
+  # MD060 - Table column style spacing
+  MD060: false
+
+# Scan these files
+globs:
+  - "AGENTS.md"
+  - "CONTEXT-GUIDE.md"
+  - "CONTRIBUTING.md"
+  - "README.md"
+  - "docs/*.md"
+  - "templates/*.md"
+
+# Ignore files
+ignores:
+  - "node_modules"
+  - "deleteme"
+
+# Support YAML frontmatter
+frontMatter: "/^---\\s*$[\\s\\S]*?^---\\s*$/m"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # .pre-commit-config.yaml
-# Minimal, opt-in pre-commit configuration for agentic-coding-quickstart
+# Pre-commit hooks for agentic-coding-quickstart
 #
 # Installation (optional):
 #   pip install pre-commit
@@ -8,7 +8,7 @@
 # Run without installing hooks:
 #   pre-commit run --all-files
 #
-# See https://pre-commit.com for more information
+# All hooks pinned to commit SHAs for supply chain security (NIST SA-12)
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -18,8 +18,18 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ['--maxkb=500']
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: ee6b38352380ce52369d16b7873093c4b8bf829b  # v8.24.3
     hooks:
       - id: gitleaks
+
+  # Markdown linting
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: d174eb7a8f35e05d4065c82d375ad84aa0b32352  # v0.17.2
+    hooks:
+      - id: markdownlint-cli2
+        args: ["--fix"]


### PR DESCRIPTION
## Summary

Enhances pre-commit configuration to align with playbook and patterns repositories per issue playbook #61.

## Changes

### New Hooks Added
| Hook | Purpose |
|------|---------|
| `check-merge-conflict` | Prevents committing files with merge conflict markers |
| `check-added-large-files` | Blocks files > 500KB to prevent accidental large commits |
| `markdownlint-cli2` | Lints markdown files with auto-fix |

### New Files
- `.markdownlint-cli2.yaml` - Configuration aligned with playbook settings

### Security
All hooks pinned to commit SHAs per NIST SA-12 (Supply Chain Protection).

## Hook Coverage Comparison (After)

| Hook | Playbook | Quickstart | Patterns |
|------|:--------:|:----------:|:--------:|
| check-yaml | ✅ | ✅ | ✅ |
| check-json | ✅ | ✅ | ✅ |
| check-merge-conflict | ✅ | ✅ | ❌ |
| check-added-large-files | ✅ | ✅ | ✅ |
| trailing-whitespace | ✅ | ✅ | ✅ |
| end-of-file-fixer | ✅ | ✅ | ✅ |
| gitleaks | ✅ | ✅ | ✅ |
| markdownlint-cli2 | ✅ | ✅ | ❌ (uses markdownlint-cli) |

## Related

Addresses playbook #61 (standardize pre-commit config across repos)