### PR TITLE
fix(opencode-web): background sbx exec command on host instead of opencode command inside sandbox

### DIFF
--- a/opencode-web.sh
+++ b/opencode-web.sh
@@ -15,4 +15,4 @@ echo "  sbx ports $sandbox --publish 4096:4096"
 echo
 
 # Run the sandbox detached with opencode serve
-sbx exec -d "$sandbox" sh -lc 'nohup opencode serve --hostname 0.0.0.0 --port 4096 &'
+sbx exec -d "$sandbox" sh -lc 'nohup opencode serve --hostname 0.0.0.0 --port 4096' &


### PR DESCRIPTION
## Summary

Tiny fix to correct a syntax error that prevents opencode from remaining running in the background. Moving the `&` outside the quote backgrounds the entire sbx exec command on the host instead of the opencode command inside sandbox.  The latter causes the process to end after a short time.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits format](../CONTRIBUTING.md#commit-message-guidelines) (e.g., `feat:`, `fix:`, `docs:`)
- [x] I have tested my changes locally
- [ ] I have updated documentation as needed
- [x] I have not included any secrets, API keys, or sensitive information

## Test Results

Tested locally to confirm desired behavior (opencode continues running in the background). 