### PR TITLE
chore(deps): bump js-yaml + markdown-it to clear moderate DoS advisories

### DIFF
--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -395,9 +395,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -457,14 +467,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -8,5 +8,9 @@
   },
   "dependencies": {
     "markdownlint-cli2": "0.22.1"
+  },
+  "overrides": {
+    "js-yaml": "4.2.0",
+    "markdown-it": "14.2.0"
   }
 }


### PR DESCRIPTION
## Context

Dependabot alert #1 flagged a moderate vuln in the CI markdown-linter dependency tree. While investigating, `npm audit` surfaced a **second** advisory (no alert filed yet). Both are transitive deps of `markdownlint-cli2@0.22.1` (in `.github/linters`), used only by the Markdown Quality CI job:

| Package | Advisory | Severity | Fixed in |
|---|---|---|---|
| `js-yaml` `<=4.1.1` | [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) — quadratic DoS via repeated YAML merge-key aliases | moderate (A:L) | 4.2.0 |
| `markdown-it` `<=14.1.1` | [GHSA-6v5v-wf23-fmfq](https://github.com/advisories/GHSA-6v5v-wf23-fmfq) — quadratic DoS in smartquotes rule | moderate (A:L) | 14.2.0 |

Both are availability-only; in a CI-only context the linter parses our own trusted markdown, so practical risk is low — but these are clean patch bumps that clear both advisories.

## Change

- `.github/linters/package.json`: add an `overrides` block pinning `js-yaml@4.2.0` and `markdown-it@14.2.0`.
- `.github/linters/package-lock.json`: regenerated to match (integrity hashes verified against registry.npmjs.org).
- `markdownlint-cli2` stays at **0.22.1** (no behavior change).

### Why `overrides` and not `npm audit fix`

`npm audit fix --force` wanted to **downgrade `markdownlint-cli2` to 0.12.1** — a breaking major regression. Pinning the two transitive deps via `overrides` clears the advisories while keeping the linter at its current version.

## Verification

```
$ npm ci      # in .github/linters
added 86 packages, and audited 87 packages in 1s
found 0 vulnerabilities

$ node -e 'require("js-yaml/package.json").version'   -> 4.2.0
$ node -e 'require("markdown-it/package.json").version' -> 14.2.0
$ node -e 'require("markdownlint-cli2/package.json").version' -> 0.22.1
```

## Supply-chain note

Given recent npm incidents, I cross-referenced the full 86-package linter tree against the **Sept 2025 qix/chalk-debug compromise** and the **Shai-Hulud worm** IOCs. No compromised package versions are present — e.g. `debug@4.4.3` is the clean post-incident rebuild (the compromised version was `4.4.2`), and none of the worm/qix IOC packages (`chalk@5.6.1`, the bad `ansi-styles`, `@ctrl/tinycolor`, etc.) appear in the tree. The lockfile carries SHA-512 integrity hashes, which `npm ci` enforces.

## Rollback

Revert this commit; restores the prior pins (and re-opens the two advisories).

## Security Impact

Positive — clears 2 moderate DoS advisories. CI-only dependency scope; no runtime/app code, perms, or secrets touched.

AI-assisted (OpenCode).
