### PR TITLE
fix(ci): remove GITHUB_TOKEN secret from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 # Release - Consumes reusable workflow from playbook
 # See: https://github.com/GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-release-please.yml
+# Note: GITHUB_TOKEN is automatically inherited, no need to pass as secret
 
 name: Release
 
@@ -14,5 +15,3 @@ jobs:
     uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-release-please.yml@main
     with:
       release-type: simple
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removes GITHUB_TOKEN secret from release.yml (reserved name collision fix).

Co-authored-by: OpenCode Agent <agent@gsa.gov>