### PR TITLE
fix(sbx): recover sandboxes with orphaned USAi placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,28 @@ For the signing mechanics and more failure modes, see the kit's
 
 </details>
 
+<details>
+<summary><strong>Pulled a branch but qsbx behaves like the old version</strong> (click to expand)</summary>
+
+`git pull origin <branch>` does **not** switch you to that branch — it merges
+into the branch you are already on, so `Already up to date` does not mean your
+working tree changed. Also, if `qsbx`/`qsb` is on your `PATH` (e.g. a symlink in
+`~/bin`), it may resolve to a **different clone** than the one you edited.
+
+Ask qsbx which file and clone are actually running:
+
+```bash
+qsbx version
+```
+
+It prints the resolved script path, the clone directory, and that clone's
+`branch@commit`. If it isn't what you expect, either `git switch <branch>` in the
+clone you run from, or re-point your `qsbx` symlink (`readlink -f "$(command -v
+qsbx)"` shows where it goes). See
+[docs/KNOWN_FAILURE_MODES.md §24](docs/KNOWN_FAILURE_MODES.md).
+
+</details>
+
 ---
 
 ## Why Sandboxes?

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -898,6 +898,80 @@ sbx secret set-custom <sandbox-name> --host api.gsa.usai.gov \
 
 ---
 
