### PR TITLE
fix(sbx): align qsbx docs/verify with v1.5.0 usai-provider global-config merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,11 @@ my-workspace/                       # Parent folder (user creates this)
 When `qsbx` creates a sandbox it applies four kits by pinned remote reference
 (`--kit git+https://github.com/GSA-TTS/agentic-coding-patterns.git#ref=<sha>&dir=…`):
 
-- **`usai-provider`** — drops `~/usai-config/opencode.jsonc` and sets
-  `OPENCODE_CONFIG` to point there (allow-listing USAi egress), so OpenCode uses
-  the GSA USAi gateway. It owns the single-valued `OPENCODE_CONFIG` channel.
+- **`usai-provider`** — stages a USAi `opencode.jsonc` at `~/usai-config/` and,
+  at container startup, merges it into OpenCode's **global** config path
+  (`~/.config/opencode/opencode.jsonc`) — copying verbatim into an empty global
+  dir, deep-merging into an existing one — so OpenCode uses the GSA USAi gateway
+  (allow-listing USAi egress). It no longer sets `OPENCODE_CONFIG`.
 - **`agentic-coding-playbook`** — at container startup, clones the playbook at a
   pinned ref into `~/.agentic-coding-playbook` and symlinks its `AGENTS.md` into
   each agent's rules path (e.g. `~/.config/opencode/AGENTS.md`) and each skill
@@ -72,7 +74,7 @@ When working on user projects, the agent has access to:
 
 | Resource | Location | Use For |
 |----------|----------|---------|
-| Global config | `~/usai-config/opencode.jsonc` (via kit `OPENCODE_CONFIG`) | Model/provider config |
+| Global config | `~/.config/opencode/opencode.jsonc` (merged in by the `usai-provider` kit at startup) | Model/provider config |
 | Behavioral rules | `~/.config/opencode/AGENTS.md` (linked to playbook clone) | Federal agent rules |
 | Skills | `~/.agents/skills` (linked to playbook clone) | Step-by-step procedures |
 | Setup guides | `./docs/` | SBX configuration, troubleshooting |

--- a/README.md
+++ b/README.md
@@ -350,8 +350,11 @@ quickstart for when you want to customize or troubleshoot.
 community [agentic-coding-patterns](https://github.com/GSA-TTS/agentic-coding-patterns)
 repo) when it creates a sandbox, delivering everything declaratively:
 
-- **`usai-provider`** — drops the USAi config at `~/usai-config/opencode.jsonc`
-  and sets `OPENCODE_CONFIG` to point there (allow-listing USAi egress).
+- **`usai-provider`** — stages the USAi config at `~/usai-config/opencode.jsonc`
+  and, at startup, merges it into OpenCode's global config at
+  `~/.config/opencode/opencode.jsonc` (allow-listing USAi egress). It composes
+  with, rather than clobbers, any existing global config, and no longer sets
+  `OPENCODE_CONFIG`.
 - **`agentic-coding-playbook`** — clones the playbook at startup into
   `~/.agentic-coding-playbook` and symlinks its `AGENTS.md` into each agent's
   rules path and its skills into `~/.agents/skills` (+ per-agent roots).

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -592,16 +592,18 @@ Your existing sandboxes and secrets will continue to work with the `sbx` CLI.
 
 The USAi provider config is not loaded in the sandbox. With `qsbx`, it is
 delivered by the `usai-provider` sbx **kit** (applied by pinned remote reference
-from the agentic-coding-patterns repo), which sets `OPENCODE_CONFIG` to
-`~/usai-config/opencode.jsonc`. `qsbx` applies it alongside the
-`agentic-coding-playbook` and `zscaler-ca-certificate` kits. This symptom appears
-when the sandbox was created without `qsbx` (so the kits were not applied), or
-with plain `sbx run` without the kit refs.
+from the agentic-coding-patterns repo), which stages an `opencode.jsonc` at
+`~/usai-config/` and, at startup, merges it into OpenCode's global config at
+`~/.config/opencode/opencode.jsonc` (the kit no longer sets `OPENCODE_CONFIG`).
+`qsbx` applies it alongside the `agentic-coding-playbook` and
+`zscaler-ca-certificate` kits. This symptom appears when the sandbox was created
+without `qsbx` (so the kits were not applied), or with plain `sbx run` without
+the kit refs.
 
 **Upgrading an existing sandbox (pre-kit).** A sandbox created with an *older*
