### PR TITLE
docs: streamline README and harden secret-handling examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,9 +343,9 @@ The agent MUST:
 
 | Service | Method | Notes |
 |---------|--------|-------|
-| USAi | Direct injection (`-e USAI_API_KEY`) | Custom endpoint not supported by SBX proxy |
+| USAi | Custom secret (`sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY`) | Custom endpoint not supported by SBX proxy |
 | GitHub | SBX proxy (`sbx secret set -g github`) | Recommended; agent never sees token |
-| GitLab | Direct injection (`-e GITLAB_TOKEN`) | Not a built-in SBX service |
+| GitLab | Custom secret (`sbx secret set-custom -g --host <host> --env GITLAB_TOKEN`) | Not a built-in SBX service |
 
 See `docs/QUICKSTART_SBX.md` for detailed credential injection patterns.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,7 +345,7 @@ The agent MUST:
 |---------|--------|-------|
 | USAi | Custom secret (`sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY`) | Custom endpoint not supported by SBX proxy |
 | GitHub | SBX proxy (`sbx secret set -g github`) | Recommended; agent never sees token |
-| GitLab | Custom secret (`sbx secret set-custom -g --host <host> --env GITLAB_TOKEN`) | Not a built-in SBX service |
+| GitLab | Custom secret (`sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN`) | Not a built-in SBX service |
 
 See `docs/QUICKSTART_SBX.md` for detailed credential injection patterns.
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,7 @@ sbx secret set -g github
 ```
 
 > [!NOTE]
-> `sbx policy set-default balanced` may need to be retried if the policy service has not settled
-> yet after login or first-time setup.
->
-> USAi is not a built-in sbx service, so we use `sbx secret set-custom` instead of
-> `sbx secret set -g`. USAi API keys expire every 7 days; when one does, see
+> USAi API keys expire every 7 days; when one does, see
 > [Troubleshooting](#troubleshooting) to rotate it.
 
 ### Step 3: Create and run a sandbox (as often as you like)
@@ -193,6 +189,17 @@ sbx policy allow network -g "api.gsa.usai.gov"
 
 </details>
 
+<details>
+<summary><strong>"sbx policy set-default" fails right after first-time setup</strong></summary>
+
+The policy service may not have settled yet after `sbx login`. Retry the command:
+
+```bash
+sbx policy set-default balanced
+```
+
+</details>
+
 ---
 
 ## Why Sandboxes?
@@ -225,6 +232,12 @@ sandbox home:
 So every sandbox you create picks up the same config, rules, and skills. `qsbx`
 uses the clone it lives in, so run it from this checkout (or via a symlink to it);
 set `QUICKSTART_CLONE` only if you want to override that.
+
+### Why the USAi key uses `set-custom`
+
+USAi is not a built-in sbx service, so we store its key with
+`sbx secret set-custom` (with an explicit `--host`) instead of `sbx secret set -g`.
+The built-in `set -g` form only recognizes known providers.
 
 ### Read-only by default
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **Audience:** GSA teams using AI coding agents
 > **Purpose:** Get AI coding agents running safely inside isolated sandboxes, connected to USAi
 
-This quickstart gets you from zero to running an AI coding agent with USAi in under 5 minutes using Docker Sandboxes.
+This quickstart gets you from zero to running an AI coding agent with USAi in under 5 minutes using the standalone `sbx` CLI.
 
 ## Agentic Coding Ecosystem
 
@@ -124,63 +124,74 @@ sbx secret set -g github
 > yet after login or first-time setup.
 >
 > USAi is not a built-in sbx service, so we use `sbx secret set-custom` instead of
-> `sbx secret set -g`. USAi API keys expire every 7 days. To rotate the secret in
-> your existing sandboxes, follow the [Rotating USAI API Keys procedure](#rotating-usai-api-keys) below.
+> `sbx secret set -g`. USAi API keys expire every 7 days; when one does, see
+> [Troubleshooting](#troubleshooting) to rotate it.
 
 ### Step 3: Create and run a sandbox (as often as you like)
-
-This clone holds your shared global config (`opencode/opencode.jsonc`) plus the
-playbook submodule (`agentic-coding-playbook/`). `qsbx` mounts the clone into the
-sandbox and symlinks the config into the locations OpenCode searches under the
-sandbox home:
-
-- `~/.config/opencode/opencode.jsonc` → the shared config
-- `~/.config/opencode/AGENTS.md` → the playbook's federal agent rules
-- `~/.agents/skills` → the playbook's skills
-
-So every sandbox you create picks up the same config, rules, and skills. Repeat
-this for each project you want to work on.
 
 ```bash
 ./qsbx run opencode /path/to/your/project
 ```
 
-`qsbx run` creates the sandbox (with this clone mounted **read-only**) if it
-doesn't exist yet, then attaches. It uses the clone it lives in, so run it from
-this checkout (or via a symlink to it); set `QUICKSTART_CLONE` only if you want
-to override that.
-
-The clone is mounted read-only for project work so a (possibly prompt-injected)
-agent can't rewrite the permission policy, rules, or skills that every other
-sandbox loads.
-
-#### Customizing the shared config
-
-To edit the shared config itself with an agent, point `qsbx` at the clone:
-
-```bash
-./qsbx run opencode .          # from inside the clone
-# or: ./qsbx run opencode /path/to/agentic-coding-quickstart
-```
-
-qsbx detects that the target is the clone and mounts it **read-write** as the
-primary workspace (and tells you so). Review the agent's changes with `git diff`
-and commit/push before they propagate to other sandboxes.
-
-Before attaching, `qsbx` checks that the sandbox's USAi key still works. If it
-has expired, it walks you through [rotating it](#rotating-usai-api-keys) and
-re-validates before launching the agent.
+`qsbx run` creates the sandbox (if it doesn't exist yet) with this clone's shared
+config mounted, then attaches. Every sandbox picks up the same USAi provider
+config, federal agent rules, and skills. Repeat this for each project you want to
+work on.
 
 That's it. You're now running an AI coding agent in an isolated container with USAi access.
 
-**Staying current:** Once in a while, `git fetch` this clone (and
-`git submodule update --remote --merge agentic-coding-playbook` to bump the
-playbook) to pick up updates, and rotate your USAi key when it expires (see
-[Rotating USAI API Keys](#rotating-usai-api-keys)).
+**Want to know what `qsbx` is doing under the hood?** See [How It Works](#how-it-works).
 
 **Need more details?** See the [Full sbx CLI Guide](docs/QUICKSTART_SBX.md).
 
 **Working across multiple repos?** See [Multiple Workspaces](docs/QUICKSTART_SBX.md#multiple-workspaces) for mounting extra directories.
+
+---
+
+## Troubleshooting
+
+If the happy path above didn't work, the two most common issues are below. For
+everything else (wrong providers, auth failures, TLS/certificate errors, and
+more), see **[docs/KNOWN_FAILURE_MODES.md](docs/KNOWN_FAILURE_MODES.md)**.
+
+<details>
+<summary><strong>Authentication failures (expired USAi key)</strong></summary>
+
+USAi API keys expire every 7 days, which is the most common cause of errors like:
+
+```
+Unauthorized: {"detail":"Not authenticated"}
+```
+
+The simplest fix: end your session, then run `./qsbx run opencode <path>` again.
+`qsbx` validates the key on attach and walks you through rotating it when needed.
+
+To rotate the key explicitly outside that workflow:
+
+1. Open https://console.gsa.usai.gov/key-management
+2. Choose "Rotate" from the "Actions" menu for your key
+3. Copy the new key using the console copy button
+4. With the key in your paste buffer, run:
+
+   ```bash
+   ./qsbx usai-rotate-api-key
+   ```
+
+   (or run the underlying `scripts/rotate-apikey` directly). It prompts for the
+   new key, then validates it in a temporary sandbox.
+
+</details>
+
+<details>
+<summary><strong>Network policy blocks USAi</strong></summary>
+
+```bash
+sbx policy allow network -g "api.gsa.usai.gov"
+```
+
+> Do NOT use "Open" policy on GFE — it exposes internal GSA resources to the agent.
+
+</details>
 
 ---
 
@@ -195,62 +206,52 @@ AI coding agents can read files, write code, and execute commands. Running them 
 
 ---
 
-## What's in This Repo
+## How It Works
 
-| File/Directory                      | Purpose                                                    |
-| ----------------------------------- | ---------------------------------------------------------- |
-| `opencode/opencode.jsonc`           | Pre-configured for USAi endpoints (shared config)          |
-| `opencode.jsonc`                    | Convenience symlink to `opencode/opencode.jsonc`           |
-| `agentic-coding-playbook/`          | Pinned submodule: federal `AGENTS.md` + agent skills       |
-| `qsbx`                              | sbx wrapper that mounts this clone and links config in     |
-| `scripts/rotate-apikey`             | Rotate your USAi API key secret (`qsbx usai-rotate-api-key`) |
-| `.zed/tasks.json`                   | Pre-configured tasks for **Zed Editor**                    |
-| `.pre-commit-config.yaml`           | Optional pre-commit hooks (secret detection, file hygiene) |
-| `AGENTS.md`                         | Rules for working **on this quickstart repo**              |
-| `docs/QUICKSTART_SBX.md`            | Full sbx CLI setup guide                                   |
-| `docs/ZED_SETUP.md`                 | **Zed Editor** integration guide                           |
-| `docs/KNOWN_FAILURE_MODES.md`       | Troubleshooting guide                                      |
+You can skip this section to get started — it explains the mechanics behind the
+quickstart for when you want to customize or troubleshoot.
 
----
+### What `qsbx` mounts and links
 
-## Zed Editor Integration (Optional)
+This clone holds your shared global config (`opencode/opencode.jsonc`) plus the
+playbook submodule (`agentic-coding-playbook/`). `qsbx` mounts the clone into the
+sandbox and symlinks the config into the locations OpenCode searches under the
+sandbox home:
 
-If you use the **Zed Editor**, pre-configured tasks are available in `.zed/tasks.json`:
+- `~/.config/opencode/opencode.jsonc` → the shared config
+- `~/.config/opencode/AGENTS.md` → the playbook's federal agent rules
+- `~/.agents/skills` → the playbook's skills
 
-- **OpenCode: Run Agent** — Launch the agent in your sandbox
-- **OpenCode: Environment Diagnostics** — Check that `sbx` is installed and your USAi key secret is set
+So every sandbox you create picks up the same config, rules, and skills. `qsbx`
+uses the clone it lives in, so run it from this checkout (or via a symlink to it);
+set `QUICKSTART_CLONE` only if you want to override that.
 
-See the **[Zed Editor Setup Guide](docs/ZED_SETUP.md)** for detailed instructions.
+### Read-only by default
 
----
+For project work, the clone is mounted **read-only** so a (possibly
+prompt-injected) agent can't rewrite the permission policy, rules, or skills that
+every other sandbox loads.
 
-## OpenCode Web (Optional)
+### Customizing the shared config
 
-An alternative to running OpenCode in the terminal is to run OpenCode Web in the sandbox and access it from your host browser. This has a few benefits:
-
-- Full support for copying text from the agent output to your host clipboard
-- Richer visual interface with improved markdown rendering
-- Easier navigation through long outputs and conversation history
-
-To run OpenCode Web in a sandbox:
+To edit the shared config itself with an agent, point `qsbx` at the clone:
 
 ```bash
