### PR TITLE
docs: fix invalid sbx CLI flags

### DIFF
--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -332,12 +332,19 @@ Config file exists on host but not mounted into container.
 
 ### Fix
 
-Ensure config is in the mounted working directory:
+Ensure config is in the mounted working directory. When using `sbx run` or `sbx create`, the current directory is automatically mounted:
+
 ```bash
-sbx exec -v $(pwd):/workspace <sandbox> sh
+# Run from the directory containing your config
+cd /path/to/project-with-config
+sbx run opencode .
 ```
 
-Or copy config into container before execution.
+Or copy config into an existing container:
+
+```bash
+sbx cp ./opencode.jsonc my-sandbox:/workspace/
+```
 
 ---
 

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -386,14 +386,24 @@ echo "$DOCKER_PAT" | sbx login --password-stdin --username "$DOCKER_USER"
 
 ## Working with Git Branches
 
-Create isolated sandboxes for different branches:
+For branch isolation, use the `--clone` flag which creates an in-container clone of your repository:
 
 ```bash
-# Create sandbox with Git worktree for a feature branch
-sbx create --branch=feature/login opencode .
+# Create sandbox with an in-container clone (changes accessible via git remote)
+sbx create --clone --name feature-work opencode .
 
-# Work in isolation - changes stay on that branch
-sbx run opencode-myproject
+# The sandbox works on a private clone; commits are accessible via:
+# git fetch sandbox-feature-work
+```
+
+Alternatively, check out the branch on your host before creating the sandbox:
+
+```bash
+# On host: switch to feature branch
+git checkout feature/login
+
+# Create sandbox - it mounts the current branch
+sbx run opencode .
 ```
 
 ---


### PR DESCRIPTION
## Summary
Fixes invalid sbx CLI commands discovered during command verification audit.

Tested against **sbx v0.31.2**.

## Changes

### docs/KNOWN_FAILURE_MODES.md
- Removed invalid `sbx exec -v $(pwd):/workspace` example
- `sbx exec` does NOT support `-v` flag for volume mounting
- Replaced with correct patterns: run from mounted directory or use `sbx cp`

### docs/QUICKSTART_SBX.md  
- Replaced invalid `sbx create --branch=feature/login` with correct `--clone` flag
- `--branch` flag doesn't exist on `sbx create`
- `--clone` creates an in-container clone accessible via git remote

## Verification
```bash
$ sbx version
Client Version:  v0.31.2

$ sbx exec --help
# Shows: -d, -e, --env-file, -i, -t, -u, -w (NO -v flag)

$ sbx create --help  
# Shows: --clone, --cpus, --kit, -m, --name, --profile, -q, -t (NO --branch flag)
```

## Issues
Fixes #104

## Security Impact
None - documentation fixes only.