### PR TITLE
fix(ci): update markdownlint-cli2-action SHA to v23.2.0

### DIFF
--- a/.github/workflows/markdown-quality.yml
+++ b/.github/workflows/markdown-quality.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530f12 # v20.0.0
+        uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
         with:
           config: '.markdownlint-cli2.jsonc'
           globs: '**/*.md'


### PR DESCRIPTION
## Summary

Updates the markdownlint-cli2-action SHA after the previous one was invalidated by an upstream force push.

## Problem

The pinned SHA `db43aef879112c3119a410d69f66701e0d530f12` no longer exists. The upstream maintainer (DavidAnson) did a force push on 2026-05-17 while adding `package-lock.json` for reproducible builds.

## Verification

- ✅ Confirmed this is **not a compromise** — DavidAnson is the original author of markdownlint (Microsoft employee, GitHub account since 2012)
- ✅ The force push was part of normal maintenance per release notes
- ✅ New SHA corresponds to tagged release v23.2.0

## Changes

| Action | Old | New |
|--------|-----|-----|
| SHA | `db43aef...` (deleted) | `ded1f94...` |
| Version | v20.0.0 | v23.2.0 |

## Release Notes (v20 → v23)

- Adds `package-lock.json` for reproducible builds
- Updates to Node.js 24
- markdownlint-cli2 v0.22.1, markdownlint v0.40.0