### PR TITLE
fix(web): run opencode web detached via sbx exec

### DIFF
--- a/opencode-web.sh
+++ b/opencode-web.sh
@@ -7,6 +7,9 @@
 
 sandbox="${1:?Usage: $0 <sandbox-name>}"
 
-sbx run "$sandbox" -- web --hostname 0.0.0.0 --port 4096 &
+# Run the sandbox detached with opencode web
+sbx exec -d "$sandbox" sh -lc 'nohup opencode web --hostname 0.0.0.0 --port 4096' &
+
+# Poll + publish ports
 until sbx ports "$sandbox" --publish 4096:4096 2>/dev/null; do sleep 1; done
 echo "Ready: $sandbox on port 4096"


### PR DESCRIPTION
## Summary

Restores `opencode-web.sh` after a behavior change in the Docker Sandbox CLI (`sbx`) broke it. A recent `sbx` release changed `sbx run` to execute **attached** (it allocates a TTY differently than the way it previously did), which prevented the OpenCode Web server from remaining active in the background.

This switches to `sbx exec -d` with `nohup` so the web server runs **detached** inside the sandbox.

## Root Cause

- A recent Docker Sandbox CLI update changed `sbx run` to run attached.
- The previous script relied on `sbx run ... &` staying backgrounded; under the new behavior it no longer did.

## Changes

- Replace `sbx run "$sandbox" -- web ...` with `sbx exec -d "$sandbox" sh -lc 'nohup opencode web --hostname 0.0.0.0 --port 4096'`
- Add inline comments documenting the detached-run and port-poll/publish steps

## Why this fix

- `sbx exec -d` runs the sandbox detached, sidestepping the new attached behavior of `sbx run`
- `nohup` keeps the web process alive independent of the launching 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits format](../CONTRIBUTING.md#commit-message-guidelines) (e.g., `feat:`, `fix:`, `docs:`)
- [x] I have tested my changes locally
- [x] I have updated documentation as needed
- [x] I have not included any secrets, API keys, or sensitive information

## Test Results

- [x] `./opencode-web.sh <sandbox-name>` starts the server and prints `Ready: <sandbox> on port 4096`
- [x] `http://127.0.0.1:4096` is reachable from the host
- [x] `sbx stop <sandbox-name>` cleanly stops it

