### PR TITLE
fix(ci): use release-please directly instead of reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
-# Release - Consumes reusable workflow from playbook
-# See: https://github.com/GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-release-please.yml
-# Note: GITHUB_TOKEN is automatically inherited, no need to pass as secret
+# Release - Uses release-please directly (simpler than reusable workflow)
+# Based on: https://github.com/googleapis/release-please-action
 
 name: Release
 
@@ -17,10 +16,13 @@ concurrency:
 permissions: {}
 
 jobs:
-  release:
-    uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-release-please.yml@workflows/v1
+  release-please:
+    name: Release Please
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    with:
-      release-type: simple
+    steps:
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          release-type: simple


### PR DESCRIPTION
## Summary

Switches from reusable workflow to direct release-please-action usage.

## Rationale

The reusable workflow approach adds unnecessary complexity for a 3-repo ecosystem:
- Silent failures that are impossible to debug (no jobs, no logs)
- Cross-repo permission issues
- Extra indirection without proportional benefit

**Simpler approach:** Each repo has its own copy of the release workflow. This is appropriate for 3 repos - it's not duplication, it's self-contained simplicity.

## Changes

Replaces:
```yaml
uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-release-please.yml@workflows/v1
```

With direct usage (same as playbook):
```yaml
- uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
  with:
    release-type: simple
```

## Validation

- [x] YAML syntax valid
- [x] CI checks pass
- [ ] Release workflow runs successfully (verify after merge)

## Follow-up

Apply same change to agentic-coding-patterns repo.