### PR TITLE
fix(docs): remove duplicate <details> tag that breaks rendering of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,6 @@ sbx login
 <details>
 <summary>Show Linux (Ubuntu) install steps (click to expand)</summary>
 
-<details>
-<summary>Show Linux (Ubuntu) install steps (click to expand)</summary>
-
 Add Docker's official apt repository (verified by its signed GPG key), then
 install `docker-sbx` — instead of piping a remote script into a root shell:
 


### PR DESCRIPTION
## Summary

The README is not rendering correctly. If you view it at https://github.com/GSA-TTS/agentic-coding-quickstart, it only renders down through step 2 in the quickstart steps. This PR removes a duplicate HTML tag that was breaking the rendering.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits format](../CONTRIBUTING.md#commit-message-guidelines) (e.g., `feat:`, `fix:`, `docs:`)
- [x] I have tested my changes locally
- [x] I have updated documentation as needed
- [x] I have not included any secrets, API keys, or sensitive information

## Test Results

<!-- How did you verify this works? Include commands run or screenshots -->

## Additional Notes

<!-- Any additional context reviewers should know -->
