### PR TITLE
docs: fix #142-independent doc accuracy issues from cross-repo review

### DIFF
--- a/.github/workflows/markdown-quality.yml
+++ b/.github/workflows/markdown-quality.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - '**/*.md'
-      - '.markdownlint-cli2.jsonc'
+      - '.markdownlint-cli2.yaml'
       - '.markdown-link-check.json'
       - '.github/linters/package*.json'
   push:
@@ -12,7 +12,7 @@ on:
       - main
     paths:
       - '**/*.md'
-      - '.markdownlint-cli2.jsonc'
+      - '.markdownlint-cli2.yaml'
       - '.markdown-link-check.json'
       - '.github/linters/package*.json'
 

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,13 @@
+{
+  "ignorePatterns": [
+    { "pattern": "^https://api\\.gsa\\.usai\\.gov" },
+    { "pattern": "^https://workshop\\.cloud\\.gov" },
+    { "pattern": "^https?://localhost" },
+    { "pattern": "^https?://127\\.0\\.0\\.1" }
+  ],
+  "timeout": "20s",
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206, 403, 429]
+}

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ sync-models:
 			echo "  Note: Run this inside SBX or export the key manually"; \
 			echo ""; \
 			echo "  To run inside SBX:"; \
-			echo "    sbx run --rm -it node:22 bash -c 'npm ci && npm run sync'"; \
+			echo "    sbx run --rm -it node:22 bash -c 'npm run sync:usai-models'"; \
 			echo ""; \
 			echo "  Or export the key and run locally:"; \
 			echo "    export USAI_API_KEY='your-key-here'"; \

--- a/README.md
+++ b/README.md
@@ -429,5 +429,3 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 ---
 
 **Data Classification:** Internal/Non-sensitive
-
-# CI trigger

--- a/docs/CODING_PRACTICES.md
+++ b/docs/CODING_PRACTICES.md
@@ -8,7 +8,7 @@ nist_controls: ["SA-8", "SA-11", "SA-12", "SA-15", "SA-17", "SI-2", "SI-4", "SI-
 frameworks: ["NIST SP 800-53 Rev 5.2", "NIST SP 800-218A", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026", "CISA Secure by Design"]
 audience: "developers"
 keywords: ["secure-coding", "input-validation", "secrets-management", "supply-chain", "SBOM", "OWASP", "SSDF", "TDD", "SOLID", "YAGNI", "DRY", "ADR", "design-by-contract", "bias-testing", "fairness", "model-evaluation", "continuous-monitoring", "model-drift"]
-related_files: ["AGENTS.md", "docs/SECURITY-CONTROLS.md", "checklists/pre-deployment.md"]
+related_files: ["AGENTS.md", "https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/SECURITY-CONTROLS.md", "https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/checklists/pre-deployment.md"]
 load_priority: "always"
 review_cycle: "quarterly"
 ---


### PR DESCRIPTION
## Summary

Fixes the quickstart documentation-accuracy findings from the Session 48 cross-repo review that are **independent of the open refactor PR #142** (the #142-dependent items — templates/Makefile/init-project provisioning docs — are deferred until #142's fate is decided).

## Changes
- **`docs/CODING_PRACTICES.md:11`** — `related_files` pointed at `docs/SECURITY-CONTROLS.md` and `checklists/pre-deployment.md`, which **don't exist in this repo** (they live in the playbook). Repointed to the playbook URLs.
- **`.github/workflows/markdown-quality.yml`** — path triggers referenced `.markdownlint-cli2.jsonc`, but the config is `.markdownlint-cli2.yaml`, so **config edits never triggered the workflow**. Fixed both trigger blocks.
- **`.markdown-link-check.json`** — the `link-check` job referenced this file via `config-file` but it **didn't exist**. Added it (ignores USAi/cloud.gov/localhost, sane timeout/retry, treats 403/429 as alive).
- **`Makefile:222`** — the SBX hint ran `npm ci && npm run sync`, but there's no `sync` script (it's `sync:usai-models`) and no install is needed. Fixed.
- **`README.md`** — removed the trailing `# CI trigger` scaffolding line.

## Note on overlap with #146
`docs/CODING_PRACTICES.md` is also touched by open PR #146 (line 410, commitlint wording) — these are **different lines** and merge cleanly in either order.

## Verification
- `actionlint` → CLEAN.
- `.markdown-link-check.json` → valid JSON.

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>