### PR TITLE
docs: remove GPT-5.x max_tokens vestigial documentation

### DIFF
--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -3,7 +3,7 @@ title: "Known Failure Modes"
 description: "Real-world failure patterns when using Docker SBX + USAi + agent frameworks"
 status: canonical
 tier: 2
-last_updated: "2026-04-14"
+last_updated: "2026-05-28"
 audience: "developers"
 keywords: ["debugging", "troubleshooting", "sbx", "usai", "failures"]
 ---
@@ -537,71 +537,6 @@ When something fails, work through this list:
 5. [ ] Is the config file actually being read? (add debug logging)
 6. [ ] Did SBX CLI syntax change? (`sbx --help`)
 7. [ ] Is this a known model/entitlement issue? (test with different model)
-
----
-
-## 18. GPT-5.x Models Fail with "Unsupported parameter: max_tokens"
-
-### Symptoms
-
-- OpenCode fails silently when using USAi GPT-5.x models
-- No error message displayed in the UI
-- Direct API calls with `max_tokens` return:
-  ```json
-  {"detail":"400: Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."}
-  ```
-
-### Affected Models
-
-- `gpt-5.4-latest-guardrails-defaultv2`
-- `gpt-5.2-latest-guardrails-defaultv2`
-
-### Root Cause
-
-OpenAI's GPT-5.x series models have deprecated the `max_tokens` parameter in favor of `max_completion_tokens`. The `@ai-sdk/openai-compatible` package (used by OpenCode for USAi) always sends `max_tokens`, which these models reject.
-
-Unlike the primary `@ai-sdk/openai` package, the OpenAI-compatible provider does **not** have reasoning model detection that converts `max_tokens → max_completion_tokens` for GPT-5.x models.
-
-### Status
-
-**USAi team is aware and working on a proxy-level fix** to translate `max_tokens → max_completion_tokens` for affected models. No ETA currently.
-
-Tracked in: [Issue #62](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/62)
-
-### Workaround
-
-Use Claude or Gemini models instead of GPT-5.x until the fix is deployed:
-
-```jsonc
-// In opencode.jsonc
-"model": "usai/claude_4_5_sonnet",  // Works correctly
-// "model": "usai/gpt-5.4-latest-guardrails-defaultv2",  // Broken until fix
-```
-
-**Working models:**
-- `usai/claude_4_5_opus`
-- `usai/claude_4_5_sonnet`
-- `usai/claude_3_5_haiku`
-- `usai/gemini-2.5-pro`
-- `usai/gemini-2.5-flash`
-
-### Verification
-
-Test directly with curl:
-
-```bash
-# This FAILS with max_tokens
-curl -s "https://api.gsa.usai.gov/api/v1/chat/completions" \
-  -H "Authorization: Bearer $USAI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"model":"gpt-5.4-latest-guardrails-defaultv2","messages":[{"role":"user","content":"hello"}],"max_tokens":10}'
-
-# This SUCCEEDS without max_tokens
-curl -s "https://api.gsa.usai.gov/api/v1/chat/completions" \
-  -H "Authorization: Bearer $USAI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"model":"gpt-5.4-latest-guardrails-defaultv2","messages":[{"role":"user","content":"hello"}]}'
-```
 
 ---
 

--- a/templates/opencode.jsonc
+++ b/templates/opencode.jsonc
@@ -9,10 +9,6 @@
   //
   // IMPORTANT: This file contains NO secrets.
   // API key is injected via USAI_API_KEY environment variable.
-  //
-  // KNOWN ISSUE: GPT-5.x models currently fail with OpenCode due to max_tokens
-  // parameter incompatibility. See docs/KNOWN_FAILURE_MODES.md Section 18.
-  // Use Claude or Gemini models until USAi deploys the proxy fix.
 
   "$schema": "https://opencode.ai/config.json",
   "enabled_providers": [
@@ -53,23 +49,20 @@
             "output": 8192
           }
         },
-        // GPT-5.x models — KNOWN ISSUE: Fails with max_tokens error.
-        // See docs/KNOWN_FAILURE_MODES.md Section 18 for details.
-        // Uncomment when USAi deploys the proxy fix.
-        // "gpt-5.4-latest-guardrails-defaultv2": {
-        //   "name": "GPT-5.4 Latest — Guardrails Default v2",
-        //   "limit": {
-        //     "context": 400000,
-        //     "output": 32768
-        //   }
-        // },
-        // "gpt-5.2-latest-guardrails-defaultv2": {
-        //   "name": "GPT-5.2 Latest — Guardrails Default v2",
-        //   "limit": {
-        //     "context": 400000,
-        //     "output": 32768
-        //   }
-        // },
+        "gpt-5.4-latest-guardrails-defaultv2": {
+          "name": "GPT-5.4 Latest — Guardrails Default v2",
+          "limit": {
+            "context": 400000,
+            "output": 32768
+          }
+        },
+        "gpt-5.2-latest-guardrails-defaultv2": {
+          "name": "GPT-5.2 Latest — Guardrails Default v2",
+          "limit": {
+            "context": 400000,
+            "output": 32768
+          }
+        },
         "gemini-2.5-pro": {
           "name": "Gemini 2.5 Pro",
           "limit": {
@@ -119,9 +112,8 @@
   "small_model": "usai/claude_3_5_haiku",
   "agent": {
     "compaction": {
-      // Use Gemini for context compaction (GPT-5.x has max_tokens issue).
-      // Gemini 2.5 Flash is fast and capable for summaries.
-      "model": "usai/gemini-2.5-flash"
+      // GPT-5.2 is a strong choice for context compaction.
+      "model": "usai/gpt-5.2-latest-guardrails-defaultv2"
     }
   },
   "compaction": {


### PR DESCRIPTION
## Summary

The USAi proxy fix has been deployed and GPT-5.x models now work correctly with OpenCode. This PR removes the workaround documentation and re-enables GPT-5.x models.

## Background

Issue #62 documented a `max_tokens` parameter incompatibility where GPT-5.x models required `max_completion_tokens` instead. The USAi team has deployed a proxy-level fix that translates the parameter automatically.

## Changes

### docs/KNOWN_FAILURE_MODES.md
- **Removed:** Section 18 "GPT-5.x Models Fail with 'Unsupported parameter: max_tokens'"
- Updated `last_updated` date in frontmatter

### templates/opencode.jsonc
- **Removed:** Warning comments about GPT-5.x incompatibility
- **Enabled:** GPT-5.x models (previously commented out)
- **Updated:** Compaction model changed from `gemini-2.5-flash` to `gpt-5.2-latest-guardrails-defaultv2`

## Verification

The fix was confirmed by the user with direct testing against the USAi API.

## Related

- Closes the tracking for issue #62 (already closed, but documentation was still present)
- Removes vestigial workaround guidance