### PR TITLE
fix(sbx): tighten zed secret setup workflow

### DIFF
--- a/.github/workflows/markdown-quality.yml
+++ b/.github/workflows/markdown-quality.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530f12 # v20.0.0
+        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20.0.0
         with:
           config: '.markdownlint-cli2.jsonc'
           globs: '**/*.md'

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,13 +1,19 @@
 [
   {
-    "label": "OpenCode: Run Agent",
+    "label": "USAi OpenCode: Run Agent",
     "command": "make run-agent",
     "use_new_terminal": true,
     "allow_concurrent_runs": false
   },
   {
-    "label": "OpenCode: Environment Diagnostics (make doctor)",
+    "label": "USAi OpenCode: Diagnostics (make doctor)",
     "command": "make doctor",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "USAi OpenCode: Set USAi API Key (SBX Secret)",
+    "command": "make setup-usai-secret",
     "use_new_terminal": true,
     "allow_concurrent_runs": false
   }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 # Agentic Coding Quickstart - Makefile
 # Simple commands for setting up and managing your AI-assisted development workspace
 
-.PHONY: setup doctor new-project clean install-hooks help init-project run-agent sync-models
+.PHONY: setup doctor new-project clean install-hooks help init-project setup-usai-secret run-agent reset-agent-sandbox sync-models
+
+PROJECT_SLUG ?= $(shell basename "$(CURDIR)" | tr -cs '[:alnum:].+-' '-' | sed 's/^-//; s/-$$//')
+SANDBOX_NAME ?= $(PROJECT_SLUG)
+USAI_MODELS_URL ?= https://api.gsa.usai.gov/api/v1/models
 
 # Default target
 help:
@@ -13,7 +17,9 @@ help:
 	@echo "  make doctor                - Run health checks on your environment"
 	@echo "  make new-project           - Create a new project directory (interactive)"
 	@echo "  make init-project TARGET_DIR=/path - Bootstrap a project directory (non-interactive)"
+	@echo "  make setup-usai-secret     - Store or reset USAI_API_KEY in SBX secrets"
 	@echo "  make run-agent             - Run OpenCode agent in SBX"
+	@echo "  make reset-agent-sandbox   - Remove the project SBX sandbox so it can be recreated"
 	@echo "  make sync-models           - Sync USAI model catalog (requires USAI_API_KEY)"
 	@echo "  make install-hooks         - [OPTIONAL] Install pre-commit hooks"
 	@echo "  make clean                 - Remove generated files"
@@ -54,21 +60,35 @@ _check-usai-key:
 		echo "  USAI_API_KEY: OK"; \
 	else \
 		echo "  USAI_API_KEY not found in SBX secrets."; \
-		read -s -p "Paste USAI_API_KEY value here: " key; \
-		echo ""; \
-		if [ -n "$$key" ]; then \
-			USAI_KEY="$$key" sh -c 'sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$$USAI_KEY"' || { \
-				echo "ERROR: Failed to store USAI_API_KEY in SBX secrets."; \
-				echo "  Check that SBX is running and you have permissions."; \
-				exit 1; \
-			}; \
-			echo "  USAI_API_KEY: Stored in SBX secrets"; \
-		else \
-			echo ""; \
-			echo "ERROR: USAI_API_KEY is required. Get your key at:"; \
-			echo "  https://console.gsa.usai.gov/key-management"; \
-			exit 1; \
-		fi; \
+		$(MAKE) --no-print-directory setup-usai-secret; \
+	fi
+
+setup-usai-secret: _check-sbx
+	@echo "Configuring USAI_API_KEY secret in SBX..."
+	@if sbx secret ls 2>/dev/null | grep -q "USAI_API_KEY"; then \
+		echo "  USAI_API_KEY is already present in SBX secrets."; \
+		read -p "Reset it? [y/N]: " confirm; \
+		case "$$confirm" in \
+			y|Y|yes|YES) echo "  Resetting USAI_API_KEY..."; echo "  USAi console: https://console.gsa.usai.gov/" ;; \
+			*) echo "  Keeping existing USAI_API_KEY secret."; exit 0 ;; \
+		esac; \
+	fi; \
+	read -s -p "Paste USAI_API_KEY value here: " key; \
+	echo ""; \
+	if [ -z "$$key" ]; then \
+		echo "ERROR: USAI_API_KEY is required. Get your key at:"; \
+		echo "  https://console.gsa.usai.gov/key-management"; \
+		exit 1; \
+	fi; \
+	USAI_KEY="$$key" sh -c 'sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$$USAI_KEY"' || { \
+		echo "ERROR: Failed to store USAI_API_KEY in SBX secrets."; \
+		echo "  Check that SBX is running and you have permissions."; \
+		exit 1; \
+	}; \
+	echo "  USAI_API_KEY: Stored in SBX secrets"; \
+	if sbx ls 2>/dev/null | awk 'NR > 1 {print $$1}' | grep -Fxq "$(SANDBOX_NAME)"; then \
+		echo "  Note: reset the existing sandbox to pick up changed custom secrets:"; \
+		echo "    make reset-agent-sandbox && make run-agent"; \
 	fi
 
 _clone-playbook:
