### PR TITLE
docs: add local lint and check scripts for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,8 @@ npm ci --prefix .github/linters
 
 # Pre-commit hooks (Python) — optional but recommended
 pip install pre-commit
+# or on Mac
+brew install pre-commit
 pre-commit install
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,19 +72,13 @@ Run CI checks locally before pushing to catch issues early.
 
 ### Install dependencies
 
+#### Markdown linter (Node.js)
 ```bash
-# Markdown linter (Node.js)
 npm ci --prefix .github/linters
-
-# Pre-commit hooks (Python) — optional but recommended
-pip install pre-commit
-# or on Mac
-brew install pre-commit
-pre-commit install
 ```
-
-Running `pre-commit install` sets up a git hook so checks run automatically on
-every commit.
+#### Pre-commit hooks (Python) — optional but recommended
+- requires `pre-commit` installation and setup
+- see `docs/PRE_COMMIT_SETUP.md` for instructions
 
 ### Available scripts
 
@@ -93,6 +87,7 @@ every commit.
 | `npm test` | Run the test suite (`node --test`) |
 | `npm run lint:md` | Lint markdown files (same rules as CI) |
 | `npm run lint` | Run all linters |
+| `npm run lint:secrets` | Run gitleaks (requires gitleaks to be installed: `brew install gitleaks`)
 | `npm run check` | Run the full pre-commit suite (gitleaks, shellcheck, YAML/JSON validation, whitespace, markdown lint) |
 
 > [!NOTE]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,47 @@ This project operates under professional standards of conduct. All contributors:
 
 ---
 
+## Local Development Checks
+
+Run CI checks locally before pushing to catch issues early.
+
+### Install dependencies
+
+```bash
+# Markdown linter (Node.js)
+npm ci --prefix .github/linters
+
+# Pre-commit hooks (Python) — optional but recommended
+pip install pre-commit
+pre-commit install
+```
+
+Running `pre-commit install` sets up a git hook so checks run automatically on
+every commit.
+
+### Available scripts
+
+| Command | What it does |
+|---------|-------------|
+| `npm test` | Run the test suite (`node --test`) |
+| `npm run lint:md` | Lint markdown files (same rules as CI) |
+| `npm run lint` | Run all linters |
+| `npm run check` | Run the full pre-commit suite (gitleaks, shellcheck, YAML/JSON validation, whitespace, markdown lint) |
+
+### Quick pre-push check
+
+```bash
+npm run lint && npm test
+```
+
+Or for the most comprehensive local check (requires pre-commit):
+
+```bash
+npm run check
+```
+
+---
+
 ## Commit Message Guidelines
 
 This project follows **Conventional Commits 1.0.0** for automated version management and changelog generation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,9 @@ every commit.
 | `npm run lint` | Run all linters |
 | `npm run check` | Run the full pre-commit suite (gitleaks, shellcheck, YAML/JSON validation, whitespace, markdown lint) |
 
+> [!NOTE]
+> `npm run check` auto-fixes some issues (markdown, whitespace, EOF) — review and stage the changes it makes.
+
 ### Quick pre-push check
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ npm ci --prefix .github/linters
 | `npm test` | Run the test suite (`node --test`) |
 | `npm run lint:md` | Lint markdown files (same rules as CI) |
 | `npm run lint` | Run all linters |
-| `npm run lint:secrets` | Run gitleaks (requires gitleaks to be installed: `brew install gitleaks`)
+| `npm run lint:secrets` | Run gitleaks (requires gitleaks to be installed: `brew install gitleaks`) |
 | `npm run check` | Run the full pre-commit suite (gitleaks, shellcheck, YAML/JSON validation, whitespace, markdown lint) |
 
 > [!NOTE]

--- a/docs/PRE_COMMIT_SETUP.md
+++ b/docs/PRE_COMMIT_SETUP.md
@@ -91,7 +91,7 @@ The agent should be configured to run pre-commit checks before committing if hoo
 The `.pre-commit-config.yaml` file uses SHA-pinned revisions for security:
 
 - **pre-commit-hooks v6.0.0**: Basic file hygiene
-- **gitleaks v8.24.3**: Secret detection
+- **gitleaks v8.30.1**: Secret detection
 
 To update hook versions, edit `.pre-commit-config.yaml` and update both the rev (SHA) and the version comment.
 

--- a/docs/PRE_COMMIT_SETUP.md
+++ b/docs/PRE_COMMIT_SETUP.md
@@ -36,6 +36,9 @@ brew install pre-commit
 # Install the hooks (from repo root)
 pre-commit install
 ```
+> [!NOTE]
+> Running `pre-commit install` sets up a git hook so checks run automatically on
+every commit.
 
 ### Inside Docker Sandbox (SBX)
 
@@ -57,6 +60,8 @@ You can run pre-commit checks on-demand without installing the hooks:
 
 ```bash
 # Run all hooks on all files
+npm run check
+# OR
 pre-commit run --all-files
 
 # Run all hooks on staged files only

--- a/docs/PRE_COMMIT_SETUP.md
+++ b/docs/PRE_COMMIT_SETUP.md
@@ -30,6 +30,8 @@ By making hooks opt-in, users can:
 ```bash
 # Install pre-commit
 pip install pre-commit
+# or on Mac
+brew install pre-commit
 
 # Install the hooks (from repo root)
 pre-commit install

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "sync:usai-models": "node scripts/sync-usai-models.mjs --write-snapshot",
     "test": "node --test",
     "lint:md": "npx --prefix .github/linters markdownlint-cli2 '**/*.md' '#node_modules' '#.github/linters/node_modules' '#CHANGELOG.md' '#agentic-coding-playbook'",
+    "lint:secrets": "gitleaks detect --source .",
     "lint": "npm run lint:md",
     "check": "pre-commit run --all-files"
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "type": "module",
   "scripts": {
     "sync:usai-models": "node scripts/sync-usai-models.mjs --write-snapshot",
-    "test": "node --test"
+    "test": "node --test",
+    "lint:md": "npx --prefix .github/linters markdownlint-cli2 '**/*.md' '#node_modules' '#.github/linters/node_modules' '#CHANGELOG.md' '#agentic-coding-playbook'",
+    "lint": "npm run lint:md",
+    "check": "pre-commit run --all-files"
   }
 }


### PR DESCRIPTION
## Summary

- Add `lint:md`, `lint`, and `check` scripts to `package.json` so contributors can run the same checks CI enforces — locally, before pushing
- Document the new scripts and setup steps in a new "Local Development Checks" section in `CONTRIBUTING.md`
- `npm run lint` runs markdownlint (same config as the `markdown-quality.yml` workflow)
- `npm run check` runs the full pre-commit suite (gitleaks, shellcheck, YAML/JSON validation, whitespace, markdown lint)

## Test plan

- [x] `npm run lint:md` — passes with 0 errors
- [x] `npm run lint` — passes
- [x] `npm test` — all 19 tests pass
- [x] `npm run lint:secrets`
- [x] Verify CONTRIBUTING.md renders correctly on GitHub