-# In one terminal, start OpenCode Web
-sbx run [your sandbox name] -- web --hostname 0.0.0.0 --port 4096
-
-# In another terminal, publish the port to your host
-sbx ports [your sandbox name] --publish 4096:4096
+./qsbx run opencode .          # from inside the clone
+# or: ./qsbx run opencode /path/to/agentic-coding-quickstart
 ```
 
-Then open `http://127.0.0.1:4096` in your browser.
+qsbx detects that the target is the clone and mounts it **read-write** as the
+primary workspace (and tells you so). Review the agent's changes with `git diff`
+and commit/push before they propagate to other sandboxes.
 
-A convenience script is available to automate this: [`opencode-web.sh`](opencode-web.sh)
+### Key pre-validation
 
-For more information, see the [OpenCode Web documentation](https://opencode.ai/docs/web).
+Before attaching, `qsbx` checks that the sandbox's USAi key still works. If it
+has expired, it walks you through [rotating it](#troubleshooting) and
+re-validates before launching the agent.
 
----
-
-## Security Model
+### Security Model
 
 1. **All execution inside sbx containers** — Isolated from your host system
 2. **Authorized endpoints only** — USAi, GitHub (via proxy)
@@ -259,112 +260,7 @@ For more information, see the [OpenCode Web documentation](https://opencode.ai/d
 
 For Git provider credentials and advanced patterns, see [docs/QUICKSTART_SBX.md](docs/QUICKSTART_SBX.md).
 
----
-
-## Troubleshooting
-
-### Network policy blocks USAi
-
-```bash
-sbx policy allow network -g "api.gsa.usai.gov"
-```
-
-> Do NOT use "Open" policy on GFE — it exposes internal GSA resources to the agent.
-
-### "docker: unknown command: docker sbx" or "docker sandbox deprecated"
-
-The `docker sandbox` command is deprecated. Install and use the standalone `sbx` CLI instead:
-
-```bash
-# macOS
-brew install docker/tap/sbx
-
-# Windows
-winget install Docker.sbx
-```
-
-Then use `sbx` commands directly (e.g., `sbx run opencode .` instead of `docker sandbox run opencode .`).
-
-### OpenCode shows wrong providers
-
-Ensure `~/.config/opencode/opencode.jsonc` inside the sandbox is the symlink
-into this clone. `qsbx` creates it (along with `AGENTS.md` and `~/.agents/skills`)
-when it creates the sandbox; if you created the sandbox another way, the USAi
-provider config won't be picked up. Re-create it with `qsbx run`, or link the
-files manually.
-
-### Authentication failed
-
-```bash
-# Check your secret is stored
-sbx secret ls
-
-# Re-set if needed
-sbx secret set -g anthropic
-```
-
-If USAi authentication fails right after copying a newly created key, regenerate the key and use
-the console copy button immediately instead of selecting the displayed text. The displayed value may
-be truncated.
-
-### Rotating USAi API keys
-
-USAi API keys expire every 7 days. A stale API key is a common cause of authentication failures like:
-
-```
-Unauthorized: {"detail":"Not authenticated"}
-```
-
-To check if your key has expired:
-
-1. Go to https://console.gsa.usai.gov/key-management
-2. Under "My Keys", check the "Expires In" field. If the value is 0h0m, then the key has expired.
-
-To rotate your key:
-
-1. On the same page, choose "Rotate" from the "Actions" menu
-2. Copy the new key using the console copy button
-3. With the key in your paste buffer, update the secret in `sbx` by running
-
-   ```bash
-   ./qsbx usai-rotate-api-key
-   ```
-
-   (or run the underlying `scripts/rotate-apikey` directly). The command will
-   prompt you for the new key. Paste it when prompted. It will also validate
-   that the new key works.
-
-> [!NOTE]
-> If you don't have a sandbox named, "opencode-agentic-coding-quickstart", then
-> you'll need to manually validate the key with:
->
-> ```bash
-> # Should return HTTP 200. A 401/403 means the key is invalid or expired.
-> sbx exec <sandbox-name> -- sh -c \
->   'curl -sS -o /dev/null -w "%{http_code}\n" \
->    -H "Authorization: Bearer $USAI_API_KEY" \
->    https://api.gsa.usai.gov/api/v1/models'
-> ```
-
-If the placeholder value hasn't changed, your existing sandboxes will automatically use the new key.
-
-#### Troubleshooting
-
-If you're still having authentication issues after rotation:
-
-1. Verify the secret is set:
-
-   ```bash
-   sbx secret ls -g | grep USAI_API_KEY
-   ```
-
-2. As a last resort, recreate your sandbox:
-   > ⚠️ **Warning:** This destroys all sandbox state including uncommitted work.
-   ```bash
-   sbx rm <sandbox-name>
-   ```
-
-### How default USAI models are chosen
+### How default USAi models are chosen
 
 The `opencode.jsonc` in this repo includes a generated USAI model catalog.
 This repository keeps that section in sync with the USAI `/models` API so new
@@ -383,11 +279,37 @@ model listed by `/models` to fail at runtime for a specific key or request. See
 To refresh the model catalog locally:
 
 ```bash
-export USAI_API_KEY="your-key-here"
+# Prompt for the key (no echo)
+read -rs USAI_API_KEY && export USAI_API_KEY
 npm run sync:usai-models
 ```
 
-For more troubleshooting, see [docs/KNOWN_FAILURE_MODES.md](docs/KNOWN_FAILURE_MODES.md).
+---
+
+## Optional Integrations
+
+- **Zed Editor** — Pre-configured tasks in `.zed/tasks.json` let you launch the
+  agent and run diagnostics from the editor. See the [Zed Editor Setup Guide](docs/ZED_SETUP.md).
+- **OpenCode Web** — Run OpenCode Web in the sandbox and reach it from your host
+  browser for clipboard support and richer markdown rendering. The
+  [`opencode-web.sh`](opencode-web.sh) script automates it; see the
+  [OpenCode Web documentation](https://opencode.ai/docs/web).
+
+---
+
+## Staying Current
+
+Once in a while, refresh this clone and the playbook to pick up updates, and
+rotate your USAi key when it expires (see [Troubleshooting](#troubleshooting)).
+
+```bash
+# Update the quickstart clone
+git fetch
+
+# Bump the playbook submodule to a newer release
+git submodule update --remote --merge agentic-coding-playbook
+git add agentic-coding-playbook && git commit -m "chore: bump playbook submodule"
+```
 
 ---
 
@@ -410,13 +332,6 @@ discovers them automatically; no separate clone is needed.
 | **Playbook** (submodule) | Federal compliance, security | `federal-security-controls-lookup`, `ato-package`, `code-review`, `cloudgov-deploy` |
 | **Patterns** | Development workflows        | `accessibility-review`, `uswds-prototype`, `test-generation`, `secure-code-review`  |
 
-To bump the playbook to a newer release:
-
-```bash
-git submodule update --remote --merge agentic-coding-playbook
-git add agentic-coding-playbook && git commit -m "chore: bump playbook submodule"
-```
-
 ---
 
 ## Getting Help
@@ -431,6 +346,24 @@ git add agentic-coding-playbook && git commit -m "chore: bump playbook submodule
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+---
+
+## What's in This Repo
+
+| File/Directory                      | Purpose                                                    |
+| ----------------------------------- | ---------------------------------------------------------- |
+| `opencode/opencode.jsonc`           | Pre-configured for USAi endpoints (shared config)          |
+| `opencode.jsonc`                    | Convenience symlink to `opencode/opencode.jsonc`           |
+| `agentic-coding-playbook/`          | Pinned submodule: federal `AGENTS.md` + agent skills       |
+| `qsbx`                              | sbx wrapper that mounts this clone and links config in     |
+| `scripts/rotate-apikey`             | Rotate your USAi API key secret (`qsbx usai-rotate-api-key`) |
+| `.zed/tasks.json`                   | Pre-configured tasks for **Zed Editor**                    |
+| `.pre-commit-config.yaml`           | Optional pre-commit hooks (secret detection, file hygiene) |
+| `AGENTS.md`                         | Rules for working **on this quickstart repo**              |
+| `docs/QUICKSTART_SBX.md`            | Full sbx CLI setup guide                                   |
+| `docs/ZED_SETUP.md`                 | **Zed Editor** integration guide                           |
+| `docs/KNOWN_FAILURE_MODES.md`       | Troubleshooting guide                                      |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ quickstart for when you want to customize or troubleshoot.
 
 ### What happened when I ran the `qsbx` command?
 
-`qsbx run` created the sandbox for that path (if it doesn't exist yet) using the underlying `sbx` command, making sure that sure this clone is accessible inside it. Then it configured the coding agent (`opencode`) to pick up configuration for using the USAi provider and made sure the agent was provisioned with custom  guidance and relevant skills for working in the federal context.
+`qsbx run` created the sandbox for that path (if it didn't exist yet) using the underlying `sbx` command, making sure that this clone was accessible inside it. Then it configured the coding agent (`opencode`) to pick up configuration for using the USAi provider and made sure the agent was provisioned with custom guidance and relevant skills for working in the federal context.
 
 ### What `qsbx` mounts and links
 

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ You can always edit the shared config in this clone by hand, but you may also us
 ```
 
 qsbx detects that the target is the clone and mounts it **read-write** as the
-primary workspace (and tells you so). Review the agent's changes carefully. You probably want to test them by starting another sandbox up and trying them out. 
+primary workspace (and tells you so). Review the agent's changes carefully. You probably want to test them by starting another sandbox up and trying them out.
 
 Note that changes to the config are visible across all sandboxes that mount it, but agents don't reload their config on the fly. To have them reread the shared configuration, you can exit them and run `qsbx run opencode /path/to/your/project -- -c` to continue the existing session where you left off.
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ You can always edit the shared config in this clone by hand, but you may also us
 qsbx detects that the target is the clone and mounts it **read-write** as the
 primary workspace (and tells you so). Review the agent's changes carefully. You probably want to test them by starting another sandbox up and trying them out. 
 
-Note that changes to the config are visible across all sandboxes that mount it, but agents don't reload their config on the fly. To have them reread the shared configuration, you can exit them and run `qsbx run opencode /path/to/your/project -c` to continue the existing session where you left off.
+Note that changes to the config are visible across all sandboxes that mount it, but agents don't reload their config on the fly. To have them reread the shared configuration, you can exit them and run `qsbx run opencode /path/to/your/project -- -c` to continue the existing session where you left off.
 
 When you're done, you probably want to version-control your customizations. We recommend that you commit them to a local branch in this clone. That way you can pull changes from main into your branch when needed.
 

--- a/README.md
+++ b/README.md
@@ -199,12 +199,14 @@ sbx policy set-default balanced
 
 ## Why Sandboxes?
 
-AI coding agents can read files, write code, and execute commands. Running them in sandboxes provides:
+AI coding agents can read files, write code, and execute commands. That makes them potent agents of chaos if they're compromised. Running them in sandboxes provides:
 
-- **Isolation** — Agent can't access your full system
-- **Secret protection** — API keys injected via proxy, never touch disk
-- **Reproducibility** — Same environment every time
-- **Audit trail** — Clear boundaries for what the agent can do
+- **Isolation** — Agent shouldn't be able to access the full host system; they should be limited both the filesystem and network access
+- **Secret protection** — By using proxy that injects secrets into outgoing requests, the actual secret is never available to the agent for exfiltration
+- **Reproducibility** — Agents should have a consistent configuration tailored to their operating context every time they run
+- **Audit trail** — Hard boundaries for what the agent can do, potentially logging violations
+
+For more details on this sandbox implementation and discussion of advanced patterns, see [docs/QUICKSTART_SBX.md](docs/QUICKSTART_SBX.md).
 
 ---
 
@@ -249,15 +251,6 @@ every other sandbox loads.
 Before attaching, `qsbx` checks that the sandbox's USAi key still works. If it
 has expired, it walks you through [rotating it](#troubleshooting) and
 re-validates before launching the agent.
-
-### Security Model
-
-1. **All execution inside sbx containers** — Isolated from your host system
-2. **Authorized endpoints only** — USAi, GitHub (via proxy)
-3. **Secret proxy** — Agent never sees raw API keys when using `sbx secret`
-4. **Agent follows AGENTS.md rules** — Explicit permissions and prohibitions
-
-For Git provider credentials and advanced patterns, see [docs/QUICKSTART_SBX.md](docs/QUICKSTART_SBX.md).
 
 ### How default USAi models are chosen
 

--- a/README.md
+++ b/README.md
@@ -129,14 +129,9 @@ sbx secret set -g github
 ./qsbx run opencode /path/to/your/project
 ```
 
-`qsbx run` creates the sandbox (if it doesn't exist yet) with this clone's shared
-config mounted, then attaches. Every sandbox picks up the same USAi provider
-config, federal agent rules, and skills. Repeat this for each project you want to
-work on.
+That's it. You're now running an AI coding agent with USAi access and restricted filesystem and network access.  Repeat this to create sandboxes for each project you want to work on.
 
-That's it. You're now running an AI coding agent in an isolated container with USAi access.
-
-**Want to know what `qsbx` is doing under the hood?** See [How It Works](#how-it-works).
+**Want to know more about what `qsbx` is doing under the hood?** See [How It Works](#how-it-works).
 
 **Need more details?** See the [Full sbx CLI Guide](docs/QUICKSTART_SBX.md).
 
@@ -218,6 +213,10 @@ AI coding agents can read files, write code, and execute commands. Running them 
 You can skip this section to get started — it explains the mechanics behind the
 quickstart for when you want to customize or troubleshoot.
 
+### What happened when I ran the `qsbx` command?
+
+`qsbx run` created the sandbox for that path (if it doesn't exist yet) using the underlying `sbx` command, making sure that sure this clone is accessible inside it. Then it configured the coding agent (`opencode`) to pick up configuration for using the USAi provider and made sure the agent was provisioned with custom  guidance and relevant skills for working in the federal context.
+
 ### What `qsbx` mounts and links
 
 This clone holds your shared global config (`opencode/opencode.jsonc`) plus the
@@ -241,22 +240,9 @@ The built-in `set -g` form only recognizes known providers.
 
 ### Read-only by default
 
-For project work, the clone is mounted **read-only** so a (possibly
+For project work, this clone is mounted **read-only** so a (possibly
 prompt-injected) agent can't rewrite the permission policy, rules, or skills that
 every other sandbox loads.
-
-### Customizing the shared config
-
-To edit the shared config itself with an agent, point `qsbx` at the clone:
-
-```bash
-./qsbx run opencode .          # from inside the clone
-# or: ./qsbx run opencode /path/to/agentic-coding-quickstart
-```
-
-qsbx detects that the target is the clone and mounts it **read-write** as the
-primary workspace (and tells you so). Review the agent's changes with `git diff`
-and commit/push before they propagate to other sandboxes.
 
 ### Key pre-validation
 
@@ -296,6 +282,23 @@ To refresh the model catalog locally:
 read -rs USAI_API_KEY && export USAI_API_KEY
 npm run sync:usai-models
 ```
+
+---
+## Customizing the shared config
+
+You can always edit the shared config in this clone by hand, but you may also use an agent to work on it! To edit it using an agent, point `qsbx` at the clone:
+
+```bash
+./qsbx run opencode .          # from inside the clone
+# or: qsbx run opencode /path/to/agentic-coding-quickstart
+```
+
+qsbx detects that the target is the clone and mounts it **read-write** as the
+primary workspace (and tells you so). Review the agent's changes carefully. You probably want to test them by starting another sandbox up and trying them out. 
+
+Note that changes to the config are visible across all sandboxes that mount it, but agents don't reload their config on the fly. To have them reread the shared configuration, you can exit them and run `qsbx run opencode /path/to/your/project -c` to continue the existing session where you left off.
+
+When you're done, you probably want to version-control your customizations. We recommend that you commit them to a local branch in this clone. That way you can pull changes from main into your branch when needed.
 
 ---
 

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -547,6 +547,83 @@ Always choose "Balanced" (Option 2) when prompted. The Balanced policy allows ty
 
 ---
 
+## 18. Migrating from `docker sandbox`
+
+### Symptoms
+
+- You're using deprecated `docker sandbox ...` commands
+- Want to know the `sbx` CLI equivalents
+
+### Root Cause
+
+The Docker Desktop-integrated `docker sandbox` command is deprecated. The standalone `sbx` CLI replaces it and does not require Docker Desktop.
+
+### Fix
+
+Migrate to the equivalent `sbx` commands:
+
+| Deprecated Command | New Command |
+|-------------------|-------------|
+| `docker sandbox create --name NAME opencode .` | `sbx create --name NAME opencode .` |
+| `docker sandbox run NAME` | `sbx run NAME` |
+| `docker sandbox exec NAME cmd` | `sbx exec NAME cmd` |
+| `docker sandbox ls` | `sbx ls` |
+| `docker sandbox rm NAME` | `sbx rm NAME` |
+
+Your existing sandboxes and secrets will continue to work with the `sbx` CLI.
+
+---
+
+## 19. OpenCode Shows Wrong Providers
+
+### Symptoms
+
+- OpenCode lists generic providers instead of USAi
+- Custom USAi model catalog missing
+
+### Root Cause
+
+The `~/.config/opencode/opencode.jsonc` inside the sandbox is not the symlink into your quickstart clone, so the USAi provider config is never loaded. This happens when the sandbox was created without `qsbx` (which sets up the symlinks for `opencode.jsonc`, `AGENTS.md`, and `~/.agents/skills`).
+
+### Fix
+
+Re-create the sandbox with `qsbx run`, which links the config automatically:
+
+```bash
+./qsbx run opencode /path/to/your/project
+```
+
+Or link the files manually inside the sandbox if you created it another way.
+
+---
+
+## 20. Authentication Failed After Copying a New Key
+
+### Symptoms
+
+- USAi authentication fails immediately after creating/copying a key
+- Key looks correct but is rejected
+
+### Root Cause
+
+The displayed key value in the console may be truncated when selected by hand, so the stored secret is incomplete.
+
+### Fix
+
+Regenerate the key and use the console **copy button** immediately instead of selecting the displayed text. Then confirm the secret is stored:
+
+```bash
+sbx secret ls -g | grep USAI_API_KEY
+```
+
+If problems persist, see [Section 2](#2-api-key-works-in-ui-but-fails-in-agent) and [Section 3](#3-agent-cannot-see-api-key--usai-authentication-fails). As a last resort, recreate the sandbox (this destroys all sandbox state, including uncommitted work):
+
+```bash
+sbx rm <sandbox-name>
+```
+
+---
+
 ## Debugging Checklist
 
 When something fails, work through this list:

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -90,12 +90,14 @@ But requests to `api.gsa.usai.gov` bypass this proxy entirely.
 
 ### Fix
 
-Inject the API key directly via environment variable:
+Store the key as a custom secret so sbx injects it for you:
+
 ```bash
-sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) SANDBOX_NAME opencode
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
 ```
 
-This passes the actual key into the container environment, where `opencode.jsonc` reads it via `{env:USAI_API_KEY}`.
+Recreate the sandbox so the secret takes effect. `opencode.jsonc` reads the
+injected value via `{env:USAI_API_KEY}`.
 
 ---
 
@@ -355,7 +357,7 @@ sbx cp ./opencode.jsonc my-sandbox:/workspace/
 - `sbx secret set -g openai` succeeds
 - But USAi authentication still fails
 - `OPENAI_API_KEY=proxy-managed` in container
-- Must use direct injection (`-e USAI_API_KEY="$USAI_API_KEY"`)
+- Must inject the key via a custom secret instead
 
 ### Root Cause
 
@@ -363,14 +365,14 @@ SBX's secret proxy intercepts requests to **known provider endpoints** (like `ap
 
 ### Security Implication
 
-**When using direct injection, the agent CAN see the API key.**
+**For custom endpoints, the agent CAN see the API key.**
 
 With proxy-based injection (standard providers):
 - Agent sees: `OPENAI_API_KEY=proxy-managed`
 - Real key is injected at the proxy level
 - Agent never has access to the raw credential
 
-With direct injection (USAi/custom endpoints):
+With a custom secret (USAi/custom endpoints):
 - Agent sees: `USAI_API_KEY=<actual-key-value>`
 - Key exists in container environment
 - Agent process can read it
@@ -384,9 +386,10 @@ With direct injection (USAi/custom endpoints):
 
 ### Fix
 
-For now, bypass the proxy and inject directly:
+Store the key as a custom secret so sbx injects it into the sandbox:
+
 ```bash
-sbx exec -it -e USAI_API_KEY="$USAI_API_KEY" -w $(pwd) SANDBOX_NAME opencode
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
 ```
 
 Your `opencode.jsonc` should use variable substitution:
@@ -415,16 +418,16 @@ When implemented, this will allow defining custom service mappings so the proxy 
 ### Context
 
 GitHub is a built-in SBX service (`sbx secret set -g github`), but GitLab is not. This means:
-- **GitHub**: Can use proxy (recommended) OR direct injection
-- **GitLab**: Must use direct injection (`-e GITLAB_TOKEN="..."`)
+- **GitHub**: Uses the proxy (recommended)
+- **GitLab**: Must use a custom secret (`sbx secret set-custom -g --host <host> --env GITLAB_TOKEN`)
 
 ### Security Assessment for MVP
 
 | Concern | Severity | Mitigation |
 |---------|----------|------------|
 | Token visible in container env | Low | Container is isolated, short-lived |
-| Token in shell history | Low | Using `$(gh auth token)` subshell avoids literal values |
-| Token in process list | Low | Only visible during exec, not persisted |
+| Token in shell history | Low | sbx prompts for the value; never typed on the command line |
+| Token in process list | Low | Stored secret injected by sbx, not passed via process args |
 | Agent could exfiltrate token | Medium | Agent already has network access; proxy doesn't prevent this |
 | Token logged by agent | Medium | AGENTS.md prohibits; pre-commit hooks catch committed secrets |
 

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -531,19 +531,9 @@ sbx create --clone --name feature-work opencode ~/my-app ~/shared-libs:ro
 
 ## Migrating from `docker sandbox`
 
-> [!NOTE]
-> The Docker Desktop-integrated `docker sandbox` command is deprecated.
-> If you're currently using `docker sandbox`, migrate to `sbx`:
-
-| Deprecated Command | New Command |
-|-------------------|-------------|
-| `docker sandbox create --name NAME opencode .` | `sbx create --name NAME opencode .` |
-| `docker sandbox run NAME` | `sbx run NAME` |
-| `docker sandbox exec NAME cmd` | `sbx exec NAME cmd` |
-| `docker sandbox ls` | `sbx ls` |
-| `docker sandbox rm NAME` | `sbx rm NAME` |
-
-Your existing sandboxes and secrets will continue to work with the `sbx` CLI.
+The Docker Desktop-integrated `docker sandbox` command is deprecated. For the
+`sbx` equivalents, see
+[Known Failure Modes — Migrating from `docker sandbox`](KNOWN_FAILURE_MODES.md#18-migrating-from-docker-sandbox).
 
 ---
 

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -104,8 +104,8 @@ Docker Sandboxes uses a secure secret store to inject credentials. Your API keys
 USAi (`api.gsa.usai.gov`) is **not a built-in sbx service**, so you must use `sbx secret set-custom`:
 
 ```bash
-# Store USAi API key for the custom endpoint
-sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
+# sbx prompts for the key
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
 ```
 
 > [!IMPORTANT]
@@ -125,7 +125,7 @@ sbx secret set -g anthropic
 ### Store GitHub Token (for code access)
 
 ```bash
-# Recommended: pipe from gh cli (never touches shell history)
+# Recommended: pipe from gh cli
 gh auth token | sbx secret set -g github
 
 # Or enter manually
@@ -138,8 +138,8 @@ sbx secret set -g github
 GitLab is **not a built-in sbx service**, so use `sbx secret set-custom`:
 
 ```bash
-# For self-hosted GitLab (e.g., workshop.cloud.gov)
-sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN --value "$GITLAB_TOKEN"
+# For self-hosted GitLab (e.g., workshop.cloud.gov). sbx prompts for the token.
+sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN
 
 # Verify access inside sandbox
 sbx exec SANDBOX_NAME sh -c 'curl -s -H "PRIVATE-TOKEN: $GITLAB_TOKEN" https://workshop.cloud.gov/api/v4/user | jq .username'
@@ -191,8 +191,8 @@ For custom API endpoints that aren't built-in services, use `sbx secret set-cust
 
 | Endpoint | Command |
 |----------|---------|
-| USAi (`api.gsa.usai.gov`) | `sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"` |
-| GitLab (self-hosted) | `sbx secret set-custom -g --host gitlab.example.com --env GITLAB_TOKEN --value "$GITLAB_TOKEN"` |
+| USAi (`api.gsa.usai.gov`) | `sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY` |
+| GitLab (self-hosted) | `sbx secret set-custom -g --host gitlab.example.com --env GITLAB_TOKEN` |
 
 > [!WARNING]
 > The `sbx secret set -g VARNAME` syntax does **not** work for custom variables like `USAI_API_KEY`.
@@ -211,7 +211,7 @@ sbx secret ls -g
 sbx secret rm -g anthropic
 
 # Update a secret (set it again, then recreate sandbox)
-sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$NEW_KEY"
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
 sbx rm my-sandbox && sbx create --name my-sandbox opencode .
 ```
 

--- a/docs/ZED_SETUP.md
+++ b/docs/ZED_SETUP.md
@@ -30,7 +30,7 @@ Using [Zed](https://zed.dev) with Docker Sandboxes and USAi provides a robust, f
    ```
 3. **USAi API Key** stored securely (USAi is a custom endpoint):
    ```bash
-   sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
+   sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
    ```
    > After setting the secret, recreate any existing sandbox: `sbx rm quickstart; sbx create --name quickstart opencode .`
 
@@ -112,7 +112,7 @@ and adjust the sandbox name to match.
 ### "ERROR: USAI_API_KEY not found"
 - USAi is a custom endpoint, so you must use `sbx secret set-custom`:
   ```bash
-  sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY --value "$USAI_API_KEY"
+  sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
   ```
 - After setting the secret, **delete and recreate** the sandbox:
   ```bash

--- a/docs/ZED_SETUP.md
+++ b/docs/ZED_SETUP.md
@@ -2,11 +2,6 @@
 
 This guide documents how to set up and run the containerized OpenCode agent inside a sandboxed Docker environment (SBX) while developing on your host machine using the **Zed editor**.
 
-> [!IMPORTANT]
-> The Docker Desktop-integrated `docker sandbox` commands are **deprecated**.
-> Use the standalone `sbx` CLI instead.
-> See [Docker's deprecation notice](https://docs.docker.com/reference/cli/docker/sandbox/).
-
 ## Why Use Zed with Docker Sandboxes?
 
 Using [Zed](https://zed.dev) with Docker Sandboxes and USAi provides a robust, fast developer workflow:

--- a/scripts/rotate-apikey
+++ b/scripts/rotate-apikey
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-QS_SBX="opencode-agentic-coding-quickstart"
+USAI_MODELS_URL="https://api.gsa.usai.gov/api/v1/models"
 
 fail() {
     echo "$@" >&2
@@ -21,12 +21,28 @@ fi
 sbx secret set-custom -g --host api.gsa.usai.gov \
       --env USAI_API_KEY --placeholder "$placeholder"
 
-if sbx ls | grep -qE "^${QS_SBX}[[:space:]]"; then
-  echo "Validating new key. 200 is OK, otherwise, you have a problem"
-  sbx exec "$QS_SBX" -- sh -c \
-     'curl -sS -o /dev/null -w "%{http_code}\n" \
-      -H "Authorization: Bearer $USAI_API_KEY" \
-      https://api.gsa.usai.gov/api/v1/models'
+# Validate the new key in a throwaway sandbox so we don't depend on any
+# particular pre-existing sandbox. Created here, removed on exit.
+validation_sbx="qsbx-keycheck-$$"
+cleanup() {
+  sbx rm "$validation_sbx" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "Validating new key in a temporary sandbox..."
+if ! sbx create --name "$validation_sbx" shell . >/dev/null 2>&1; then
+  echo "Could not create a validation sandbox; skipping check." >&2
+  echo "The key was rotated. Re-run 'qsbx run' to validate on next attach." >&2
+  exit 0
+fi
+
+status=$(sbx exec "$validation_sbx" -- sh -c \
+   "curl -sS -o /dev/null -w '%{http_code}' \
+    -H \"Authorization: Bearer \$USAI_API_KEY\" \
+    $USAI_MODELS_URL" 2>/dev/null || true)
+
+if [ "$status" = "200" ]; then
+  echo "Key validated (HTTP 200). You're good to go."
 else
-  echo "Cannot find sandbox, $QS_SBX, for validation. See README.md for help"
+  fail "Key validation failed (HTTP ${status:-unknown}). Double-check the key and rotate again."
 fi


### PR DESCRIPTION
## Summary

Restructures the README so first-time readers hit the quickstart and troubleshooting first, with implementation mechanics deferred to a "How It Works" section. Also hardens secret-handling examples across the docs (store via `sbx secret set-custom`/prompt instead of inline `--value`/`-e`) and makes `rotate-apikey` validate the new key in a throwaway sandbox instead of requiring a specific pre-existing one. Troubleshooting and the `docker sandbox` migration table are consolidated into `KNOWN_FAILURE_MODES.md`.

## Related Issues

<!-- none -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits format](../CONTRIBUTING.md#commit-message-guidelines) (e.g., `feat:`, `fix:`, `docs:`)
- [x] I have tested my changes locally
- [x] I have updated documentation as needed
- [x] I have not included any secrets, API keys, or sensitive information

## Test Results

`bash -n scripts/rotate-apikey` passes; README internal anchors verified to resolve.

## Additional Notes

AI-assisted. Companion issue filed for the playbook submodule's inline-secret examples: GSA-TTS/agentic-coding-playbook#112.