+## 24. Pulled/Switched a Branch but qsbx Still Shows Old Behavior
+
+### Symptoms
+
+- You `git pull` or `git checkout` a branch with a fix, but `qsbx`/`qsb` still
+  prints wording or behaves in a way that only exists in an **older** version.
+- `git pull origin <branch>` prints **`Already up to date.`** yet nothing changes.
+- You are `cd`'d into a quickstart clone, but the behavior does not match the
+  code you see in that clone's `qsbx`.
+
+### Root Cause
+
+Two independent traps, often combined:
+
+1. **`git pull origin <branch>` does not switch you to that branch.** `pull` =
+   `fetch` + `merge FETCH_HEAD` into the branch you are **currently on**.
+   `Already up to date` means the *merge* was a no-op — **not** that your working
+   tree now contains the branch. If you never ran `git switch <branch>` /
+   `git checkout <branch>`, your working tree still has the old `qsbx`.
+
+2. **A `qsbx`/`qsb` on your `PATH` points at a *different* clone.** If `qsb` is an
+   alias for the bare name `qsbx` (not `./qsbx`), the shell resolves it via
+   `PATH`. A symlink in `~/bin` or `/usr/local/bin` may point at a **different
+   clone** than the one you edited/pulled. `qsbx` follows that symlink to find
+   its own directory, so it runs the *other* clone's code — you update clone A
+   and execute clone B.
+
+A related variant: exporting `QUICKSTART_CLONE` overrides where sibling helper
+scripts are located, which can also make "which clone is in effect" confusing.
+
+### Fix
+
+First, ask qsbx which file and clone are actually running:
+
+```bash
+qsbx version
+```
+
+It prints the resolved script path, the clone directory, and that clone's git
+branch@commit (and flags if the tree is dirty or `QUICKSTART_CLONE` is set).
+Compare the branch/commit against what you expect.
+
+Then, depending on which trap you hit:
+
+- **Wrong branch checked out:** switch (don't just pull):
+
+  ```bash
+  git switch fix/your-branch      # or: git checkout fix/your-branch
+  git rev-parse --abbrev-ref HEAD # confirm
+  ```
+
+- **Running a different clone via a PATH symlink:** either run the clone you
+  updated directly, or re-point the symlink:
+
+  ```bash
+  # Run the clone you actually updated:
+  ./qsbx run opencode <your-project>
+
+  # …or see where the installed one lives and re-point it:
+  readlink -f "$(command -v qsbx)"
+  ```
+
+When you run `qsbx run` from inside one quickstart clone while the executing
+`qsbx` lives in another, qsbx now prints a startup note pointing this out.
+
+### Prevention
+
+- Use `git switch <branch>` to change branches; treat `Already up to date` as a
+  signal to check `git rev-parse --abbrev-ref HEAD`, not confirmation.
+- Keep a single canonical clone, and make any `qsbx`/`qsb` on `PATH` a symlink to
+  that clone's `qsbx`. Run `qsbx version` when in doubt.
+
+---
+
 ## Debugging Checklist
 
 When something fails, work through this list:

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -3,7 +3,7 @@ title: "Known Failure Modes"
 description: "Real-world failure patterns when using Docker SBX + USAi + agent frameworks"
 status: canonical
 tier: 2
-last_updated: "2026-07-03"
+last_updated: "2026-07-08"
 audience: "developers"
 keywords: ["debugging", "troubleshooting", "sbx", "usai", "failures"]
 ---
@@ -791,6 +791,110 @@ failure modes, see the kit's
 > [agentic-coding-patterns#211](https://github.com/GSA-TTS/agentic-coding-patterns/issues/211);
 > the quickstart-side decision (docs + advisory) is recorded in
 > [ADR-0007](adr/0007-commit-verification-identity-guidance.md).
+
+---
+
+## 23. USAi 401 in an Existing Sandbox After Deleting/Recreating the Global Secret
+
+### Symptoms
+
+- A **fresh** sandbox authenticates to USAi fine, but an **existing** sandbox
+  keeps failing with **HTTP 401** from the models API.
+- You recently **deleted the global USAi secret and re-added it** (rather than
+  using `qsbx usai-rotate-api-key`), and/or you had a stray `USAI_API_KEY`
+  exported in your shell (`.zshrc`/`.bashrc`) that you commented out.
+- `qsbx run` printed something like:
+
+  ```text
+  The global USAi key works in a fresh sandbox, but 'opencode-workspace' still
+  fails with HTTP 401. This usually means the existing sandbox has a stale
+  USAI_API_KEY placeholder from before rotation.
+
+  Could not read the sandbox's USAI_API_KEY placeholder. Aborting attach.
+  ```
+
+- The `usai-provider` config (`opencode.jsonc`) **is** loaded — OpenCode shows
+  the USAi provider and correct `baseURL` — so this is **not** the pre-kit
+  migration case in [Section 19](#19-opencode-shows-wrong-providers). The config
+  is fine; only the injected credential fails to resolve.
+
+### Root Cause
+
+USAi is injected as a **custom secret** (`sbx secret set-custom`), which is
+**not** proxied. Instead, sbx bakes a **placeholder token** into each sandbox's
+`USAI_API_KEY` at creation time, and the sbx proxy resolves that placeholder to
+the real global secret value at request time.
+
+When you **delete and re-add** the global secret (as opposed to rotating it in
+place), sbx mints a **new placeholder**. A newly created sandbox picks up the new
+placeholder, but an **existing** sandbox still carries the **old** placeholder —
+which the proxy can no longer resolve. The proxy then injects an **empty**
+`USAI_API_KEY`, so USAi returns 401. Reading the sandbox's baked-in value can
+even come back **empty**, which is why older `qsbx` versions hit a hard
+`Could not read the sandbox's USAI_API_KEY placeholder. Aborting attach.`
+dead-end here.
+
+> Contrast with `qsbx usai-rotate-api-key` (`scripts/rotate-apikey`), which
+> **preserves the existing placeholder** across rotation on purpose — so running
+> sandboxes keep resolving. Deleting + re-adding the secret defeats that.
+
+### Fix (automatic)
+
+Current `qsbx` detects this exact case — sandbox 401 while a fresh sandbox
+returns 200 — and offers two recovery routes, in order:
+
+1. **Recreate the sandbox, preserving your sessions** (recommended). `qsbx`
+   exports your chat sessions (sanitized), recreates the sandbox the current way
+   (so it gets the correct, current placeholder), and imports the sessions back.
+   This is the same session-preserving migration used for pre-kit sandboxes.
+2. **Non-destructive rebind.** If you decline the recreate, `qsbx` can add a
+   **sandbox-scoped** USAi secret bound to the **current global placeholder** and
+   re-validate — keeping the sandbox as-is. You are prompted for the current USAi
+   key (never passed on the command line).
+
+Just re-run and answer the prompts:
+
+```bash
+./qsbx run opencode /path/to/your/project
+```
+
+### Fix (manual)
+
+If you prefer to do it by hand, either recreate the sandbox:
+
+```bash
+sbx rm --force <sandbox-name>
+./qsbx run opencode /path/to/your/project
+```
+
+…or rebind the existing sandbox to the current global placeholder. First read
+the current placeholder from the global secret list, then bind a sandbox-scoped
+secret to it (sbx prompts for the key value):
+
+```bash
+# The value in the USAI_API_KEY column is the current placeholder:
+sbx secret ls -g | grep USAI_API_KEY
+
+sbx secret set-custom <sandbox-name> --host api.gsa.usai.gov \
+  --env USAI_API_KEY --placeholder <current-placeholder>
+```
+
+> **Do not** bind to the sandbox's *old* placeholder — that is the value that
+> stopped resolving. Always bind to the **current global** one.
+
+### Prevention
+
+- Rotate with `qsbx usai-rotate-api-key`, which preserves the placeholder so
+  existing sandboxes keep working. Avoid deleting + re-adding the global secret.
+- Remove any `export USAI_API_KEY=...` from your shell profile — the sandbox gets
+  its value from sbx injection, and a host env var only causes confusion.
+
+### Related
+
+- [Section 3 — Agent Cannot See API Key / USAi Authentication Fails](#3-agent-cannot-see-api-key--usai-authentication-fails)
+- [Section 14 — SBX Proxy Doesn't Work with Custom baseURL](#14-sbx-proxy-doesnt-work-with-custom-baseurl-security-implication)
+- [Section 20 — Authentication Failed After Copying a New Key](#20-authentication-failed-after-copying-a-new-key)
+- Decision record: [ADR-0008](adr/0008-usai-placeholder-recovery.md)
 
 ---
 

--- a/docs/adr/0008-usai-placeholder-recovery.md
+++ b/docs/adr/0008-usai-placeholder-recovery.md
@@ -1,0 +1,126 @@
+---
+title: "USAi Placeholder Recovery: Offer Session-Preserving Recreate, Then Non-Destructive Rebind"
+status: accepted
+date: 2026-07-08
+decision_makers: ["Bret Mogilefsky"]
+category: configuration-management
+nist_controls: ["AC-6", "CM-6", "IA-5", "SC-12", "SI-11", "SI-17"]
+impact_level: low
+ato_relevance: yes-process
+risk_treatment: mitigate
+supersedes: []
+---
+
+# ADR-0008: USAi Placeholder Recovery — Offer Session-Preserving Recreate, Then Non-Destructive Rebind
+
+## Context and Problem Statement
+
+USAi is injected into sandboxes as a **custom secret** (`sbx secret set-custom`),
+which is **not** proxied. sbx bakes a **placeholder token** into each sandbox's
+`USAI_API_KEY` at creation time and resolves that placeholder to the real global
+secret value at request time (see
+[KNOWN_FAILURE_MODES.md §14](../KNOWN_FAILURE_MODES.md#14-sbx-proxy-doesnt-work-with-custom-baseurl-security-implication)).
+
+`scripts/rotate-apikey` (`qsbx usai-rotate-api-key`) deliberately **preserves**
+the placeholder across rotation, so existing sandboxes keep resolving. But a user
+who instead **deletes and re-adds** the global USAi secret — or otherwise
+regenerates it — causes sbx to mint a **new** placeholder. A freshly created
+sandbox picks up the new placeholder; an **existing** sandbox still carries the
+**old** one, which the proxy can no longer resolve. The proxy then injects an
+**empty** `USAI_API_KEY`, and USAi returns **HTTP 401**. The sandbox's baked-in
+value can even read back **empty**.
+
+`qsbx` already distinguished this from an expired key: on a sandbox 401 it probes
+a throwaway fresh sandbox, and a fresh-200 result routes to
+`offer_update_stale_placeholder`. But that function had two defects:
+
+1. It rebound the sandbox-scoped secret to the **sandbox's own** placeholder
+   (`--placeholder "$sandbox_placeholder"`) — the very value that stopped
+   resolving — so the "repair" re-bound to a dead token.
+2. When the sandbox placeholder read back **empty** (the common real case, seen
+   in the field), it hit a hard `Could not read the sandbox's USAI_API_KEY
+   placeholder. Aborting attach.` with **no recovery path** — the exact dead-end
+   a user reported.
+
+The question: what should `qsbx` do when it detects this orphaned-placeholder
+state, given that the sandbox's `opencode.jsonc` is otherwise correct and the
+user may have live chat sessions in it?
+
+## Decision
+
+`qsbx` treats this as a **recoverable** state and offers two routes, in order.
+
+### 1. Offer a session-preserving recreate first (when it can)
+
+When `qsbx run` has the create args in hand (the AGENT form), the **first**
+option is to recreate the sandbox via the existing session-preserving migration
+(`migrate_or_halt`): export sessions (sanitized) → remove → recreate with the
+kits (which mint a correct, current placeholder) → import sessions. This is the
+most reliable fix because it guarantees the sandbox carries the current
+placeholder, and it reuses a well-tested, fail-closed path (never removes a
+sandbox without a verified export).
+
+### 2. Non-destructive rebind to the CURRENT GLOBAL placeholder
+
+If the user declines the recreate (or on the attach-by-name form, where `qsbx`
+lacks the create args), `qsbx` offers to add a **sandbox-scoped** custom secret
+bound to the **current global placeholder** — read from `sbx secret ls -g` via
+`global_usai_placeholder`, **never** the stale/empty sandbox value — then
+re-validates with `check_key`. The user is prompted for the current key; it is
+never passed on the command line.
+
+### 3. Fail closed only when there is nothing safe to bind to
+
+If the sandbox placeholder already **equals** the current global placeholder,
+this is not a stale-placeholder case and `qsbx` aborts (rebinding would change
+nothing). If there is **no** global placeholder to bind to (the secret is truly
+gone), `qsbx` aborts with explicit recreate guidance rather than binding to an
+empty value. Binding to the stale/empty sandbox placeholder — the old bug — is
+never done.
+
+## Consequences
+
+- **Better:** the reported dead-end (empty placeholder → hard abort) becomes a
+  guided recovery. The default path preserves the user's sessions; the fallback
+  keeps the sandbox in place without deleting anything.
+- **Correctness:** the rebind now targets the **current global** placeholder, so
+  it actually resolves — fixing the second defect where the repair re-bound to a
+  dead token.
+- **Least privilege / secret hygiene (AC-6, IA-5):** the key is still entered
+  interactively (never on the command line or in shell history); rebinding is
+  scoped to the single affected sandbox.
+- **Reuse:** route 1 reuses `migrate_or_halt`'s fail-closed guarantees rather
+  than adding a second destructive path.
+- **Limitation:** on attach-by-name, only the rebind is offered (no create args
+  to recreate with); the user can re-run in AGENT form to get the recreate
+  option. Noted in the code.
+- **Not prevented at the source:** this does not stop a delete+re-add from
+  orphaning placeholders in the first place; prevention is documented guidance
+  (use `qsbx usai-rotate-api-key`). Acceptable for a low-impact dev tool.
+
+## Validation
+
+- Offline unit checks in `scripts/test-migrate-or-halt` (stubbed `sbx`, no Docker
+  or network) covering `offer_update_stale_placeholder`:
+  - empty sandbox placeholder + present global, decline recreate + accept rebind,
+    post-repair 200 → returns 0 and binds to the **current global** placeholder;
+  - accept the recreate offer → runs the migration (`sbx rm`/recreate) and does
+    **not** `secret set-custom`;
+  - empty sandbox placeholder + **no** global → aborts with recreate guidance,
+    no `set-custom`;
+  - sandbox placeholder == global (not stale) → aborts, no `set-custom`;
+  - attach-by-name (no create args) → recreate not offered; rebind used.
+- `bash -n qsbx` clean; `./scripts/test-migrate-or-halt` 49/49; markdownlint /
+  shellcheck / gitleaks via `npm run lint` clean.
+- **Verified live** with `./scripts/verify-migrate-live` on a sandbox-capable
+  host: the end-to-end path (recreate/rebind against a real sandbox, USAi 200
+  afterward, session preserved) succeeds.
+
+## Links
+
+- Failure mode: [KNOWN_FAILURE_MODES.md §23](../KNOWN_FAILURE_MODES.md#23-usai-401-in-an-existing-sandbox-after-deletingrecreating-the-global-secret)
+- Related: [ADR-0005](0005-kits-from-patterns-and-agent-trust-model.md) (kits by
+  pinned reference), [KNOWN_FAILURE_MODES.md §14](../KNOWN_FAILURE_MODES.md#14-sbx-proxy-doesnt-work-with-custom-baseurl-security-implication)
+  (custom-secret injection), [§20](../KNOWN_FAILURE_MODES.md#20-authentication-failed-after-copying-a-new-key)
+- Rotation helper that preserves the placeholder: `scripts/rotate-apikey`
+- Upstream custom-service support: [docker/sbx-releases#35](https://github.com/docker/sbx-releases/issues/35)

--- a/qsbx
+++ b/qsbx
@@ -952,9 +952,30 @@ sandbox_usai_placeholder() {
   sbx exec "$name" -- sh -c 'printf "%s" "${USAI_API_KEY:-}"' </dev/null 2>/dev/null || true
 }
 
+# Repair path for a sandbox whose baked-in USAI_API_KEY placeholder no longer
+# resolves — the classic case being a global USAi secret that was DELETED and
+# re-added (or otherwise regenerated), which mints a NEW placeholder. A fresh
+# sandbox gets the new placeholder (so check_fresh_sandbox_key is 200), but the
+# existing sandbox still carries the OLD placeholder, so the proxy resolves it to
+# nothing and USAi returns 401. The old sandbox's baked-in value can even read
+# back EMPTY. See docs/KNOWN_FAILURE_MODES.md section 23 and ADR-0008.
+#
+# Two recovery routes, offered in this order:
+#   1. Recreate the sandbox via the session-preserving migration (migrate_or_halt)
+#      — guarantees a correct, current placeholder and keeps chat sessions. This
+#      is offered FIRST when we have the create args to do it.
+#   2. Non-destructive rebind: add a sandbox-scoped custom secret bound to the
+#      CURRENT GLOBAL placeholder (not the stale/empty sandbox one), prompting for
+#      the key. Keeps the sandbox as-is.
+#
+# Usage: offer_update_stale_placeholder NAME STATUS [CREATE_ARGS...]
+# CREATE_ARGS (optional) are the `sbx create`-style args used to offer route 1;
+# when absent (e.g. attach-by-name), only route 2 is offered.
 offer_update_stale_placeholder() {
   local name="$1"
   local status="$2"
+  shift 2
+  local create_args=("$@")
   local sandbox_placeholder=""
   local global_placeholder=""
   sandbox_placeholder=$(sandbox_usai_placeholder "$name")
@@ -963,30 +984,73 @@ offer_update_stale_placeholder() {
   echo >&2
   echo "The global USAi key works in a fresh sandbox, but '$name' still" >&2
   echo "fails with HTTP ${status:-unknown}. This usually means the existing" >&2
-  echo "sandbox has a stale USAI_API_KEY placeholder from before rotation." >&2
+  echo "sandbox has a stale USAI_API_KEY placeholder — most often because the" >&2
+  echo "global USAi secret was deleted and re-added, which regenerates the" >&2
+  echo "placeholder. A fresh sandbox picks up the new one; this one still has" >&2
+  echo "the old (now unresolvable) placeholder." >&2
   echo >&2
-  if [ -z "$sandbox_placeholder" ]; then
-    echo "Could not read the sandbox's USAI_API_KEY placeholder. Aborting attach." >&2
-    return 1
-  fi
 
-  if [ -n "$global_placeholder" ] && [ "$sandbox_placeholder" = "$global_placeholder" ]; then
+  # Not a stale-placeholder case: the sandbox already carries the SAME placeholder
+  # as the current global secret, so rebinding it would change nothing. (An empty
+  # sandbox placeholder never equals a non-empty global one, so this correctly
+  # does NOT fire on the empty/orphaned case handled below.)
+  if [ -n "$sandbox_placeholder" ] && [ -n "$global_placeholder" ] \
+      && [ "$sandbox_placeholder" = "$global_placeholder" ]; then
     echo "'$name' already uses the current global placeholder, so this is not" >&2
     echo "a stale-placeholder case. Aborting attach." >&2
     return 1
   fi
 
-  echo "qsbx can repair this without deleting the sandbox by adding a" >&2
-  echo "sandbox-scoped USAi custom secret that uses the placeholder already" >&2
-  echo "injected into '$name'. You will be prompted for the current USAi key;" >&2
-  echo "qsbx will not pass the key on the command line." >&2
-  printf "Update sandbox-scoped USAi placeholder for '%s' now? [y/N] " "$name" >&2
+  # Route 1 (preferred): session-preserving recreate. Offered only when we have
+  # both the create args to rebuild the sandbox and the migration helper. This
+  # keeps the user's chat sessions and guarantees a current placeholder.
+  if [ "${#create_args[@]}" -gt 0 ] && command -v migrate_or_halt >/dev/null 2>&1; then
+    echo "The most reliable fix is to recreate '$name' the current way, moving" >&2
+    echo "your existing chat sessions across. This guarantees a working key." >&2
+    printf "Recreate '%s' (keeping your sessions) now? [y/N] " "$name" >&2
+    local recreate_answer=""
+    if [ -n "${QSBX_PROMPT_STDIN:-}" ]; then
+      read -r recreate_answer || true
+    else
+      read -r recreate_answer </dev/tty || true
+    fi
+    case "$recreate_answer" in
+      [yY]|[yY][eE][sS])
+        # migrate_or_halt exits the process on failure and returns 0 on success,
+        # after which the caller attaches. It re-exports/imports sessions itself.
+        migrate_or_halt "$name" "${create_args[@]}"
+        return 0
+        ;;
+    esac
+    echo >&2
+  fi
+
+  # Route 2: non-destructive rebind to the CURRENT GLOBAL placeholder. We must
+  # have a global placeholder to bind to — binding to the stale/empty sandbox
+  # placeholder is exactly what left the sandbox broken, so never do that.
+  if [ -z "$global_placeholder" ]; then
+    echo "Could not read a current global USAi placeholder to rebind to, so" >&2
+    echo "qsbx cannot repair '$name' in place. Recreate it with:" >&2
+    echo "  sbx rm --force '$name' && ./qsbx run opencode <your-project-folder>" >&2
+    echo "Aborting attach." >&2
+    return 1
+  fi
+
+  echo "Alternatively, qsbx can repair this WITHOUT deleting the sandbox by" >&2
+  echo "adding a sandbox-scoped USAi secret bound to the CURRENT global" >&2
+  echo "placeholder. You will be prompted for the current USAi key; qsbx will" >&2
+  echo "not pass the key on the command line." >&2
+  printf "Rebind '%s' to the current placeholder now? [y/N] " "$name" >&2
   local repair_answer=""
-  read -r repair_answer || true
+  if [ -n "${QSBX_PROMPT_STDIN:-}" ]; then
+    read -r repair_answer || true
+  else
+    read -r repair_answer </dev/tty || true
+  fi
   case "$repair_answer" in
     [yY]|[yY][eE][sS])
       sbx secret set-custom "$name" --host api.gsa.usai.gov \
-        --env USAI_API_KEY --placeholder "$sandbox_placeholder"
+        --env USAI_API_KEY --placeholder "$global_placeholder"
       status=$(check_key "$name")
       if [ "$status" = "200" ]; then
         echo "Sandbox placeholder repaired and key validated. Continuing." >&2
@@ -1064,8 +1128,14 @@ warn_if_no_git_identity() {
 # Validate the sandbox's key and, if it is not working, walk the user through
 # rotating it via scripts/rotate-apikey. Best-effort: if we cannot run the check
 # (e.g. no curl in the sandbox), we warn and continue rather than block attach.
+# Usage: ensure_valid_key NAME [CREATE_ARGS...]
+# CREATE_ARGS (optional) are the `sbx create`-style args; when provided they let
+# the stale-placeholder repair offer a session-preserving recreate as its first
+# option (see offer_update_stale_placeholder). Attach-by-name omits them.
 ensure_valid_key() {
   local name="$1"
+  shift
+  local create_args=("$@")
   local status
   local fresh_status
   status=$(check_key "$name")
@@ -1081,7 +1151,7 @@ ensure_valid_key() {
 
   fresh_status=$(check_fresh_sandbox_key)
   if [ "$fresh_status" = "200" ]; then
-    offer_update_stale_placeholder "$name" "$status"
+    offer_update_stale_placeholder "$name" "$status" "${create_args[@]+"${create_args[@]}"}"
     return $?
   fi
 
@@ -1115,7 +1185,7 @@ ensure_valid_key() {
 
       fresh_status=$(check_fresh_sandbox_key)
       if [ "$fresh_status" = "200" ]; then
-        offer_update_stale_placeholder "$name" "$status"
+        offer_update_stale_placeholder "$name" "$status" "${create_args[@]+"${create_args[@]}"}"
         return $?
       fi
 
@@ -1197,8 +1267,9 @@ case "$subcommand" in
       fi
 
       # Verify the sandbox's USAi key works before attaching; prompt to rotate
-      # if it does not.
-      ensure_valid_key "$name"
+      # if it does not. Pass the create args so a stale-placeholder repair can
+      # offer a session-preserving recreate as its first option.
+      ensure_valid_key "$name" "${create_args[@]}"
 
       # Advisory: the git-ssh-sign kit signs commits with the forwarded SSH key
       # and fails closed if the host agent has no key loaded. Warn up front.

--- a/qsbx
+++ b/qsbx
@@ -63,7 +63,72 @@ SCRIPT_DIR=$(script_dir) || { echo "qsbx: could not resolve script directory" >&
 # The quickstart clone defaults to this script's directory; QUICKSTART_CLONE
 # overrides it if exported. Used only to locate sibling helper scripts and to
 # support editing this repo as a project — the kits themselves are remote (below).
+# Record whether the user overrode it, so `version` can surface that (an override
+# is another way "which clone am I really using?" gets confusing).
+if [ -n "${QUICKSTART_CLONE:-}" ]; then QUICKSTART_CLONE_OVERRIDDEN=1; else QUICKSTART_CLONE_OVERRIDDEN=""; fi
 QUICKSTART_CLONE="${QUICKSTART_CLONE:-$SCRIPT_DIR}"
+
+# The absolute path of the qsbx file actually being executed, with symlinks
+# resolved. This is the single most useful fact when a user reports "I pulled
+# the branch but the old behavior persists": a `qsbx`/`qsb` on PATH is very
+# often a symlink into a DIFFERENT clone than the one they edited/pulled, so
+# they run stale code. `version` prints this and the startup hint compares it
+# against the invoking repo. SCRIPT_DIR already followed the symlink chain, so
+# the resolved file is SCRIPT_DIR + this script's basename.
+QSBX_RESOLVED_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
+
+# Print the version/identity of the qsbx that is actually running: the resolved
+# script path, the clone's git branch + short SHA + dirty flag (if the clone is
+# a git repo), and the pinned patterns-kit ref. This exists so "which qsbx am I
+# running?" is answerable in one command — the failure the wrong-clone class of
+# bug reports keeps hitting. Best-effort: git details are omitted (not faked) if
+# git is absent or SCRIPT_DIR is not a work tree.
+print_version() {
+  echo "qsbx"
+  echo "  script:      $QSBX_RESOLVED_PATH"
+  echo "  clone dir:   $SCRIPT_DIR"
+  if command -v git >/dev/null 2>&1 \
+      && git -C "$SCRIPT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    local branch sha dirty=""
+    branch=$(git -C "$SCRIPT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+    sha=$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo "?")
+    # Mark the tree dirty only if THIS clone has uncommitted changes.
+    git -C "$SCRIPT_DIR" diff --quiet 2>/dev/null && git -C "$SCRIPT_DIR" diff --cached --quiet 2>/dev/null || dirty=" (dirty)"
+    echo "  git:         ${branch}@${sha}${dirty}"
+  else
+    echo "  git:         (not a git clone — cannot report branch/commit)"
+  fi
+  echo "  patterns kit ref: $PATTERNS_KIT_REF"
+  echo "  min sbx:     $MIN_SBX_VERSION"
+  [ -n "${QUICKSTART_CLONE_OVERRIDDEN:-}" ] \
+    && echo "  note: QUICKSTART_CLONE is set in your environment ($QUICKSTART_CLONE)."
+}
+
+# Startup hint for the wrong-clone / didn't-switch failure mode. When the user
+# runs qsbx from inside a git clone of THIS repo (cwd is a work tree) but the
+# qsbx that actually executed lives in a DIFFERENT clone, they are almost
+# certainly editing/pulling one clone and running another. Warn (never block),
+# and only when we can be confident: both the cwd and the resolved script's
+# clone are git work trees AND their toplevels differ. Silent otherwise.
+warn_if_running_foreign_clone() {
+  command -v git >/dev/null 2>&1 || return 0
+  local cwd_top script_top
+  cwd_top=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null) || return 0
+  script_top=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null) || return 0
+  [ -n "$cwd_top" ] && [ -n "$script_top" ] || return 0
+  [ "$cwd_top" = "$script_top" ] && return 0
+  # Only nag when the cwd clone looks like a quickstart checkout (has a qsbx),
+  # so we don't warn for every unrelated project the user runs qsbx against.
+  [ -f "$cwd_top/qsbx" ] || return 0
+  echo "qsbx: note — you are inside a quickstart clone at:" >&2
+  echo "        $cwd_top" >&2
+  echo "      but the qsbx actually running lives in a DIFFERENT clone:" >&2
+  echo "        $QSBX_RESOLVED_PATH" >&2
+  echo "      If you pulled/switched branches in the first but see stale" >&2
+  echo "      behavior, you are running the other clone. Run 'qsbx version'" >&2
+  echo "      to confirm, and either re-point your qsbx symlink or run" >&2
+  echo "      ./qsbx from the clone you updated." >&2
+}
 
 # ============================================================================
 # KITS — the four sbx mixin kits applied to every sandbox, sourced from the
@@ -1207,6 +1272,14 @@ fi
 subcommand="${1:-}"
 
 case "$subcommand" in
+  version|--version|-v)
+    # Report which qsbx is actually running (resolved path + clone git state).
+    # This is deliberately NOT passed through to `sbx version`; use `sbx version`
+    # directly for the sbx CLI's own version.
+    print_version
+    exit 0
+    ;;
+
   usai-rotate-api-key)
     # Front the standalone rotation helper as a subcommand so qsbx is the single
     # entry point for this repo's sbx extensions. The script stays runnable on
@@ -1230,6 +1303,10 @@ case "$subcommand" in
   run)
     shift
     require_sbx_version
+    # Surface the wrong-clone / didn't-switch trap up front: if the user is
+    # inside one quickstart clone but the running qsbx lives in another, they may
+    # be running stale code. Advisory only.
+    warn_if_running_foreign_clone
     # Split args into the create portion (agent + paths + flags) and any agent
     # args after "--", which only apply on attach.
     create_args=()

--- a/scripts/test-migrate-or-halt
+++ b/scripts/test-migrate-or-halt
@@ -80,6 +80,10 @@ case "$cmd" in
         [ "${STUB_EXPORT_EMPTY:-0}" = "1" ] && exit 0   # nothing on stdout
         printf '{"session":"data"}\n' ;;
       *"opencode import"*) [ "${STUB_IMPORT_FAIL:-0}" = "1" ] && exit 4; exit 0 ;;
+      # sandbox_usai_placeholder reads the baked-in USAI_API_KEY. Empty unless a
+      # test sets STUB_SANDBOX_PLACEHOLDER (used by the stale-placeholder tests
+      # that reuse this full stub, e.g. the recreate-first path via migrate).
+      *'USAI_API_KEY:-'*) printf '%s' "${STUB_SANDBOX_PLACEHOLDER:-}"; exit 0 ;;
       # Kit-applied probe (kit_feature_absent wraps the snippet to print
       # present/absent and exit 0). Match on the usai config path in the wrapped
       # command. "present" iff the sandbox was (re)created and the kit is not
@@ -103,6 +107,13 @@ case "$cmd" in
   rm)   [ "${STUB_RM_FAIL:-0}" = "1" ] && exit 5; : >"$STUBDIR/.removed"; exit 0 ;;
   cp)   [ "${STUB_CP_FAIL:-0}" = "1" ] && exit 6; exit 0 ;;
   create) [ "${STUB_CREATE_FAIL:-0}" = "1" ] && exit 7; : >"$STUBDIR/.created"; exit 0 ;;
+  secret)
+    # `sbx secret ls -g` — used by global_usai_placeholder. Emit a USAi row with
+    # the global placeholder when a test provides one; otherwise nothing.
+    if [ "${2:-}" = "ls" ] && [ -n "${STUB_GLOBAL_PLACEHOLDER:-}" ]; then
+      printf 'api.gsa.usai.gov   USAI_API_KEY   %s\n' "$STUB_GLOBAL_PLACEHOLDER"
+    fi
+    exit 0 ;;
   kit)  exit 0 ;;
   settings) exit 0 ;;
   *)    exit 0 ;;
@@ -286,6 +297,115 @@ assert_eq "create-fail exits non-zero" "1" "$rc"
 assert_not_contains "create-fail does NOT import" "$log" "opencode import"
 assert_contains "create-fail preserves exports" "$out" "Your saved sessions are here:"
 unset STUB_CREATE_FAIL
+cleanup_stubs
+
+# --- offer_update_stale_placeholder scaffolding ----------------------------
+# A focused sbx stub for the stale-placeholder repair. It models the three reads
+# that function makes — the sandbox's baked-in USAI_API_KEY (via `sbx exec …
+# printf $USAI_API_KEY`), the global secret list (`sbx secret ls -g`), and the
+# post-repair key check (`sbx exec … curl … %{http_code}`) — plus `secret
+# set-custom`. Behavior is env-driven per test:
+#   STUB_SANDBOX_PLACEHOLDER  value the sandbox's USAI_API_KEY reads back as ("" = empty)
+#   STUB_GLOBAL_PLACEHOLDER   placeholder printed in the `secret ls -g` USAi row ("" = none)
+#   STUB_KEY_STATUS           http code check_key returns after repair (e.g. 200, 401)
+make_placeholder_stub() {
+  cat >"$STUBDIR/sbx" <<'STUB'
+{ printf 'sbx'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >>"$CALLS"
+case "${1:-}" in
+  exec)
+    snippet=""; prev=""
+    for a in "$@"; do [ "$prev" = "-c" ] && { snippet="$a"; break; }; prev="$a"; done
+    case "$snippet" in
+      *'USAI_API_KEY:-'*) printf '%s' "${STUB_SANDBOX_PLACEHOLDER:-}" ;;   # sandbox_usai_placeholder
+      *'%{http_code}'*)   printf '%s' "${STUB_KEY_STATUS:-401}" ;;         # check_key after repair
+      *) exit 0 ;;
+    esac
+    ;;
+  secret)
+    # `sbx secret ls -g` — emit a USAi row carrying the global placeholder, or
+    # nothing when STUB_GLOBAL_PLACEHOLDER is empty (secret deleted).
+    if [ "${2:-}" = "ls" ]; then
+      [ -n "${STUB_GLOBAL_PLACEHOLDER:-}" ] && \
+        printf 'api.gsa.usai.gov   USAI_API_KEY   %s\n' "$STUB_GLOBAL_PLACEHOLDER"
+    fi
+    exit 0 ;;   # set-custom etc. just succeed (and are logged above)
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x "$STUBDIR/sbx"
+}
+
+# 6d) Orphaned/empty sandbox placeholder + present global, user picks the
+# non-destructive rebind (declines recreate 'n', accepts rebind 'y'), and the
+# post-repair key check is 200 -> returns 0 and binds to the GLOBAL placeholder.
+make_stubs; load_qsbx
+make_placeholder_stub
+export STUB_SANDBOX_PLACEHOLDER="" STUB_GLOBAL_PLACEHOLDER="ph-new-123" STUB_KEY_STATUS=200
+out=$( printf 'n\ny\n' | offer_update_stale_placeholder mybox 401 opencode /proj 2>&1 ); rc=$?
+log=$(cat "$CALLS")
+assert_eq "orphaned+rebind returns 0" "0" "$rc"
+assert_contains "rebind uses CURRENT GLOBAL placeholder" "$log" "--placeholder ph-new-123"
+assert_not_contains "rebind never binds to empty sandbox placeholder" "$log" "--placeholder ph-new-123 --placeholder"
+assert_contains "rebind confirms success" "$out" "repaired and key validated"
+unset STUB_SANDBOX_PLACEHOLDER STUB_GLOBAL_PLACEHOLDER STUB_KEY_STATUS
+cleanup_stubs
+
+# 6e) Recreate offered FIRST when create args are present; accepting it runs the
+# session-preserving migration (migrate_or_halt) rather than the rebind. Uses the
+# migrate-capable stub so the migration completes; asserts we did NOT set-custom.
+# Two 'y' answers: one for the recreate offer, one for migrate_or_halt's own
+# confirmation prompt.
+make_stubs
+export STUB_SESSION_LIST="ses_aaa"
+# migrate_or_halt needs the full migrate stub (export/rm/create/import). Bind the
+# sandbox/global reads onto it so offer_update_stale_placeholder's pre-migration
+# reads still work.
+( printf 'y\ny\n' | STUB_GLOBAL_PLACEHOLDER="ph-new" STUB_SANDBOX_PLACEHOLDER="" \
+    offer_update_stale_placeholder mybox 401 opencode /proj ) >/dev/null 2>&1 </dev/null; rc=$?
+log=$(cat "$CALLS")
+assert_eq "recreate-first returns 0" "0" "$rc"
+assert_contains "recreate-first runs migration (rm)" "$log" "sbx rm --force mybox"
+assert_not_contains "recreate-first does NOT set-custom" "$log" "secret set-custom"
+unset STUB_SESSION_LIST
+cleanup_stubs
+
+# 6f) Empty sandbox placeholder AND no global placeholder (secret truly gone):
+# nothing safe to bind to -> abort with recreate guidance, no set-custom.
+make_stubs; load_qsbx
+make_placeholder_stub
+export STUB_SANDBOX_PLACEHOLDER="" STUB_GLOBAL_PLACEHOLDER=""
+out=$( printf 'n\n' | offer_update_stale_placeholder mybox 401 2>&1 ); rc=$?
+log=$(cat "$CALLS")
+assert_eq "no-global aborts non-zero" "1" "$rc"
+assert_not_contains "no-global never set-custom" "$log" "secret set-custom"
+assert_contains "no-global gives recreate guidance" "$out" "sbx rm --force 'mybox'"
+unset STUB_SANDBOX_PLACEHOLDER STUB_GLOBAL_PLACEHOLDER
+cleanup_stubs
+
+# 6g) Sandbox placeholder already EQUALS the current global (not a stale case):
+# abort without changing anything.
+make_stubs; load_qsbx
+make_placeholder_stub
+export STUB_SANDBOX_PLACEHOLDER="ph-same" STUB_GLOBAL_PLACEHOLDER="ph-same"
+out=$( printf 'y\n' | offer_update_stale_placeholder mybox 401 opencode /proj 2>&1 ); rc=$?
+log=$(cat "$CALLS")
+assert_eq "not-stale aborts non-zero" "1" "$rc"
+assert_contains "not-stale explains" "$out" "not"
+assert_not_contains "not-stale never set-custom" "$log" "secret set-custom"
+unset STUB_SANDBOX_PLACEHOLDER STUB_GLOBAL_PLACEHOLDER
+cleanup_stubs
+
+# 6h) Attach-by-name (no create args): recreate route is NOT offered; only the
+# rebind is. Rebind succeeds (200).
+make_stubs; load_qsbx
+make_placeholder_stub
+export STUB_SANDBOX_PLACEHOLDER="" STUB_GLOBAL_PLACEHOLDER="ph-x" STUB_KEY_STATUS=200
+out=$( printf 'y\n' | offer_update_stale_placeholder mybox 401 2>&1 ); rc=$?
+log=$(cat "$CALLS")
+assert_eq "attach-by-name rebind returns 0" "0" "$rc"
+assert_not_contains "attach-by-name never recreates" "$log" "sbx rm --force"
+assert_contains "attach-by-name binds to global placeholder" "$log" "--placeholder ph-x"
+unset STUB_SANDBOX_PLACEHOLDER STUB_GLOBAL_PLACEHOLDER STUB_KEY_STATUS
 cleanup_stubs
 
 # 7) extract_session_ids: pulls ses_ tokens, ignores chatter.

