### PR TITLE
chore(models): sync USAI catalog with new Opus 4.8, 4.7 and Sonnet 4.6

### DIFF
--- a/templates/opencode.jsonc
+++ b/templates/opencode.jsonc
@@ -78,6 +78,34 @@
       "models": {
         // BEGIN GENERATED USAI MODELS
         // Anthropic Models
+        "claude_4_8_opus": {
+          "name": "Claude 4.8 Opus",
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          }
+        },
+        "claude_4_7_opus": {
+          "name": "Claude 4.7 Opus",
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          }
+        },
+        "claude_4_6_sonnet": {
+          "name": "Claude 4.6 Sonnet",
+          "limit": {
+            "context": 1000000,
+            "output": 64000
+          }
+        },
+        "claude_4_5_haiku": {
+          "name": "Claude 4.5 Haiku",
+          "limit": {
+            "context": 200000,
+            "output": 64000
+          }
+        },
         "claude_4_5_opus": {
           "name": "Claude 4.5 Opus",
           "limit": {
@@ -101,6 +129,13 @@
         },
 
         // OpenAI Models
+        "gpt-5.5-latest-guardrails-defaultv2": {
+          "name": "GPT 5.5 Latest Guardrails Defaultv2",
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          }
+        },
         "gpt-5.4-latest-guardrails-defaultv2": {
           "name": "GPT-5.4 Latest — Guardrails Default v2",
           "limit": {
@@ -163,14 +198,14 @@
   // ===========================================================================
   // MODEL SELECTION
   // ===========================================================================
-  "model": "usai/claude_4_5_opus",
-  "small_model": "usai/claude_3_5_haiku",
+  "model": "usai/claude_4_8_opus",
+  "small_model": "usai/claude_4_5_haiku",
   // ===========================================================================
   // AGENT CONFIGURATION
   // ===========================================================================
   "agent": {
     "compaction": {
-      "model": "usai/gpt-5.4-latest-guardrails-defaultv2",
+      "model": "usai/gpt-5.5-latest-guardrails-defaultv2",
       "temperature": 0
     },
     "summary": {


### PR DESCRIPTION
## Summary

Syncs the USAI model catalog with newly available models.

## New Models Added

| Model | Vendor | Context | Output |
|-------|--------|---------|--------|
| `claude_4_8_opus` | Anthropic | 1M | 128K |
| `claude_4_7_opus` | Anthropic | 1M | 128K |
| `claude_4_6_sonnet` | Anthropic | 1M | 64K |
| `claude_4_5_haiku` | Anthropic | 200K | 64K |
| `gpt-5.5-latest-guardrails-defaultv2` | OpenAI | 400K | 128K |

## Default Model Updates

| Setting | Before | After |
|---------|--------|-------|
| `model` | `claude_4_5_opus` | `claude_4_8_opus` |
| `small_model` | `claude_3_5_haiku` | `claude_4_5_haiku` |
| `agent.compaction.model` | `gpt-5.4-latest` | `gpt-5.5-latest` |

## Verification

```bash
make sync-models
```

Generated automatically from USAI `/v1/models` API.