### PR TITLE
fix(docs): harden Docker install (no curl|sudo sh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,39 @@ sbx login
 <details>
 <summary>Show Linux (Ubuntu) install steps (click to expand)</summary>
 
+<details>
+<summary>Show Linux (Ubuntu) install steps (click to expand)</summary>
+
+Add Docker's official apt repository (verified by its signed GPG key), then
+install `docker-sbx` — instead of piping a remote script into a root shell:
+
 ```bash
-curl -fsSL https://get.docker.com | sudo REPO_ONLY=1 sh
-sudo apt-get install docker-sbx
-sudo usermod -aG kvm $USER && newgrp kvm
+# 1. Add Docker's apt repo with its verified signing key
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# 2. Install the sbx package from the now-trusted repo
+sudo apt-get update
+sudo apt-get install -y docker-sbx
+sudo usermod -aG kvm "$USER" && newgrp kvm
 sbx login
 ```
 
+See [Docker's apt install docs](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository).
+
 </details>
+
+> **Tip (macOS):** install `sbx` via Homebrew (shown above) rather than a
+> downloaded installer, so Homebrew verifies the formula and keeps it updatable
+> with `brew upgrade`.
 
 **Check it worked:** after `sbx login` finishes with no error, run `sbx version`.
 You should see a line like `sbx version: v0.32.0 <sha>`.


### PR DESCRIPTION
## Summary

Replaces the Linux Docker install step that piped a remote script into a root shell:

```bash
curl -fsSL https://get.docker.com | sudo REPO_ONLY=1 sh   # ❌ unverified remote code as root
```

with the explicit apt-repo flow **gated behind Docker's published GPG signing key**, so apt verifies package authenticity (no unpinned, unverified remote execution — consistent with the federal supply-chain posture). Adds a macOS tip to prefer Homebrew over a downloaded installer. Mirrors [Docker's official apt install docs](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository).

Closes #155.

## Supersedes #180

This **supersedes PR #180**, which bundled two things: this Docker-install hardening **and** a change to the pre-commit `shellcheck` hook (swap `shellcheck-py` → a system-binary local hook) to dodge `CERTIFICATE_VERIFY_FAILED` behind a TLS-intercepting proxy (ZScaler).

The shellcheck part is **dropped** because the correct fix is **trusting the ZScaler CA inside the sandbox** — the `zscaler-ca-certificate` sbx mixin kit (patterns [#191](https://github.com/GSA-TTS/agentic-coding-patterns/pull/191)) — not a non-downloading hook (which was solving the wrong layer). So this PR is the supply-chain README hardening **only**, rebuilt cleanly off current `main` to avoid the `opencode.jsonc` entanglement #180's branch carried.

#180 will be closed in favor of this.

## Verification
- `npm run lint:md` → 0 errors

## Type of Change
- [x] Documentation (supply-chain hardening)

🤖 AI-assisted (OpenCode).