### PR TITLE
fix: correct CODING_PRACTICES.md link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,7 +353,7 @@ See `docs/QUICKSTART_SBX.md` for detailed credential injection patterns.
 
 ## Coding Standards
 
-- Follow [`agentic-coding-playbook/docs/CODING_PRACTICES.md`](agentic-coding-playbook/docs/CODING_PRACTICES.md) (the pinned playbook submodule) for secure coding guidelines
+- Follow [`agentic-coding-playbook/docs/CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md) (the pinned playbook submodule) for secure coding guidelines
 - Prefer explicit configuration over implicit behavior
 - Maximum function length: 50 lines
 - All external input MUST be validated before use


### PR DESCRIPTION
## Summary

Add correct CODING_PRACTICES.md link. Since CODING_PRACTICES lives in a separate repo, the entire link is required. Corrected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits format](../CONTRIBUTING.md#commit-message-guidelines) (e.g., `feat:`, `fix:`, `docs:`)
- [x] I have tested my changes locally
- [x] I have updated documentation as needed
- [x] I have not included any secrets, API keys, or sensitive information

## Test Results

Checked via Preview. New link works.