--- a/scripts/test-migrate-or-halt
+++ b/scripts/test-migrate-or-halt
@@ -448,6 +448,7 @@ cleanup_stubs
 # qsbx with the env var exported so the override-detection at load time fires.
 make_stubs
 ( export QUICKSTART_CLONE="$REPO_ROOT"
+  # shellcheck disable=SC1090
   QSBX_SOURCE_ONLY=1 . "$QSBX"; set +e
   out=$(print_version 2>&1)
   case "$out" in *"QUICKSTART_CLONE is set"*) echo PASS ;; *) echo "FAIL: $out" ;; esac
@@ -458,7 +459,7 @@ cleanup_stubs
 # 10) warn_if_running_foreign_clone: SAME clone (cwd toplevel == script toplevel)
 # -> silent. Here cwd is REPO_ROOT and SCRIPT_DIR is REPO_ROOT, so no warning.
 make_stubs; load_qsbx
-out=$( cd "$REPO_ROOT" && warn_if_running_foreign_clone 2>&1 ); 
+out=$( cd "$REPO_ROOT" && warn_if_running_foreign_clone 2>&1 );
 assert_eq "same-clone: no foreign-clone warning" "" "$out"
 cleanup_stubs
 

--- a/scripts/test-migrate-or-halt
+++ b/scripts/test-migrate-or-halt
@@ -428,6 +428,64 @@ assert_contains "kits: zscaler" "$kits_joined" "zscaler-ca-certificate"
 assert_contains "kits: git-ssh-sign" "$kits_joined" "git-ssh-sign"
 cleanup_stubs
 
