### PR TITLE
ci: set persist-credentials: false on lint/pre-commit checkouts

### DIFF
--- a/.github/workflows/markdown-quality.yml
+++ b/.github/workflows/markdown-quality.yml
@@ -30,6 +30,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -54,6 +56,8 @@ jobs:
     continue-on-error: true  # External URLs can be flaky
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,6 +26,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'


### PR DESCRIPTION
Closes #160.

Three `actions/checkout` steps left `GITHUB_TOKEN` persisted in `.git/config` for the job duration — every other workflow in the workspace already sets `persist-credentials: false` (zizmor `artipacked`). These lint/pre-commit jobs run third-party npm + pre-commit hooks, so a compromised hook could read the persisted token.

- `markdown-quality.yml`: both checkout steps (lint + link-check)
- `pre-commit.yml`: the checkout step

## Verification
YAML valid; 3 `persist-credentials: false` added. Jobs only read+lint (no push), so no functional impact.

## Security Impact
Positive — removes token-exfil surface. NIST AC-6, SC-8.

AI-assisted (OpenCode).