### PR TITLE
chore(ci): convert to direct workflows

### DIFF
--- a/.github/workflows/markdown-quality.yml
+++ b/.github/workflows/markdown-quality.yml
@@ -1,6 +1,3 @@
-# Markdown Quality - Consumes reusable workflow from playbook
-# See: https://github.com/GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-markdown-quality.yml
-
 name: Markdown Quality
 
 on:
@@ -25,8 +22,29 @@ permissions:
   contents: read
 
 jobs:
-  markdown:
-    uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-markdown-quality.yml@workflows/v1
-    with:
-      run-link-check: true
-      continue-on-link-error: true
+  markdown-lint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530f12 # v20.0.0
+        with:
+          config: '.markdownlint-cli2.jsonc'
+          globs: '**/*.md'
+
+  link-check:
+    name: Link Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true  # External URLs can be flaky
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
+        with:
+          config-file: ".markdown-link-check.json"
+          use-quiet-mode: "yes"
+          folder-path: "."

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -35,27 +35,3 @@ jobs:
             PR title must follow conventional commits format:
             type: description (e.g., "feat: add new feature")
             Valid types: feat, fix, docs, chore, refactor, test, perf, ci
-
-  validate-commits:
-    name: Validate Commits
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Check commit messages
-        run: |
-          # Get commits in this PR
-          COMMITS=$(git log --format="%s" origin/${{ github.base_ref }}..${{ github.head_ref }} 2>/dev/null || echo "")
-          if [ -z "$COMMITS" ]; then
-            echo "No commits to check"
-            exit 0
-          fi
-
-          # Check each commit follows conventional commits
-          echo "$COMMITS" | while read -r msg; do
-            if ! echo "$msg" | grep -qE "^(feat|fix|docs|chore|refactor|test|perf|ci)(\(.+\))?!?: .+"; then
-              echo "::warning::Commit message doesn't follow conventional commits: $msg"
-            fi
-          done

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,15 +1,61 @@
-# PR Lint - Consumes reusable workflow from playbook
-# See: https://github.com/GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-pr-lint.yml
-# Note: GITHUB_TOKEN is automatically inherited, no need to pass as secret
-
 name: PR Lint
 
 on:
   pull_request:
     types: [opened, edited, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+
 jobs:
-  lint:
-    uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-pr-lint.yml@workflows/v1
-    with:
-      validate-commits: true
+  conventional-commits:
+    name: Conventional Commit Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            perf
+            ci
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            PR title must follow conventional commits format:
+            type: description (e.g., "feat: add new feature")
+            Valid types: feat, fix, docs, chore, refactor, test, perf, ci
+
+  validate-commits:
+    name: Validate Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check commit messages
+        run: |
+          # Get commits in this PR
+          COMMITS=$(git log --format="%s" origin/${{ github.base_ref }}..${{ github.head_ref }} 2>/dev/null || echo "")
+          if [ -z "$COMMITS" ]; then
+            echo "No commits to check"
+            exit 0
+          fi
+
+          # Check each commit follows conventional commits
+          echo "$COMMITS" | while read -r msg; do
+            if ! echo "$msg" | grep -qE "^(feat|fix|docs|chore|refactor|test|perf|ci)(\(.+\))?!?: .+"; then
+              echo "::warning::Commit message doesn't follow conventional commits: $msg"
+            fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
-# Release - Consumes reusable workflow from playbook
-# See: https://github.com/GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-release-please.yml
-# Note: GITHUB_TOKEN is automatically inherited, no need to pass as secret
+# Release - Uses release-please directly (simpler than reusable workflow)
+# Based on: https://github.com/googleapis/release-please-action
 
 name: Release
 
@@ -17,10 +16,13 @@ concurrency:
 permissions: {}
 
 jobs:
-  release:
-    uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-release-please.yml@workflows/v1
+  release-please:
+    name: Release Please
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    with:
-      release-type: simple
+    steps:
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          release-type: simple


### PR DESCRIPTION
## Summary

Converts all workflows from reusable (playbook) to direct implementations.

## Changes

| Workflow | Before | After |
|----------|--------|-------|
| `pr-lint.yml` | Reusable from playbook | Direct semantic-pull-request |
| `markdown-quality.yml` | Reusable from playbook | Direct markdownlint + link-check |
| `release.yml` | Reusable from playbook | Direct release-please |

## Rationale

For a 3-repo ecosystem, reusable workflows add more complexity than they save:
- Silent cross-repo failures (no jobs, no logs)
- Permission issues between repos
- Extra indirection layer

Direct workflows are:
- Self-contained and easy to understand
- Failures show up with actual logs
- No cross-repo dependencies

## Related

- PR #99 (playbook) - Removed reusable workflow files
- PR #130 - Initial release workflow fix (superseded by this PR)