+# 9) print_version reports the resolved script path + this clone's git state.
+# The harness sources the real qsbx from REPO_ROOT, so SCRIPT_DIR is REPO_ROOT
+# and the git branch/commit come from this repo. We assert the stable labels and
+# that it names the actual repo dir (not a guess) and exits 0.
+make_stubs; load_qsbx
+out=$(print_version 2>&1); rc=$?
+assert_eq "version exits 0" "0" "$rc"
+assert_contains "version shows script path" "$out" "$REPO_ROOT/qsbx"
+assert_contains "version shows clone dir" "$out" "$REPO_ROOT"
+assert_contains "version shows patterns kit ref" "$out" "$PATTERNS_KIT_REF"
+# This repo IS a git work tree, so the git line must carry a branch@sha, not the
+# "not a git clone" fallback.
+assert_contains "version reports git state" "$out" "git:"
+assert_not_contains "version not-a-clone fallback absent here" "$out" "not a git clone"
+cleanup_stubs
+
+# 9b) print_version surfaces a QUICKSTART_CLONE override note when set. Re-source
+# qsbx with the env var exported so the override-detection at load time fires.
+make_stubs
+( export QUICKSTART_CLONE="$REPO_ROOT"
+  QSBX_SOURCE_ONLY=1 . "$QSBX"; set +e
+  out=$(print_version 2>&1)
+  case "$out" in *"QUICKSTART_CLONE is set"*) echo PASS ;; *) echo "FAIL: $out" ;; esac
+) | grep -q PASS && pass "version notes QUICKSTART_CLONE override" \
+  || fail "version notes QUICKSTART_CLONE override"
+cleanup_stubs
+
+# 10) warn_if_running_foreign_clone: SAME clone (cwd toplevel == script toplevel)
+# -> silent. Here cwd is REPO_ROOT and SCRIPT_DIR is REPO_ROOT, so no warning.
+make_stubs; load_qsbx
+out=$( cd "$REPO_ROOT" && warn_if_running_foreign_clone 2>&1 ); 
+assert_eq "same-clone: no foreign-clone warning" "" "$out"
+cleanup_stubs
+
+# 10b) warn_if_running_foreign_clone: DIFFERENT clone -> warns. Build a throwaway
+# git work tree that looks like a quickstart clone (has a qsbx), cd into it, and
+# call the function while SCRIPT_DIR still points at REPO_ROOT. Expect the note.
+make_stubs; load_qsbx
+FOREIGN=$(mktemp -d "${TMPDIR:-/tmp}/qsbx-foreign.XXXXXX")
+git -C "$FOREIGN" init -q
+: >"$FOREIGN/qsbx"            # make it look like a quickstart clone
+out=$( cd "$FOREIGN" && warn_if_running_foreign_clone 2>&1 )
+assert_contains "foreign-clone: warns" "$out" "DIFFERENT clone"
+assert_contains "foreign-clone: names the running script" "$out" "$REPO_ROOT/qsbx"
+assert_contains "foreign-clone: suggests version cmd" "$out" "qsbx version"
+rm -rf "$FOREIGN"
+cleanup_stubs
+
+# 10c) warn_if_running_foreign_clone: cwd is a NON-quickstart git repo (no qsbx)
+# -> silent (we don't nag for unrelated projects the user runs qsbx against).
+make_stubs; load_qsbx
+PLAIN=$(mktemp -d "${TMPDIR:-/tmp}/qsbx-plain.XXXXXX")
+git -C "$PLAIN" init -q
+out=$( cd "$PLAIN" && warn_if_running_foreign_clone 2>&1 )
+assert_eq "non-quickstart cwd: no warning" "" "$out"
+rm -rf "$PLAIN"
+cleanup_stubs
+
 echo
 echo "  passed: $PASS   failed: $FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Deleting and re-adding the global USAi secret (instead of rotating in place) orphans the placeholder baked into existing sandboxes, so they 401 while a fresh sandbox works. `qsbx` detected the symptom but its repair rebound to the dead placeholder and hard-aborted when it read back empty. This adds a guided recovery — session-preserving recreate first, then a non-destructive rebind to the current global placeholder — plus offline tests and a documented failure mode. AI-assisted; see commit history and ADR-0008 for detail.

Verification: `./scripts/test-migrate-or-halt` 49/49, `npm run lint` clean, and `./scripts/verify-migrate-live` succeeded on a sandbox-capable host.