### PR TITLE
chore: remove redundant root CODEOWNERS (consolidate to .github/CODEOWNERS)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,0 @@
-# CODEOWNERS for agentic-coding-quickstart
-# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-# Security-sensitive files require admin review
-/.github/workflows/         @GSA-TTS/agentic-coding-admins
-/SECURITY.md                @GSA-TTS/agentic-coding-admins
-
-# Documentation
-/docs/                      @GSA-TTS/agentic-coding-team


### PR DESCRIPTION
Closes #165.

GitHub honors only `.github/CODEOWNERS` when both it and a root `CODEOWNERS` exist — so the root file was **silently-ignored dead config** that diverged from the effective rules (it referenced `@GSA-TTS/agentic-coding-admins` and, in some repos, non-existent paths). The canonical `.github/CODEOWNERS` already assigns everything to `@GSA-TTS/agentic-coding-team`.

Per the decision to consolidate all ownership to `agentic-coding-team` (admins retain access via team membership + the admin break-glass bypass on branch protection). Root file moved to workspace `deleteme/` staging.

## Security Impact
Positive — eliminates a misleading, ignored review-ownership file; single canonical CODEOWNERS. NIST CM-6.

AI-assisted (OpenCode).