### PR TITLE
docs: fix sbx CLI flag documentation and README claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ AI coding agents can read files, write code, and execute commands. Running them 
 If you use the **Zed Editor**, pre-configured tasks are available in `.zed/tasks.json`:
 
 - **OpenCode: Run Agent** — Launch the agent in your sandbox
-- **OpenCode: Create Sandbox** — Create a new sandbox
 - **OpenCode: Environment Diagnostics** — Run `make doctor`
 
 See the **[Zed Editor Setup Guide](docs/ZED_SETUP.md)** for detailed instructions.

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -3,7 +3,7 @@ title: "Known Failure Modes"
 description: "Real-world failure patterns when using Docker SBX + USAi + agent frameworks"
 status: canonical
 tier: 2
-last_updated: "2026-05-28"
+last_updated: "2026-06-02"
 audience: "developers"
 keywords: ["debugging", "troubleshooting", "sbx", "usai", "failures"]
 ---
@@ -483,16 +483,26 @@ To resolve this during local development, you can tell Node.js to ignore TLS val
 
 #### Workaround: Pass Environment Variable via SBX
 
-Run your agent with the environment variable injected directly into the sandbox:
+The `sbx run` command does **not** support the `-e` flag for environment variables. Use the two-step `create` + `exec` pattern instead:
 
 ```bash
 # For debugging TLS issues only - never use with real credentials
-sbx run -e NODE_TLS_REJECT_UNAUTHORIZED=0 opencode .
+
+# Step 1: Create the sandbox (or skip if it already exists)
+sbx create --name debug-sandbox opencode .
+
+# Step 2: Run with environment variable
+sbx exec -e NODE_TLS_REJECT_UNAUTHORIZED=0 debug-sandbox opencode
 ```
 
-This passes the `NODE_TLS_REJECT_UNAUTHORIZED=0` environment variable into the sandbox at runtime without persisting it.
+Alternatively, combine into a single line:
 
-> **Note:** The previous `make run-agent` passthrough has been removed. Use the `sbx run -e` flag directly to inject environment variables.
+```bash
+sbx create --name debug-sandbox opencode . 2>/dev/null || true && \
+sbx exec -e NODE_TLS_REJECT_UNAUTHORIZED=0 debug-sandbox opencode
+```
+
+**Important:** Only `sbx exec` supports the `-e` flag, not `sbx run`.
 
 ---
 

--- a/docs/ZED_SETUP.md
+++ b/docs/ZED_SETUP.md
@@ -149,12 +149,14 @@ run-agent:
 
 ### SSL/TLS Certificate Errors ("unable to get local issuer certificate")
 - If OpenCode launches but fails to connect with an `unable to get local issuer certificate` error, this is due to SSL/TLS interception/decryption on federal GFE (Government Furnished Equipment) networks.
-- **To fix this:** Set the environment variable when running:
+- **To fix this:** Use the two-step `create` + `exec` pattern (since `sbx run` does not support `-e`):
   ```bash
   # For debugging TLS issues only - never use with real credentials
-  sbx run -e NODE_TLS_REJECT_UNAUTHORIZED=0 opencode .
+  sbx create --name debug-sandbox opencode . 2>/dev/null || true && \
+  sbx exec -e NODE_TLS_REJECT_UNAUTHORIZED=0 debug-sandbox opencode
   ```
 - **⚠️ Security Warning:** Disabling TLS validation bypasses certificate verification. Only use this for debugging in isolated local environments, never with real credentials.
+- See [KNOWN_FAILURE_MODES.md](KNOWN_FAILURE_MODES.md#16-ssltls-certificate-errors-unable-to-get-local-issuer-certificate) for details.
 
 ### Terminal Output is Frozen or Unresponsive
 - If a task runs and does not respond to keystrokes, close the terminal pane (`Cmd + W`) and trigger the task again via the tasks palette.

--- a/templates/opencode.jsonc
+++ b/templates/opencode.jsonc
@@ -6,7 +6,7 @@
   // 2. Customize the models list based on your USAi API key entitlements
   // 3. Update the default model if needed
   // 4. Set up your USAi API key as a SBX secret before the first run:
-  //    sbx secret set-custom -g --host api.gsa.usai.gov --name USAI_API_KEY --value <your_api_key>
+  //    sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value <your_api_key>
   // 5. Run with: sbx run opencode .
   //
   // IMPORTANT: This file contains NO secrets.


### PR DESCRIPTION
## Summary
Fixes critical documentation inconsistencies with sbx CLI commands found during comprehensive doc audit.

## Changes

### templates/opencode.jsonc (CRITICAL)
- Fixed `--name` flag to `--env` for `sbx secret set-custom` command
- Users following the old instructions would get syntax errors

### docs/ZED_SETUP.md
- Removed incorrect `sbx run -e` documentation (`sbx run` does NOT support `-e` flag)
- Added correct two-step `create` + `exec` pattern for environment variable injection
- Added link to KNOWN_FAILURE_MODES.md for full details

### README.md
- Removed non-existent "OpenCode: Create Sandbox" task from Zed tasks list
- Task doesn't exist in `.zed/tasks.json`

## Verification
```bash
# Verify --env is correct flag
sbx secret set-custom --help

# Verify sbx run doesn't support -e
sbx run --help

# Verify .zed/tasks.json contents
cat .zed/tasks.json
```

## Issues
Fixes #102

## Security Impact
None - documentation fixes only. Actually improves security by ensuring users can correctly set up credentials.