### PR TITLE
security: harden pre-commit workflow per NIST SA-12/AC-6

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,20 +1,32 @@
 # Pre-commit - Runs all pre-commit hooks on all files
 # Enforces shellcheck, gitleaks, markdownlint, and other hooks in CI
+#
+# Security hardening per NIST SA-12 (Supply Chain) and AC-6 (Least Privilege)
 
 name: Pre-commit
 
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
 
+concurrency:
+  group: pre-commit-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1


### PR DESCRIPTION
## Summary

Hardens the pre-commit CI workflow added in PR #91 per security review findings.

## Changes

### HIGH Severity (Fixed)
1. **SHA-pinned all actions** - Prevents supply chain attacks per NIST SA-12
   - `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
   - `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065` (v5.6.0)
   - `pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd` (v3.0.1)

2. **Added `permissions: contents: read`** - Least privilege per NIST AC-6

### MEDIUM Severity (Fixed)
3. **Added `concurrency:` block** - Prevents duplicate/wasted runs
4. **Added `timeout-minutes: 15`** - Resource protection

### LOW Severity (Fixed)
5. **Added branch filter on `pull_request`** - Consistency with other workflows

## Related Issues

Closes #96

## Type of Change
- [x] Security hardening

## Checklist
- [x] Follows Conventional Commits
- [x] Pre-commit hooks pass locally
- [x] No secrets included

## Control Mapping
- NIST SA-12 (Supply Chain Protection)
- NIST AC-6 (Least Privilege)
- NIST SC-5 (Denial of Service Protection)

Co-authored-by: OpenCode Agent <agent@gsa.gov>