### PR TITLE
ci: exclude release-please CHANGELOG.md from markdownlint

### DIFF
--- a/.github/workflows/markdown-quality.yml
+++ b/.github/workflows/markdown-quality.yml
@@ -45,7 +45,7 @@ jobs:
           npm audit --audit-level=high
 
       - name: Run markdownlint
-        run: npx --prefix .github/linters markdownlint-cli2 "**/*.md" "#node_modules" "#.github/linters/node_modules"
+        run: npx --prefix .github/linters markdownlint-cli2 "**/*.md" "#node_modules" "#.github/linters/node_modules" "#CHANGELOG.md" "#agentic-coding-playbook"
 
   link-check:
     name: Link Check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@
 # All hooks pinned to commit SHAs for supply chain security (NIST SA-12)
 
 # The playbook is a pinned git submodule; it has its own hooks/CI. Don't lint it
-# from this repo.
-exclude: '^agentic-coding-playbook/'
+# from this repo. CHANGELOG.md is release-please-generated; don't lint/reformat it.
+exclude: '^(agentic-coding-playbook/|CHANGELOG\.md$)'
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Context

`main` CI has been **red since the v0.10.0 release commit** (#132). release-please regenerates `CHANGELOG.md` with formatting markdownlint-cli2 rejects (`MD012/no-multiple-blanks` at the section breaks), which fails:

- **Markdown Quality** → `Markdown Lint` (2 errors on `CHANGELOG.md:10,20`)
- **Pre-commit** → `markdownlint-cli2 --fix` reformats the file → "files were modified by this hook" → exit 1

Every future release commit would re-break `main` the same way.

## Plan / Change

- `.github/workflows/markdown-quality.yml`: add `#CHANGELOG.md` (and the `#agentic-coding-playbook` submodule guard) to the markdownlint-cli2 glob.
- `.pre-commit-config.yaml`: extend the top-level `exclude` to also skip `CHANGELOG.md`.

This matches the **existing convention in the playbook and patterns repos**, which both already pass `#CHANGELOG.md` to markdownlint-cli2. CHANGELOG.md is a generated artifact — it should not be hand-linted or auto-reformatted.

## Verification

```
$ npx --prefix .github/linters markdownlint-cli2 "**/*.md" "#node_modules" "#.github/linters/node_modules" "#CHANGELOG.md" "#agentic-coding-playbook"
Linting: 17 file(s)
Summary: 0 error(s)
```

Pre-commit regex validated (`^(agentic-coding-playbook/|CHANGELOG\.md$)`); markdownlint/shellcheck hooks correctly skip with no in-scope files.

## Rollback

Revert this commit; restores the prior globs (and the red gate).

## Security Impact

None — CI lint scope only. No code, deps, perms, or secrets touched.

AI-assisted (OpenCode).