### PR TITLE
chore(security): harden remote fetches in sync-usai-models.mjs (#138)

### DIFF
--- a/scripts/sync-usai-models.mjs
+++ b/scripts/sync-usai-models.mjs
@@ -27,6 +27,13 @@ const DISPLAY_NAME_OVERRIDES = {
 const DEFAULT_TEMPLATE_PATH = path.resolve("templates/opencode.jsonc")
 const DEFAULT_FIXTURE_PATH = path.resolve("tests/fixtures/usai-models.json")
 const MODELS_DEV_URL = "https://models.dev/models.json"
+const USAI_MODELS_URL = "https://api.gsa.usai.gov/api/v1/models"
+
+// Network hardening limits (Issue #138). Remote feeds (USAi API, models.dev)
+// are third-party content written into committed config, so we bound time and
+// size and validate the shape before trusting the response.
+const FETCH_TIMEOUT_MS = 15000
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024 // 10 MiB
 
 // Fallback limits for models not found in models.dev
 const FALLBACK_LIMITS = {
@@ -253,17 +260,129 @@ function findModelsDevMatch(usaiId, catalog) {
 }
 
 /**
+ * Fetch with a timeout and a hard response-size cap. Remote feeds are
+ * untrusted third-party content, so we never read an unbounded body and we
+ * always bound the request time. (Issue #138)
+ * @param {string} url
+ * @param {object} [options] - fetch options
+ * @returns {Promise<unknown>} parsed JSON
+ */
+async function fetchJsonBounded(url, options = {}) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? FETCH_TIMEOUT_MS)
+
+  let response
+  try {
+    response = await fetch(url, { ...options, signal: controller.signal })
+  } catch (err) {
+    if (err.name === "AbortError") {
+      throw new Error(`request to ${url} timed out after ${FETCH_TIMEOUT_MS}ms`)
+    }
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "(no body)")
+    throw new Error(`request to ${url} failed: ${response.status} ${response.statusText} - ${body.slice(0, 200)}`)
+  }
+
+  // Reject obviously-oversized payloads up front when the server advertises a
+  // length; otherwise enforce the cap while streaming the body.
+  const declaredLength = Number(response.headers.get("content-length") || "0")
+  if (declaredLength > MAX_RESPONSE_BYTES) {
+    throw new Error(`response from ${url} too large: ${declaredLength} bytes > ${MAX_RESPONSE_BYTES}`)
+  }
+
+  const text = await readBodyCapped(response, url)
+  try {
+    return JSON.parse(text)
+  } catch (err) {
+    throw new Error(`response from ${url} was not valid JSON: ${err.message}`)
+  }
+}
+
+/**
+ * Read a Response body, aborting if it exceeds MAX_RESPONSE_BYTES.
+ * @param {Response} response
+ * @param {string} url
+ * @returns {Promise<string>}
+ */
+async function readBodyCapped(response, url) {
+  if (!response.body || typeof response.body.getReader !== "function") {
+    // Environments without a streaming body (e.g. some test doubles): fall
+    // back to text() but still enforce the byte cap afterwards.
+    const text = await response.text()
+    if (Buffer.byteLength(text, "utf8") > MAX_RESPONSE_BYTES) {
+      throw new Error(`response from ${url} exceeded ${MAX_RESPONSE_BYTES} bytes`)
+    }
+    return text
+  }
+
+  const reader = response.body.getReader()
+  const chunks = []
+  let total = 0
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    total += value.byteLength
+    if (total > MAX_RESPONSE_BYTES) {
+      await reader.cancel().catch(() => {})
+      throw new Error(`response from ${url} exceeded ${MAX_RESPONSE_BYTES} bytes`)
+    }
+    chunks.push(value)
+  }
+  return Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf8")
+}
+
+/**
+ * Validate that a USAi models payload has the expected shape before we trust
+ * it enough to rewrite committed config. Accepts a top-level array, or an
+ * object with a `data` or `models` array. (Issue #138)
+ * @param {unknown} payload
+ * @returns {unknown} the same payload (for chaining)
+ */
+function validateUsaiPayload(payload) {
+  const list = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.data)
+      ? payload.data
+      : Array.isArray(payload?.models)
+        ? payload.models
+        : null
+
+  if (!list) {
+    throw new Error("USAi payload invalid: expected an array or { data | models: [] }")
+  }
+  if (list.length === 0) {
+    throw new Error("USAi payload invalid: model list is empty")
+  }
+  const hasUsableId = list.some(
+    (m) => m && typeof m === "object" && (m.id || m.model_id || m.name),
+  )
+  if (!hasUsableId) {
+    throw new Error("USAi payload invalid: no entries have an id/model_id/name field")
+  }
+  return payload
+}
+
+export { validateUsaiPayload, fetchJsonBounded }
+
+/**
  * Fetch and parse the models.dev catalog.
  * @returns {Promise<Object>} Catalog keyed by model ID
  */
 async function fetchModelsDevCatalog() {
   try {
-    const response = await fetch(MODELS_DEV_URL)
-    if (!response.ok) {
-      console.error(`models.dev fetch failed: ${response.status}`)
+    const catalog = await fetchJsonBounded(MODELS_DEV_URL)
+    // models.dev returns an object keyed by id; reject anything else rather
+    // than feeding a malformed catalog into the enrichment matcher.
+    if (!catalog || typeof catalog !== "object" || Array.isArray(catalog)) {
+      console.error("models.dev catalog has unexpected shape; skipping enrichment")
       return {}
     }
-    return response.json()
+    return catalog
   } catch (err) {
     console.error(`models.dev fetch error: ${err.message}`)
     return {}
@@ -483,12 +602,12 @@ async function loadPayload(args) {
   const useFixture = args.includes("--fixture") || fixtureArg || !process.env.USAI_API_KEY
 
   if (useFixture) {
-    return JSON.parse(await readFile(fixturePath, "utf8"))
+    return validateUsaiPayload(JSON.parse(await readFile(fixturePath, "utf8")))
   }
 
-  let response
+  let payload
   try {
-    response = await fetch("https://api.gsa.usai.gov/api/v1/models", {
+    payload = await fetchJsonBounded(USAI_MODELS_URL, {
       headers: {
         accept: "application/json",
         authorization: `Bearer ${process.env.USAI_API_KEY}`,
@@ -498,12 +617,7 @@ async function loadPayload(args) {
     throw new Error(`USAI API fetch failed: ${err.message}`)
   }
 
-  if (!response.ok) {
-    const body = await response.text().catch(() => "(no body)")
-    throw new Error(`USAI models request failed: ${response.status} ${response.statusText} - ${body}`)
-  }
-
-  return response.json()
+  return validateUsaiPayload(payload)
 }
 
 async function main() {

--- a/tests/sync-usai-models.test.mjs
+++ b/tests/sync-usai-models.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 import vm from "node:vm"
 
-import { updateTemplate } from "../scripts/sync-usai-models.mjs"
+import { updateTemplate, validateUsaiPayload, fetchJsonBounded } from "../scripts/sync-usai-models.mjs"
 
 const templatePath = new URL("../templates/opencode.jsonc", import.meta.url)
 const fixturePath = new URL("./fixtures/usai-models.json", import.meta.url)
@@ -274,4 +274,122 @@ test("updateTemplate handles version matching across naming conventions", async 
   assert.ok(claude, "claude model should exist")
   assert.equal(claude.contextWindow, 200000)
   assert.equal(claude.modelsDevId, "anthropic/claude-4.5-sonnet")
+})
+
+test("validateUsaiPayload accepts array, { data }, and { models } shapes", () => {
+  const entry = [{ id: "claude_4_5_opus", name: "Claude 4.5 Opus" }]
+  assert.deepEqual(validateUsaiPayload(entry), entry)
+
+  const dataShape = { data: entry }
+  assert.deepEqual(validateUsaiPayload(dataShape), dataShape)
+
+  const modelsShape = { models: entry }
+  assert.deepEqual(validateUsaiPayload(modelsShape), modelsShape)
+})
+
+test("validateUsaiPayload accepts entries keyed by model_id or name only", () => {
+  assert.doesNotThrow(() => validateUsaiPayload([{ model_id: "gpt-5.5" }]))
+  assert.doesNotThrow(() => validateUsaiPayload({ data: [{ name: "Claude 4.8 Opus" }] }))
+})
+
+test("validateUsaiPayload rejects malformed payloads", () => {
+  // Wrong top-level shape
+  assert.throws(() => validateUsaiPayload({}), /expected an array/)
+  assert.throws(() => validateUsaiPayload(null), /expected an array/)
+  assert.throws(() => validateUsaiPayload("nope"), /expected an array/)
+  // Empty list
+  assert.throws(() => validateUsaiPayload([]), /empty/)
+  assert.throws(() => validateUsaiPayload({ data: [] }), /empty/)
+  // No usable identifier on any entry
+  assert.throws(() => validateUsaiPayload([{ foo: "bar" }]), /id\/model_id\/name/)
+})
+
+// --- fetchJsonBounded network hardening (Issue #138) ---
+
+function withStubbedFetch(stub, fn) {
+  const original = globalThis.fetch
+  globalThis.fetch = stub
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      globalThis.fetch = original
+    })
+}
+
+function jsonResponse(body, { ok = true, status = 200, headers = {} } = {}) {
+  const text = typeof body === "string" ? body : JSON.stringify(body)
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    headers: { get: (k) => headers[k.toLowerCase()] ?? null },
+    body: null, // force the text() fallback path in readBodyCapped
+    text: async () => text,
+  }
+}
+
+test("fetchJsonBounded parses a well-formed JSON response", async () => {
+  await withStubbedFetch(
+    async () => jsonResponse({ ok: true, data: [1, 2, 3] }),
+    async () => {
+      const result = await fetchJsonBounded("https://example.test/feed.json")
+      assert.deepEqual(result, { ok: true, data: [1, 2, 3] })
+    },
+  )
+})
+
+test("fetchJsonBounded throws on non-OK responses", async () => {
+  await withStubbedFetch(
+    async () => jsonResponse("nope", { ok: false, status: 503 }),
+    async () => {
+      await assert.rejects(
+        () => fetchJsonBounded("https://example.test/feed.json"),
+        /failed: 503/,
+      )
+    },
+  )
+})
+
+test("fetchJsonBounded throws on invalid JSON", async () => {
+  await withStubbedFetch(
+    async () => jsonResponse("{not json", { headers: { "content-type": "application/json" } }),
+    async () => {
+      await assert.rejects(
+        () => fetchJsonBounded("https://example.test/feed.json"),
+        /not valid JSON/,
+      )
+    },
+  )
+})
+
+test("fetchJsonBounded rejects payloads over the size cap (declared length)", async () => {
+  await withStubbedFetch(
+    async () => jsonResponse({ a: 1 }, { headers: { "content-length": String(50 * 1024 * 1024) } }),
+    async () => {
+      await assert.rejects(
+        () => fetchJsonBounded("https://example.test/feed.json"),
+        /too large/,
+      )
+    },
+  )
+})
+
+test("fetchJsonBounded aborts on timeout", async () => {
+  await withStubbedFetch(
+    (_url, opts) =>
+      new Promise((_resolve, reject) => {
+        // Never resolves on its own; reject when the AbortController fires.
+        opts.signal.addEventListener("abort", () => {
+          const err = new Error("aborted")
+          err.name = "AbortError"
+          reject(err)
+        })
+      }),
+    async () => {
+      await assert.rejects(
+        () => fetchJsonBounded("https://example.test/slow.json", { timeoutMs: 10 }),
+        /timed out/,
+      )
+    },
+  )
 })


### PR DESCRIPTION
## Summary

The USAi API (`api.gsa.usai.gov`) and `models.dev` are third-party feeds whose responses get written into the committed `opencode.jsonc`. Before this change the fetches had **no timeout, no response-size cap, and no shape validation** — a hung, oversized, or malformed/hijacked response could stall the sync or inject arbitrary entries into config. (TLS already covered transport; this is about content integrity + availability.)

## Changes
- **`fetchJsonBounded()`** — single hardened fetch helper used by both feeds:
  - `AbortController` timeout (15s default, per-call overridable).
  - **10 MiB response cap**, enforced via a streaming reader (with a `text()` fallback for non-streaming bodies) and an early check of `content-length` when advertised.
  - Explicit non-OK handling (truncated body in the error) and JSON-parse error wrapping.
- **`validateUsaiPayload()`** — requires a non-empty array (or `{ data }` / `{ models }` array) with at least one entry carrying `id`/`model_id`/`name`; applied to **both** the fixture and live-API paths before the data is used.
- models.dev catalog: reject anything that isn't a keyed object rather than feeding a malformed catalog into the matcher.

## Tests
8 new cases (payload-shape accept/reject; bounded-fetch parse / non-OK / invalid-JSON / size-cap / timeout). **Full suite: 19/19 pass** (`node --test`). Existing `--check` behavior unchanged (verified pre/post against the fixture and live models.dev).

## Closes
Closes #138

AI-assisted (OpenCode).

Co-authored-by: OpenCode Agent <ai-agent@gsa.gov>