-`qsbx` (before the kit migration) has no `OPENCODE_CONFIG` and no playbook clone.
-`qsbx` cannot auto-heal it in place: the fix would be `sbx kit add`, but an
-upstream sbx bug ([docker/sbx-releases#133][sbx133]) makes `sbx kit add` fail
+`qsbx` (before the kit migration) has no USAi provider config and no playbook
+clone. `qsbx` cannot auto-heal it in place: the fix would be `sbx kit add`, but
+an upstream sbx bug ([docker/sbx-releases#133][sbx133]) makes `sbx kit add` fail
 (`failed to read tar header: unexpected EOF`) on any kit that ships a static
 file — and the `usai-provider` kit ships `opencode.jsonc`. Because a sandbox
 without the USAi provider config is unusable, in-place healing is **disabled**
@@ -622,8 +624,9 @@ Instead, when you `qsbx run` an existing pre-kit sandbox, `qsbx` offers to
    name. This is irreversible, so `qsbx` only does it *after* a successful,
    verified export, and never if you decline or the export captures nothing.
 4. It recreates the sandbox with all the kits, **verifies the USAi kit
-   actually applied** (checks for the config file at
-   `/home/agent/usai-config/opencode.jsonc`), and only then imports the sessions.
+   actually applied** (checks for the kit's staged config file at
+   `/home/agent/usai-config/opencode.jsonc`, which the kit ships and merges into
+   the global config at startup), and only then imports the sessions.
    If the recreate or verification fails, it stops and keeps your exported
    sessions in a temp directory rather than importing into a broken sandbox.
 

--- a/qsbx
+++ b/qsbx
@@ -9,8 +9,9 @@
 # Solution: when qsbx creates a sandbox it applies FOUR sbx mixin kits from the
 # community agentic-coding-patterns repo, by remote reference pinned to a commit
 # (see PATTERNS_KIT_REF below), so every sandbox is configured declaratively:
-#   1. usai-provider     — configures the USAi OpenCode provider (drops
-#      ~/usai-config/opencode.jsonc and sets OPENCODE_CONFIG; allow-lists USAi
+#   1. usai-provider     — configures the USAi OpenCode provider (stages
+#      ~/usai-config/opencode.jsonc and merges it into OpenCode's global config
+#      at ~/.config/opencode/opencode.jsonc at startup; allow-lists USAi
 #      egress).
 #   2. agentic-coding-playbook — at container startup, clones the playbook at a
 #      pinned ref and symlinks its AGENTS.md + skills into each agent's search
@@ -147,7 +148,7 @@ fi
 # fails ("failed to read tar header: unexpected EOF") on any kit that ships a
 # static files/ payload (docker/sbx-releases#133). The usai-provider kit ships
 # files/opencode.jsonc, so it cannot be injected into a running sandbox — and a
-# sandbox without the USAi provider config is unusable (no OPENCODE_CONFIG, no
+# sandbox without the USAi provider config is unusable (no USAi provider, no
 # endpoint, no models), so healing only the other two kits is pointless. Instead
 # of a doomed `sbx kit add`, qsbx offers an assisted session migration (see
 # migrate_or_halt) or halts with documented options. Re-enable this (export
@@ -502,10 +503,11 @@ create_with_config() {
 }
 
 # Heal a sandbox created before qsbx applied these kits. Such sandboxes may lack
-# the USAi provider config (no OPENCODE_CONFIG), the playbook clone, and/or the
-# Zscaler CA. We detect each and inject the missing kit into the running sandbox
-# with `sbx kit add` — no recreation needed. Best-effort: if the (experimental)
-# command fails, warn with the manual recovery step and continue to attach.
+# the USAi provider config (no staged usai-config), the playbook clone, and/or
+# the Zscaler CA. We detect each and inject the missing kit into the running
+# sandbox with `sbx kit add` — no recreation needed. Best-effort: if the
+# (experimental) command fails, warn with the manual recovery step and continue
+# to attach.
 #
 # Wait until `sbx exec` works in a sandbox, or the readiness timeout elapses.
 # Returns 0 once a trivial exec succeeds, 1 if it never does within the budget.
@@ -593,16 +595,20 @@ ensure_kit_applied() {
 
   ensure_kit_sources_allowed
 
-  # 1) USAi provider kit: present iff the kit's config file is present. (We probe
-  #    the dropped file, not the OPENCODE_CONFIG env var, which an exec shell may
-  #    not see — see USAI_KIT_CONFIG_PATH.)
+  # 1) USAi provider kit: present iff the kit's staged config file is present.
+  #    (We probe the file the kit ships, not any env var: the kit no longer sets
+  #    OPENCODE_CONFIG, and kit-injected env is not reliably visible to an exec
+  #    shell anyway — see USAI_KIT_CONFIG_PATH.)
   if kit_feature_absent "$name" "test -f '$USAI_KIT_CONFIG_PATH' && echo present"; then
     echo "qsbx: '$name' is missing the USAi kit (no config file); injecting it" >&2
     echo "      with 'sbx kit add'..." >&2
     if sbx kit add "$name" "$USAI_KIT" </dev/null >/dev/null 2>&1; then
-      # A stale ~/.config/opencode/opencode.jsonc symlink (to the removed
-      # opencode/ path) is now harmless — OPENCODE_CONFIG takes precedence — but
-      # remove it if it dangles so it can't confuse OpenCode or the user.
+      # The kit's startup step merges its config into the GLOBAL path
+      # (~/.config/opencode/opencode.jsonc). A leftover dangling SYMLINK there
+      # from a much older layout (when that path symlinked into a since-removed
+      # opencode/ dir) would block that write, so remove it if — and only if — it
+      # is a symlink that no longer resolves. A real merged config file is left
+      # untouched (the guard requires -L).
       sbx exec "$name" -- sh -c \
         'f="$HOME/.config/opencode/opencode.jsonc"; if [ -L "$f" ] && [ ! -e "$f" ]; then rm -f "$f"; fi' \
         </dev/null >/dev/null 2>&1 || true
@@ -668,17 +674,21 @@ sandbox_exists() {
   sbx ls -q 2>/dev/null | grep -Fxq -- "$1"
 }
 
-# Absolute path where the usai-provider kit installs its OpenCode config (and
-# sets OPENCODE_CONFIG to). We detect the kit by the presence of THIS FILE rather
-# than the OPENCODE_CONFIG env var: kit-injected env vars reach the agent process
-# but are not reliably visible to a fresh `sbx exec … sh -c` shell, whereas the
-# dropped file always is. Keep in sync with the kit's spec.yaml.
+# Absolute path where the usai-provider kit STAGES its OpenCode config. As of the
+# patterns v1.5.0 kit this staged file is the merge SOURCE: a startup step merges
+# it into OpenCode's GLOBAL config (~/.config/opencode/opencode.jsonc), and the
+# kit no longer sets OPENCODE_CONFIG. We still detect the kit by the presence of
+# THIS staged FILE (not an env var, and not the merged global config): the kit
+# always ships it, so it is present iff the kit was applied — including in a
+# stopped sandbox where the startup merge has not re-run. kit-injected env vars
+# are also not reliably visible to a fresh `sbx exec … sh -c` shell. Keep in sync
+# with the kit's spec.yaml.
 USAI_KIT_CONFIG_PATH="/home/agent/usai-config/opencode.jsonc"
 
 # True (0) iff an existing sandbox lacks the USAi provider config — i.e. it was
-# created before the kit migration. We probe for the config FILE the kit drops
-# (see USAI_KIT_CONFIG_PATH), not the OPENCODE_CONFIG env var, because the env
-# var isn't reliably visible to an exec shell.
+# created before the kit migration. We probe for the staged config FILE the kit
+# ships (see USAI_KIT_CONFIG_PATH), not the merged global config or any env var,
+# because the staged file is the most reliable "kit applied" signal.
 #
 # Waits for exec readiness first: a stopped/just-touched sandbox's exec times out
 # for a while, and treating that as "config absent" would wrongly trigger a

--- a/scripts/verify-migrate-live
+++ b/scripts/verify-migrate-live
@@ -6,18 +6,19 @@
 # machine that can create sandboxes (Docker + KVM, `sbx login` done).
 #
 # It proves the claim behind PR #184 / issue #188: when qsbx meets an existing
-# sandbox that predates the kit migration (no OPENCODE_CONFIG), it can export
-# that sandbox's sessions, remove and recreate it under the same name with the
-# kits, import the sessions back, and end up with a WORKING USAi provider.
+# sandbox that predates the kit migration (no USAi provider config), it can
+# export that sandbox's sessions, remove and recreate it under the same name with
+# the kits, import the sessions back, and end up with a WORKING USAi provider.
 #
 # What it does (all on a throwaway sandbox named qsbx-migrate-verify-<pid>):
 #   1. Create a "pre-kit" sandbox WITHOUT the kits (plain `sbx create opencode`),
-#      so it has no OPENCODE_CONFIG — the exact condition migrate_or_halt targets.
+#      so it has no USAi provider config — the condition migrate_or_halt targets.
 #   2. Seed a session in it via `opencode run` so there is something to migrate.
-#   3. Record the session id(s) and confirm OPENCODE_CONFIG is absent (pre-state).
+#   3. Record the session id(s) and confirm the USAi config is absent (pre-state).
 #   4. Run `qsbx run opencode <dir>` and answer "y" to the migration prompt.
-#   5. Assert post-state: OPENCODE_CONFIG is now set (USAi kit applied), the
-#      USAi models endpoint answers 200, and the migrated session id survived.
+#   5. Assert post-state: the USAi kit is applied (its config landed at OpenCode's
+#      global path), OpenCode resolves a USAi model, and the migrated session id
+#      survived.
 #   6. Clean up the throwaway sandbox (always, via trap).
 #
 # Usage:
@@ -36,11 +37,17 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 QSBX="$REPO_ROOT/qsbx"
 
 SANDBOX="qsbx-migrate-verify-$$"
-# Absolute path where the usai-provider kit drops its OpenCode config (and points
-# OPENCODE_CONFIG at). We detect the kit by this FILE, not the env var, because
-# kit-injected env is not reliably visible to a fresh `sbx exec` shell. Keep in
-# sync with the kit's spec.yaml / qsbx's USAI_KIT_CONFIG_PATH.
+# Absolute path where the usai-provider kit STAGES its OpenCode config. As of the
+# patterns v1.5.0 kit this is the merge SOURCE, not the path OpenCode reads: a
+# startup step merges it into the GLOBAL config (see GLOBAL_CFG below). qsbx keys
+# its pre-kit detection off this staged file (USAI_KIT_CONFIG_PATH), so the
+# pre-state probe here mirrors it. Keep in sync with qsbx's USAI_KIT_CONFIG_PATH.
 KIT_CFG="/home/agent/usai-config/opencode.jsonc"
+# Absolute path OpenCode actually reads. The kit's startup merge lands its config
+# here (copying verbatim into an empty global dir, deep-merging into an existing
+# one). This is the authoritative post-migration artifact — the kit's own
+# scripts/verify asserts on this path. The kit no longer sets OPENCODE_CONFIG.
+GLOBAL_CFG="/home/agent/.config/opencode/opencode.jsonc"
 WORKDIR="${1:-}"
 MADE_WORKDIR=0
 PASS=0
@@ -84,7 +91,7 @@ cleanup() {
   info "Cleanup"
   if [ "${KEEP:-0}" = "1" ]; then
     echo "  KEEP=1 set — leaving sandbox '$SANDBOX' and workspace '$WORKDIR' in place." >&2
-    echo "  Inspect with:  sbx exec $SANDBOX -- sh -c 'ls -la /home/agent/usai-config; env | grep -i opencode'" >&2
+    echo "  Inspect with:  sbx exec $SANDBOX -- sh -c 'ls -la /home/agent/.config/opencode /home/agent/usai-config'" >&2
     echo "  Remove later:  sbx rm --force $SANDBOX" >&2
     return
   fi
@@ -119,7 +126,7 @@ else
   echo "  using provided workspace: $WORKDIR"
 fi
 
-# --- 1) Create a pre-kit sandbox (no kits => no OPENCODE_CONFIG) -------------
+# --- 1) Create a pre-kit sandbox (no kits => no USAi provider config) --------
 info "1) Creating a pre-kit sandbox WITHOUT kits: $SANDBOX"
 if sbx create --name "$SANDBOX" opencode "$WORKDIR" >/dev/null 2>&1; then
   ok "created pre-kit sandbox"
@@ -147,9 +154,10 @@ fi
 
 # --- 3) Confirm the pre-state: USAi kit config absent ------------------------
 info "3) Confirming pre-state (USAi config absent)"
-# Probe the kit's config FILE, not the OPENCODE_CONFIG env var (an exec shell
-# may not see kit-injected env). This is the same signal qsbx uses to decide a
-# sandbox is "pre-kit".
+# Probe the kit's STAGED config FILE (KIT_CFG). This is the same signal qsbx uses
+# to decide a sandbox is "pre-kit" (sandbox_missing_usai / USAI_KIT_CONFIG_PATH):
+# the file the kit ships, not any env var (an exec shell may not see kit-injected
+# env). A plain `sbx create opencode` writes no such file, so it is absent here.
 pre_cfg=$(sbx_exec_retry "$SANDBOX" "test -f '$KIT_CFG' && echo yes" || true)
 if [ "$pre_cfg" != "yes" ]; then
   ok "USAi kit config absent (this is a genuine pre-kit sandbox)"
@@ -179,31 +187,30 @@ info "5) Asserting post-state (working USAi + sessions survived)"
 echo "  (waiting for the recreated sandbox to become exec-ready...)"
 wait_ready "$SANDBOX" || echo "  (warning: sandbox not exec-ready within ${READY_TIMEOUT}s; probes may be unreliable)" >&2
 
-# The usai-provider kit sets OPENCODE_CONFIG to this path and drops the config
-# file there (with an ownership-marker comment). Note: a kit's environment
-# variables are injected into the AGENT process, but a fresh `sbx exec … sh -c`
-# shell may not inherit them, so reading $OPENCODE_CONFIG is unreliable. Assert
-# on the artifact the kit actually installs instead — the config file and its
-# marker — mirroring the kit's own scripts/verify.
-KIT_CFG="/home/agent/usai-config/opencode.jsonc"
-cfg_present=$(sbx_exec_retry "$SANDBOX" "test -f '$KIT_CFG' && echo yes" || true)
-marker_present=$(sbx_exec_retry "$SANDBOX" "grep -q 'usai-provider-kit:owns-opencode-config' '$KIT_CFG' 2>/dev/null && echo yes" || true)
-if [ "$cfg_present" = "yes" ] && [ "$marker_present" = "yes" ]; then
-  ok "usai-provider kit applied (config file + ownership marker present at $KIT_CFG)"
+# The usai-provider kit's startup step merges its config into OpenCode's GLOBAL
+# path (GLOBAL_CFG) and no longer sets OPENCODE_CONFIG. Assert on the artifact
+# the kit actually installs — the global config file carrying the USAi provider —
+# mirroring the kit's own scripts/verify. The staged source (KIT_CFG) also still
+# exists (it is the merge source), and when the global dir starts empty the merge
+# copies KIT_CFG verbatim, preserving the ownership marker; after a merge into a
+# pre-existing config the marker (a comment) is dropped, so we do not require it.
+cfg_present=$(sbx_exec_retry "$SANDBOX" "test -f '$GLOBAL_CFG' && echo yes" || true)
+usai_in_cfg=$(sbx_exec_retry "$SANDBOX" "grep -q '\"usai\"' '$GLOBAL_CFG' 2>/dev/null && echo yes" || true)
+if [ "$cfg_present" = "yes" ] && [ "$usai_in_cfg" = "yes" ]; then
+  ok "usai-provider kit applied (USAi provider present in global config at $GLOBAL_CFG)"
 elif [ "$cfg_present" = "yes" ]; then
-  bad "USAi config present but ownership marker missing" "kit may be a partial/older version"
+  bad "global config present but USAi provider missing" "kit merge may have failed"
 else
-  bad "USAi config file missing at $KIT_CFG" "the usai-provider kit did not apply"
+  bad "global OpenCode config missing at $GLOBAL_CFG" "the usai-provider kit did not apply"
 fi
 
-# Belt-and-suspenders: OPENCODE_CONFIG should also point at that file when read
-# from the agent's own environment. This is informational (see the note above),
-# so it never fails the run — it just corroborates the artifact check.
-env_cfg=$(sbx_exec_retry "$SANDBOX" 'printf "%s" "${OPENCODE_CONFIG:-}"' || true)
-if [ "$env_cfg" = "$KIT_CFG" ]; then
-  ok "OPENCODE_CONFIG in-env points at the kit config"
+# Corroboration: the kit stages its source config at KIT_CFG (the merge source),
+# which should also survive. Informational — never fails the run.
+staged_present=$(sbx_exec_retry "$SANDBOX" "test -f '$KIT_CFG' && echo yes" || true)
+if [ "$staged_present" = "yes" ]; then
+  ok "kit staging source present at $KIT_CFG"
 else
-  echo "  (note: OPENCODE_CONFIG read from an exec shell was '${env_cfg:-<unset>}'; kit env isn't always visible to a fresh 'sbx exec' shell — the artifact check above is authoritative)" >&2
+  echo "  (note: staged source '$KIT_CFG' absent; the global config check above is authoritative)" >&2
 fi
 
 # NOTE: we deliberately do NOT probe the USAi HTTP endpoint with USAI_API_KEY as
@@ -211,7 +218,7 @@ fi
 # kit, so `curl … /models` returns 200 even in a sandbox where the kit never
 # applied — a false positive that masked a real migration bug during
 # development. The authoritative signal that the provider is configured is the
-# kit's config file + ownership marker, checked above. As a functional
+# global config carrying the USAi provider, checked above. As a functional
 # corroboration, confirm OpenCode itself resolves the USAi provider.
 usai_models=$(sbx_exec_retry "$SANDBOX" 'opencode models 2>/dev/null | grep -i usai | head -1' || true)
 if [ -n "$usai_models" ]; then
@@ -220,18 +227,17 @@ else
   echo "  (note: could not confirm a USAi model via 'opencode models'; the config-file check above is authoritative for kit application)" >&2
 fi
 
-# Diagnostic dump: when the artifact and the 200 disagree (as they did during
-# investigation), show what the recreated sandbox actually contains so we can
-# see where the kit config landed (or didn't). Runs whenever the file check
-# failed, or always under KEEP=1.
+# Diagnostic dump: when the global config check fails, show what the recreated
+# sandbox actually contains so we can see where the kit config landed (or
+# didn't). Runs whenever the file check failed, or always under KEEP=1.
 if [ "$cfg_present" != "yes" ] || [ "${KEEP:-0}" = "1" ]; then
   info "Diagnostics (kit artifact locations)"
-  echo "  --- ls -la /home/agent/usai-config (expected kit config dir) ---" >&2
+  echo "  --- ls -la /home/agent/.config/opencode (global config dir) ---" >&2
+  sbx_exec_retry "$SANDBOX" 'ls -la /home/agent/.config/opencode 2>&1 || echo "(missing)"' >&2 || true
+  echo "  --- ls -la /home/agent/usai-config (kit staging dir) ---" >&2
   sbx_exec_retry "$SANDBOX" 'ls -la /home/agent/usai-config 2>&1 || echo "(missing)"' >&2 || true
   echo "  --- any opencode.jsonc under /home/agent ---" >&2
   sbx_exec_retry "$SANDBOX" 'find /home/agent -name "opencode.json*" 2>/dev/null || echo "(none)"' >&2 || true
-  echo "  --- OPENCODE_CONFIG in a login shell ---" >&2
-  sbx_exec_retry "$SANDBOX" 'sh -lc "printf %s \"\${OPENCODE_CONFIG:-<unset>}\""' >&2 || true
   echo "" >&2
 fi
 


### PR DESCRIPTION
## Context

> AI-assisted change (OpenCode agent, USAi `claude_4_8_opus`), reviewed by the author.

Quickstart **v1.0.0** bumped `PATTERNS_KIT_REF` to patterns **v1.5.0**, which incorporated a change to the `usai-provider` kit (kit ADR-0004): it **stopped setting `OPENCODE_CONFIG`** and now **merges** its staged `~/usai-config/opencode.jsonc` into OpenCode's **global** config at `~/.config/opencode/opencode.jsonc` at startup (copy-verbatim into an empty global dir, deep-merge into an existing one).

I audited every qsbx behavior that relies on the presence/absence/location of `opencode.jsonc`.

**Good news — the load-bearing runtime logic still works.** qsbx detects a pre-kit sandbox and verifies post-migration by probing the *staged* file `USAI_KIT_CONFIG_PATH=/home/agent/usai-config/opencode.jsonc`. The v1.5.0 kit still ships that file (it's the merge source), so `sandbox_missing_usai`, `ensure_kit_applied`, and `migrate_or_halt`'s post-recreate check remain correct.

**What had drifted** (the subject of this PR):

1. `scripts/verify-migrate-live` asserted post-migration state on **`OPENCODE_CONFIG`** (now never set) plus the staged file + ownership marker. The `OPENCODE_CONFIG` corroboration would always emit a misleading "unset" note. The kit's *own* `scripts/verify` was updated to check the global path; this quickstart script was not.
2. `qsbx` comments described the removed `OPENCODE_CONFIG` channel, and the dangling-symlink cleanup in `ensure_kit_applied` had an **inverted rationale** ("`OPENCODE_CONFIG` takes precedence").
3. `AGENTS.md`, `README.md`, `docs/KNOWN_FAILURE_MODES.md` all still documented the `OPENCODE_CONFIG → ~/usai-config/opencode.jsonc` delivery model.

## Plan / Changes

- **`scripts/verify-migrate-live`** — authoritative post-migration check now targets the global config `~/.config/opencode/opencode.jsonc` containing `provider.usai` (mirrors the kit's `scripts/verify`); staged-file check kept as informational corroboration; removed the misleading `OPENCODE_CONFIG` probe; refreshed the header, pre-state comments, and the diagnostics dump.
- **`qsbx`** — corrected `USAI_KIT_CONFIG_PATH` / `ensure_kit_applied` / header comments to the stage-then-merge model; clarified the symlink cleanup only removes a *dangling* symlink that would block the global-config merge (guard requires `-L` + unresolved), never a real merged file. **No behavior change.**
- **`AGENTS.md` / `README.md` / `docs/KNOWN_FAILURE_MODES.md`** — describe the global-config merge mechanism.

## Verification

```
$ ./scripts/test-migrate-or-halt
  passed: 33   failed: 0

$ npm run lint:md
  Summary: 0 error(s)

$ bash -n qsbx && bash -n scripts/verify-migrate-live
  (syntax OK)
```

`verify-migrate-live` and the kit's own `scripts/verify` require a host that can create sandboxes (Docker + KVM, `sbx login`), so they were not run here; the offline harness + linters were.

## Rollback

Revert this commit — it is documentation + one verification script + non-functional qsbx comments.

## Security Impact

None. No change to auth/authz, data handling, network egress, or qsbx's detection/migration control flow.