@@ -194,10 +214,32 @@ _check-target-dir:
 clean:
 	@echo "Nothing to clean (this repo doesn't generate files)"
 
+
+_check-usai-api:
+	@echo "Checking USAi API access..."
+	@if sbx ls 2>/dev/null | awk 'NR > 1 {print $$1}' | grep -Fxq "$(SANDBOX_NAME)"; then \
+		echo "  Using USAI_API_KEY from SBX secret in sandbox: $(SANDBOX_NAME)"; \
+		sbx exec "$(SANDBOX_NAME)" sh -lc 'command -v curl >/dev/null 2>&1 || exit 64; test -n "$$USAI_API_KEY" || exit 65; curl -fsS --connect-timeout 10 --max-time 30 -H "Authorization: Bearer $$USAI_API_KEY" "$(USAI_MODELS_URL)" >/dev/null' >/dev/null 2>&1; \
+		case "$$?" in \
+			0) echo "  USAi API: OK" ;; \
+			64) echo "  [WARN] curl not found in sandbox; skipping preflight API check" ;; \
+			65) echo "ERROR: USAI_API_KEY is not available inside sandbox '$(SANDBOX_NAME)'."; echo "  Reset the sandbox so it picks up current SBX custom secrets:"; echo "    make reset-agent-sandbox && make run-agent"; exit 1 ;; \
+			*) echo "ERROR: USAi API check failed from sandbox '$(SANDBOX_NAME)'."; echo "  The key may be expired or invalid."; echo "  USAi console: https://console.gsa.usai.gov/"; echo "  Reset it with:"; echo "    make setup-usai-secret"; echo "  Then recreate the sandbox:"; echo "    make reset-agent-sandbox && make run-agent"; exit 1 ;; \
+		esac; \
+	else \
+		echo "  [WARN] Sandbox '$(SANDBOX_NAME)' does not exist yet; skipping preflight API check"; \
+		echo "         If auth fails after launch, visit https://console.gsa.usai.gov/ and run: make setup-usai-secret"; \
+	fi
+
 # Run OpenCode agent in sandbox with default name
-run-agent: _check-usai-key
-	@echo "Running OpenCode agent in SBX sandbox..."
-	@sbx run opencode .
+run-agent: _check-usai-key _check-usai-api
+	@echo "Running OpenCode agent in SBX sandbox: $(SANDBOX_NAME)"
+	@sbx run --name "$(SANDBOX_NAME)" opencode .
+
+reset-agent-sandbox:
+	@echo "Removing SBX sandbox: $(SANDBOX_NAME)"
+	@sbx rm "$(SANDBOX_NAME)" 2>/dev/null || true
+	@echo "Run 'make run-agent' to recreate it for this workspace."
 
 # Install pre-commit hooks (optional)
 install-hooks:  ## [OPTIONAL] Install pre-commit hooks

--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ AI coding agents can read files, write code, and execute commands. Running them 
 
 If you use the **Zed Editor**, pre-configured tasks are available in `.zed/tasks.json`:
 
-- **OpenCode: Run Agent** — Launch the agent in your sandbox
-- **OpenCode: Environment Diagnostics** — Run `make doctor`
+- **USAi OpenCode: Run Agent** — Launch the agent in your sandbox
+- **USAi OpenCode: Diagnostics** — Run `make doctor`
+- **USAi OpenCode: Set USAi API Key** — Store or reset `USAI_API_KEY` as an SBX custom secret
 
 See the **[Zed Editor Setup Guide](docs/ZED_SETUP.md)** for detailed instructions.
 

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -544,6 +544,42 @@ Always choose "Balanced" (Option 2) when prompted. The Balanced policy allows ty
 
 ---
 
