### PR TITLE
chore(hooks): add shellcheck pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,10 @@ repos:
     hooks:
       - id: markdownlint-cli2
         args: ["--fix"]
+
+  # Shell script linting (shellcheck-py: native binary, no Docker required)
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: 745eface02aef23e168a8afb6b5737818efbea95  # v0.11.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]


### PR DESCRIPTION
## Summary

Adds shellcheck validation for shell scripts via pre-commit.
Uses SHA-pinning for supply chain security per NIST SA-12.

## Related Issues

Refs: #88

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits format](../CONTRIBUTING.md#commit-message-guidelines) (e.g., `feat:`, `fix:`, `docs:`)
- [x] I have tested my changes locally
- [ ] I have updated documentation as needed
- [x] I have not included any secrets, API keys, or sensitive information

## Test Results

Successfully ran locally with `pre-commit run --all-files`

## Additional Notes

We may want to create a follow-on PR to run all pre-commit hooks in CI.  However, I wanted to keep this separate since that change would have more potential to break things.
