### PR TITLE
fix(ci): add permissions block to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,5 +19,8 @@ permissions: {}
 jobs:
   release:
     uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-release-please.yml@workflows/v1
+    permissions:
+      contents: write
+      pull-requests: write
     with:
       release-type: simple


### PR DESCRIPTION
## Summary

Fixes the release workflow which was failing with `startup_failure` on every push to main.

## Problem

The release workflow uses a reusable workflow from the playbook repo:
```yaml
uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-release-please.yml@workflows/v1
```

Reusable workflows require the **caller** to explicitly grant permissions. The reusable workflow defines `permissions: {}` at the workflow level, so the caller must specify them at the job level.

## Solution

Added the required permissions block to the job:
```yaml
permissions:
  contents: write
  pull-requests: write
```

## Validation

- [x] YAML syntax valid
- [ ] Workflow runs successfully (will verify after merge)