+## 18. SBX Fails to Start with Host Path `chdir` Error
+
+### Symptoms
+
+- Zed task or `make run-agent` exits after printing an OCI runtime error
+- Error includes: `OCI runtime exec failed: chdir to '/Users/.../your-project': no such file or directory`
+- The task runner may still report the task as finished successfully
+
+### Root Cause
+
+SBX cached sandbox metadata can point at a workspace path that is not available inside the container. This is most likely after moving, renaming, or reprovisioning a project, or after reusing a loosely named/default sandbox.
+
+### Fix
+
+Generated projects use a deterministic sandbox name based on the current directory. Remove that sandbox and let SBX recreate it from the current workspace:
+
+```bash
+make reset-agent-sandbox
+make run-agent
+```
+
+If you override the sandbox name, pass the same name to both commands:
+
+```bash
+make reset-agent-sandbox SANDBOX_NAME=my-project
+make run-agent SANDBOX_NAME=my-project
+```
+
+You can also inspect the cached workspace path directly:
+
+```bash
+sbx ls
+```
+
+---
+
 ## Debugging Checklist
 
 When something fails, work through this list:

--- a/docs/ZED_SETUP.md
+++ b/docs/ZED_SETUP.md
@@ -53,15 +53,16 @@ You will see several tasks preconfigured for this workspace:
 
 | Task Label | Description | Underlying Command |
 |------------|-------------|--------------------|
-| `OpenCode: Run Agent` | Launches OpenCode inside SBX (secrets auto-injected, creates sandbox if needed) | `make run-agent` |
-| `OpenCode: Environment Diagnostics` | Performs health checks on your Docker & SBX setup | `make doctor` |
+| `USAi OpenCode: Run Agent` | Launches OpenCode inside a project-named SBX sandbox (secrets auto-injected, creates sandbox if needed) | `make run-agent` |
+| `USAi OpenCode: Diagnostics (make doctor)` | Performs health checks on your Docker & SBX setup | `make doctor` |
+| `USAi OpenCode: Set USAi API Key (SBX Secret)` | Prompts for `USAI_API_KEY` and stores it as an SBX custom secret | `make setup-usai-secret` |
 
 > **Note:** The deprecated Docker Desktop tasks have been removed. Use the `sbx` CLI tasks above.
 
 ### 3. Step-by-Step Workflow inside Zed
 
-1. **Run Diagnostics:** Open the tasks palette and select `OpenCode: Environment Diagnostics (make doctor)`. It will open a panel in Zed and verify your Docker and setup states.
-2. **Launch OpenCode Agent:** Select `OpenCode: Run Agent`. This creates the sandbox if needed and launches the agent.
+1. **Run Diagnostics:** Open the tasks palette and select `USAi OpenCode: Diagnostics (make doctor)`. It will open a panel in Zed and verify your Docker and setup states.
+2. **Launch OpenCode Agent:** Select `USAi OpenCode: Run Agent`. This creates the sandbox if needed and launches the agent.
 3. **Interact with the Agent:** The agent will boot inside a terminal panel in Zed. You can type prompts directly to the agent (e.g. *"Analyze the directory structure and check for AGENTS.md"*).
 4. **Interactive Approvals:** Because our `opencode.jsonc` is configured with `"edit": "ask"` and `"bash": "ask"` for safety, the agent will prompt you in the terminal for approval before making file changes or running mutating shell commands. Type `y` or `n` directly into the Zed terminal tab to respond.
 
@@ -75,7 +76,14 @@ If you prefer to run commands manually, you can open Zed's integrated terminal (
 # Check if your environment is healthy
 make doctor
 
+# Store or reset your USAi key in SBX secrets
+make setup-usai-secret
+
 # Run agent (creates sandbox automatically if needed)
+make run-agent
+
+# Remove and recreate the project sandbox if SBX cached a stale workspace path
+make reset-agent-sandbox
 make run-agent
 ```
 
@@ -107,27 +115,16 @@ cp templates/SBX_PATTERNS.md "$TARGET_REPO/docs/"
 tail -n +6 templates/AGENTS_SBX_ADDENDUM.md >> "$TARGET_REPO/AGENTS.md"
 ```
 
