### PR TITLE
chore: gitignore qsbx backups and repomix dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,13 @@ tmp/
 temp/
 deleteme/
 
+# qsbx config backups (qsbx writes <target>.<timestamp>.qsbx-bak before overwriting)
+*.qsbx-bak
+
+# repomix / repo-packing dumps (generated for LLM context, never committed)
+repomix-output.*
+.repomix/
+
 # =========================
 # NODE.JS
 # =========================


### PR DESCRIPTION
## Summary

Two generated-artifact patterns were slipping past `.gitignore`:

- **`*.qsbx-bak`** — `qsbx` writes `<target>.<timestamp>.qsbx-bak` when backing up an existing config before overwriting it. The timestamped suffix isn't caught by the existing `*.bak` (the extension is `-bak`, not `.bak`), so these backups could be committed.
- **`repomix-output.*` / `.repomix/`** — repomix repo-packing dumps generated for LLM context; never meant to be committed (one was found untracked in a working tree).

Minimal, node/shell-appropriate; no behavior change.

## Type of Change
- [x] Chore (repo hygiene)

🤖 AI-assisted (OpenCode).