### PR TITLE
feat(sbx): bump patterns kit ref to v1.5.0 release

### DIFF
--- a/qsbx
+++ b/qsbx
@@ -70,7 +70,7 @@ QUICKSTART_CLONE="${QUICKSTART_CLONE:-$SCRIPT_DIR}"
 # commit below (sbx requires remote kit refs to be a full 40-char commit SHA).
 # ============================================================================
 PATTERNS_KIT_REPO="git+https://github.com/GSA-TTS/agentic-coding-patterns.git"
-PATTERNS_KIT_REF="6cb6cde94f228073555837028cb5150b7c80005a"  # -patterns main @ PR #201 merge (relaxes usai-provider permissions)
+PATTERNS_KIT_REF="d2a379ff7cdff611d6d623a1ce7b21e543f76ea8"  # -patterns v1.5.0 release
 PATTERNS_KIT_DIR="integrations/isolation/sbx-kits"
 
 # Remote kit references (repo#ref=<sha>&dir=<subpath>). Applied in order via


### PR DESCRIPTION
## Context

`qsbx` applies four sbx mixin kits from `GSA-TTS/agentic-coding-patterns`
by a pinned commit SHA. The ref was pinned to `6cb6cde` (main @ PR #201
merge). This bumps it to the **v1.5.0** release commit so we start pulling
in the kit updates shipped since v1.4.0.

## Changes

- `qsbx:73` — `PATTERNS_KIT_REF`
  - From: `6cb6cde94f228073555837028cb5150b7c80005a` (main @ PR #201 merge)
  - To:   `d2a379ff7cdff611d6d623a1ce7b21e543f76ea8` (v1.5.0 tag)

Single-line change. All four kit refs (`USAI_KIT`, `PLAYBOOK_KIT`,
`ZSCALER_KIT`, `GITSSHSIGN_KIT`) interpolate `PATTERNS_KIT_REF`, so this
one bump covers every kit.

## What we pull in (v1.4.0+PR#201 -> v1.5.0)

- **usai-provider now merges into** the global opencode config instead of
  overwriting it (patterns#216)
- Skill schema tightened: `additionalProperties: false` + new `name`
  field (patterns#202)
- Security Skills Pack M2 additions (patterns#205, #206)
- unsafe-shell-pattern scanner wired into CI (patterns#210)

## Verification

- [x] SHA confirmed against the `v1.5.0` git tag via GitHub API
      (`refs/tags/v1.5.0` -> `d2a379ff7cdff611d6d623a1ce7b21e543f76ea8`)
- [x] 40-char full commit SHA (sbx requirement for remote kit refs)
- [x] Confirmed no other file hardcoded the old SHA (grep clean)
- [x] Live sandbox re-verify performed (verified by maintainer)

## Rollback

Revert this commit, or reset `PATTERNS_KIT_REF` in `qsbx` back to
`6cb6cde94f228073555837028cb5150b7c80005a`, then recreate sandboxes.

## Security Impact

Supply-chain: changes the pinned source commit for the four sbx kits
(includes the USAi provider that allow-lists egress and configures the
OpenCode provider). Target is a signed release tag on the trusted
`GSA-TTS/agentic-coding-patterns` repo; source prefix
(`github.com/GSA-TTS/`) is already on the kit.allowedSources allowlist —
no boundary change.

AI-assisted: ref bump and PR prepared by an AI coding agent; SHA and live
sandbox behavior verified by the maintainer.