-### Step 2: Configure your `Makefile`
+### Step 2: Use the generated `Makefile`
 
-Add these targets to your target repository's `Makefile` so that the Zed tasks function properly:
+The bootstrap copies this repository's `Makefile` into the target project. That file provides the Zed task targets:
 
-```makefile
-# Create SBX sandbox using sbx CLI
-create-sandbox:
- @echo "Creating SBX sandbox..."
- @if sbx ls | grep -q "my-sandbox"; then \
-  echo "Sandbox already exists. Skipping creation."; \
- else \
-  sbx create --name my-sandbox opencode .; \
- fi
+- `make setup-usai-secret` prompts for `USAI_API_KEY`, confirms before replacing an existing SBX secret, and points reset users to `https://console.gsa.usai.gov/`.
+- `make doctor` checks local tooling, SBX access, SBX secret presence, and workspace files.
+- `make run-agent` uses the current directory name as the SBX sandbox name and checks USAi API access from an existing sandbox before launch.
+- `make reset-agent-sandbox` removes the project sandbox so changed custom secrets or workspace paths can be picked up.
 
-# Run OpenCode agent in sandbox using sbx CLI
-run-agent:
- @echo "Running OpenCode agent in SBX sandbox..."
- @sbx run my-sandbox
-```
-
-*(Note: If your sandbox name is different than `my-sandbox`, make sure to update the name in the `Makefile` and `.zed/tasks.json` to match!)*
+The default sandbox name is the current directory name. You can override it with `SANDBOX_NAME=my-project make run-agent`.
 
 ---
 
@@ -161,3 +158,12 @@ run-agent:
 ### Terminal Output is Frozen or Unresponsive
 - If a task runs and does not respond to keystrokes, close the terminal pane (`Cmd + W`) and trigger the task again via the tasks palette.
 - Standard interactive shells are fully supported, but if you run into environment issues, run `make run-agent` directly in Zed's integrated terminal (`Ctrl + ~`) instead of the task runner.
+
+### `OCI runtime exec failed: chdir ... no such file or directory`
+- SBX may be trying to reuse cached workspace metadata for a sandbox whose host path changed or was never mounted correctly.
+- Remove the project sandbox and let `make run-agent` recreate it from the current directory:
+  ```bash
+  make reset-agent-sandbox
+  make run-agent
+  ```
+- See [KNOWN_FAILURE_MODES.md](KNOWN_FAILURE_MODES.md#18-sbx-fails-to-start-with-host-path-chdir-error) for details.

--- a/templates/zed-tasks.json
+++ b/templates/zed-tasks.json
@@ -1,13 +1,19 @@
 [
   {
-    "label": "OpenCode: Run Agent (Standalone CLI)",
+    "label": "USAi OpenCode: Run Agent",
     "command": "make run-agent",
     "use_new_terminal": true,
     "allow_concurrent_runs": false
   },
   {
-    "label": "OpenCode: Environment Diagnostics (make doctor)",
+    "label": "USAi OpenCode: Diagnostics (make doctor)",
     "command": "make doctor",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "USAi OpenCode: Set USAi API Key (SBX Secret)",
+    "command": "make setup-usai-secret",
     "use_new_terminal": true,
     "allow_concurrent_runs": false
   }


### PR DESCRIPTION
## Summary
- add a Zed task and Make target for setting or resetting the USAi SBX custom secret
- use the current directory name as the default SBX sandbox name and add a reset target for stale sandbox paths
- keep `make doctor` lightweight while adding a `run-agent` preflight for expired sandbox credentials
- align Zed docs, task labels, and troubleshooting guidance

## Validation
- `node -e 'for (const f of ["templates/zed-tasks.json", ".zed/tasks.json"]) { JSON.parse(require("fs").readFileSync(f,"utf8")); console.log(f+" OK") }'`\n- `make help`\n- `make doctor`\n- `printf 'n\\n' | make setup-usai-secret`\n- `make -n run-agent`\n- `SANDBOX_NAME=__quickstart_validation_noop__ make reset-agent-sandbox`\n- `make -n init-project TARGET_DIR="$PWD/.tmp-validate-project"`\n- `npm test`\n\nAI-assisted: yes\n