### PR TITLE
fix(acq): don't hang key rotation when sbx needs a login (#211)

### DIFF
--- a/scripts/rotate-apikey
+++ b/scripts/rotate-apikey
@@ -82,9 +82,29 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Validating new key in a temporary sandbox..."
-if ! sbx create --name "$validation_sbx" shell . >/dev/null 2>&1; then
-  echo "Could not create a validation sandbox; skipping check." >&2
-  echo "The key was rotated. Re-run 'qsbx run' to validate on next attach." >&2
+# `sbx create` needs an authenticated sbx session. If the session has expired,
+# `sbx create` triggers an interactive browser login — and if its output is
+# swallowed and it's unbounded, the script appears to hang with no explanation
+# (#211). Two guards: (1) do NOT silence stderr, so any login prompt is visible;
+# (2) bound the create with a timeout so an interactive-login handshake can never
+# hang the script indefinitely. sbx has no non-interactive auth-status probe, so
+# the timeout is the safety net.
+_sbx_create_timeout="${ROTATE_VALIDATE_TIMEOUT:-120}"
+if command -v timeout >/dev/null 2>&1; then
+  _run_create() { timeout "$_sbx_create_timeout" sbx create --name "$validation_sbx" shell . >/dev/null; }
+else
+  _run_create() { sbx create --name "$validation_sbx" shell . >/dev/null; }
+fi
+rc=0
+_run_create || rc=$?
+if [ "$rc" != "0" ]; then
+  if [ "$rc" = "124" ]; then
+    echo "Validation timed out after ${_sbx_create_timeout}s — sbx likely needed an interactive login." >&2
+    echo "Run 'sbx login', then 'acq run' (it validates the key on next attach)." >&2
+  else
+    echo "Could not create a validation sandbox; skipping check." >&2
+    echo "The key was rotated. Run 'sbx login' if needed, then 'acq run' — it validates on next attach." >&2
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Fixes the key-rotation hang reported in #211: `acq usai-rotate-api-key` wedged at the validation step when `sbx` needed a fresh login — after the browser popup and a successful login, the script never returned.

Closes #211.

## Root cause

`scripts/rotate-apikey` validates the rotated key by creating a throwaway sandbox:

```sh
if ! sbx create --name "$validation_sbx" shell . >/dev/null 2>&1; then
```

When the `sbx` session had expired, that `sbx create` triggered an interactive browser login — but its output was fully silenced (`>/dev/null 2>&1`) and the call was unbounded, so from the user's side the script just hung with no indication it was waiting on (or had finished) a login. The key rotation itself runs *before* this step, so the key was already rotated — only the post-rotation validation hung.

## Fix

- **Stop silencing stderr** on the validation `sbx create` so any login prompt is visible.
- **Bound it with `timeout`** (default 120s, override via `ROTATE_VALIDATE_TIMEOUT`) so an interactive-login handshake can never hang the script indefinitely. (`sbx` has no non-interactive auth-status probe, so the timeout is the safety net.)
- **On timeout/failure, exit cleanly** and tell the user the key was **already rotated** and to run `sbx login` then `acq run` (which validates on attach) — a hiccup no longer implies the rotation failed.

Uses `rc=0; cmd || rc=$?` to capture the real exit code under `set -euo pipefail` (a plain `if ! cmd` would mask it as 0, breaking the 124-timeout branch).

## Testing

- `bash -n` + `shellcheck -S warning` clean.
- Verified the `rc=124` capture works correctly under `set -e`.

AI-assisted (OpenCode). Non-contract bug fix.
