### PR TITLE
docs: add sbx multi-workspace guidance for cross-repo setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ That's it. You're now running an AI coding agent in an isolated container with U
 
 **Need more details?** See the [Full sbx CLI Guide](docs/QUICKSTART_SBX.md).
 
+**Working across multiple repos?** See [Multiple Workspaces](docs/QUICKSTART_SBX.md#multiple-workspaces) for mounting extra directories.
+
 ---
 
 ## Why Sandboxes?

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Ensure you're in a directory with `opencode.jsonc`. For sbx, the workspace is au
 
 ```bash
 # Check your secret is stored
-sbx secret list
+sbx secret ls
 
 # Re-set if needed
 sbx secret set -g anthropic

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -443,6 +443,12 @@ sbx run opencode ~/projects/backend ~/projects/frontend:ro
 Prefer read-only mounts for secondary workspaces unless the agent genuinely needs write access. This
 limits accidental modifications and reduces the blast radius of agent errors.
 
+> [!WARNING]
+> Mounted directories expose **all content** to the agent, including `.env` files, `.git/config`
+> (which may contain tokens), and any secrets in the mounted path. Avoid mounting directories that
+> contain sensitive files you do not want the agent to see. Use selective, targeted mounts rather
+> than mounting parent or home directories.
+
 ---
 
 ## Working with Git Branches

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -457,9 +457,36 @@ sbx create --clone --name feature-work opencode .
 # git fetch sandbox-feature-work
 ```
 
-> [!WARNING]
+> [!NOTE]
+> `--clone` replaced the earlier `--branch` flag in sbx v0.31.0. If your CLI does not recognize
+> `--clone`, update to the latest version.
+>
 > Removing a clone-mode sandbox deletes the in-sandbox clone. Any commits you have not fetched
 > (`git fetch sandbox-<name>`) or pushed to an upstream remote are lost.
+
+### Understanding the Git Remote Lifecycle
+
+When you use `--clone`, the sandbox exposes its clone as a Git remote named `sandbox-<name>` on
+your host repository:
+
+| Event | Effect |
+|-------|--------|
+| `sbx create --clone` | Adds `sandbox-<name>` remote to your host `.git/config` |
+| `sbx stop` | Git daemon stops; `git fetch sandbox-<name>` fails until restart |
+| `sbx run` (restart) | Git daemon restarts on a new port; CLI updates remote URL automatically |
+| `sbx rm` | Removes sandbox, clone, daemon, and the `sandbox-<name>` remote entry |
+
+**Safe pattern before removal:**
+
+```bash
+# Fetch any uncommitted work first
+git fetch sandbox-feature-work
+
+# Then remove
+sbx rm feature-work
+```
+
+### Direct Mode Alternative
 
 Alternatively, check out the branch on your host before creating the sandbox:
 

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -384,6 +384,67 @@ echo "$DOCKER_PAT" | sbx login --password-stdin --username "$DOCKER_USER"
 
 ---
 
+## Multiple Workspaces
+
+You can mount additional directories alongside the primary workspace when creating a sandbox. This
+is useful when you need to reference multiple repos or folders from one sandbox session.
+
+### Syntax
+
+```bash
+sbx run <agent> <primary-workspace> [extra-workspace]:ro [extra-workspace]:ro ...
+```
+
+- **Primary workspace** — The first path; agent starts here. Read/write by default.
+- **Extra workspaces** — Additional paths the agent can access.
+- **`:ro` suffix** — Mounts extra workspaces as read-only (recommended for reference repos).
+
+All workspaces appear inside the sandbox at their absolute host paths.
+
+### Example: App Repo + Playbook Reference
+
+```bash
+# Primary: your app (read/write)
+# Secondary: agentic-coding-playbook (read-only reference)
+sbx run opencode ~/projects/my-app ~/projects/agentic-coding-playbook:ro
+```
+
+The agent can edit `~/projects/my-app` and read from `~/projects/agentic-coding-playbook` without
+risk of modifying the playbook content.
+
+### Example: Frontend + Backend Repos
+
+```bash
+# Primary: backend (read/write)
+# Secondary: frontend (read-only for now)
+sbx run opencode ~/projects/backend ~/projects/frontend:ro
+```
+
+### Important Constraints
+
+| Constraint | Detail |
+|------------|--------|
+| Mounts are fixed at creation | You cannot add or remove workspaces from an existing sandbox |
+| Changing mounts requires recreation | `sbx rm <name>` then recreate with new paths |
+| `:ro` applies to extra workspaces only | Primary workspace is always read/write in direct mode |
+| Mounted content is visible to agent | Only mount what the agent needs to see |
+
+### When to Use Multi-Workspace
+
+| Use Case | Recommended Setup |
+|----------|-------------------|
+| Reference standards/skills from playbook | Primary: your app, Secondary: playbook `:ro` |
+| Cross-repo code review | Primary: repo under review, Secondary: related repos `:ro` |
+| Docs + implementation side by side | Primary: implementation, Secondary: docs `:ro` |
+| Monorepo-style multi-package work | Primary: one package, Secondary: shared libs `:ro` |
+
+### Security Recommendation
+
+Prefer read-only mounts for secondary workspaces unless the agent genuinely needs write access. This
+limits accidental modifications and reduces the blast radius of agent errors.
+
+---
+
 ## Working with Git Branches
 
 For branch isolation, use the `--clone` flag which creates an in-container clone of your repository:
@@ -396,6 +457,10 @@ sbx create --clone --name feature-work opencode .
 # git fetch sandbox-feature-work
 ```
 
+> [!WARNING]
+> Removing a clone-mode sandbox deletes the in-sandbox clone. Any commits you have not fetched
+> (`git fetch sandbox-<name>`) or pushed to an upstream remote are lost.
+
 Alternatively, check out the branch on your host before creating the sandbox:
 
 ```bash
@@ -405,6 +470,18 @@ git checkout feature/login
 # Create sandbox - it mounts the current branch
 sbx run opencode .
 ```
+
+### Clone Mode + Multiple Workspaces
+
+Clone mode and multiple workspaces work together. When using both:
+
+```bash
+sbx create --clone --name feature-work opencode ~/my-app ~/shared-libs:ro
+```
+
+- The primary workspace (`~/my-app`) is cloned inside the sandbox
+- Extra workspaces (`~/shared-libs:ro`) are mounted as-is (not cloned)
+- Use `git fetch sandbox-feature-work` to retrieve commits from the cloned primary
 
 ---
 


### PR DESCRIPTION
## Summary

Add documentation for mounting multiple directories into a single sandbox, based on Docker's
sbx multi-workspace pattern. Also refresh branch isolation guidance to match current sbx behavior.

## Changes

### Multi-Workspace Guidance (Fixes #112)

- Add dedicated **Multiple Workspaces** section to `docs/QUICKSTART_SBX.md`
- Document `:ro` suffix for read-only secondary mounts
- Add concrete examples:
  - App repo + playbook reference
  - Frontend + backend repos
- Clarify that mounts are fixed at creation time (changing requires `sbx rm` + recreate)
- Add cross-link from README to multi-workspace guidance

### Branch Isolation Refresh (Fixes #113)

- Add note that `--clone` replaced `--branch` in sbx v0.31.0
- Document the `sandbox-<name>` Git remote lifecycle (create/stop/run/rm)
- Add safe pattern for fetching commits before `sbx rm`
- Document Clone Mode + Multiple Workspaces combination
- Add warning about clone-mode sandbox deletion and unfetched commits

## Security Notes

- Recommends read-only mounts for secondary workspaces by default
- Warns that mounted content is visible to agent

## Issue Coverage

- Fixes #112
- Fixes #113

## Testing

- Pre-commit hooks pass (gitleaks, markdownlint)
- Commands verified against current sbx CLI documentation at docs.docker.com/ai/sandboxes/usage/
