### PR TITLE
fix(acq): make USAi key rotation backend-neutral

### DIFF
--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -448,9 +448,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -10,7 +10,8 @@
     "markdownlint-cli2": "0.22.1"
   },
   "overrides": {
-    "js-yaml": "4.2.0",
-    "markdown-it": "14.2.0"
+    "js-yaml": "4.3.0",
+    "markdown-it": "14.2.0",
+    "linkify-it": "5.0.2"
   }
 }

--- a/README.md
+++ b/README.md
@@ -267,8 +267,10 @@ To rotate the key explicitly outside that workflow:
    ./acq usai-rotate-api-key
    ```
 
-   (or run the underlying `scripts/rotate-apikey` directly). It prompts for the
-   new key, then validates it in a temporary sandbox.
+   (or run the underlying `scripts/rotate-apikey` directly — a thin shim that
+   forwards to `acq usai-rotate-api-key`). It prompts for the new key, then
+   validates it in a temporary sandbox. Rotation runs through the active
+   backend (sbx or msb), so it works regardless of which backend you use.
 
 </details>
 

--- a/acq
+++ b/acq
@@ -48,9 +48,6 @@ export ACQ_SCRIPT_DIR
 # The resolved path of this acq script (for version output).
 ACQ_RESOLVED_PATH="${ACQ_SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]}")"
 
-# Standalone helper scripts.
-ROTATE_SCRIPT="${ACQ_SCRIPT_DIR}/scripts/rotate-apikey"
-
 # Source common backend-agnostic logic.
 # shellcheck disable=SC1091
 . "${ACQ_SCRIPT_DIR}/acq.backends/common.sh"
@@ -253,11 +250,12 @@ acq_resolve_backend "${explicit_backend}"
 case "$subcommand" in
   usai-rotate-api-key)
     shift
-    if [ ! -x "$ROTATE_SCRIPT" ]; then
-      echo "acq: scripts/rotate-apikey not found or not executable" >&2
+    if ! command -v acq_backend_rotate_key >/dev/null 2>&1; then
+      echo "acq: the '${ACQ_RESOLVED_BACKEND}' backend does not implement key rotation" >&2
+      echo "     (acq_backend_rotate_key). Rotate manually, then re-run." >&2
       exit 1
     fi
-    exec "$ROTATE_SCRIPT" "$@"
+    acq_backend_rotate_key "$@"
     ;;
 
   create)

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -401,9 +401,11 @@ ensure_valid_key() {
   echo "  3. Copy the new key using the console copy button" >&2
   echo >&2
 
-  local rotate_script="${ACQ_SCRIPT_DIR}/scripts/rotate-apikey"
-  if [ ! -x "$rotate_script" ]; then
-    echo "Cannot find scripts/rotate-apikey; rotate manually, then re-run." >&2
+  local rotate_via_backend=1
+  if ! command -v acq_backend_rotate_key >/dev/null 2>&1; then
+    rotate_via_backend=0
+    echo "The '${ACQ_RESOLVED_BACKEND:-active}' backend does not implement key rotation." >&2
+    echo "Rotate manually, then re-run." >&2
     return 1
   fi
 
@@ -412,7 +414,12 @@ ensure_valid_key() {
   read -r answer || true
   case "$answer" in
     [yY]|[yY][eE][sS])
-      "$rotate_script"
+      if [ "$rotate_via_backend" -eq 1 ]; then
+        acq_backend_rotate_key || {
+          echo "Rotation did not complete. Aborting attach." >&2
+          return 1
+        }
+      fi
       status=$(check_key "$name")
       if [ "$status" = "200" ]; then
         echo "Key validated. Continuing." >&2

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -1015,6 +1015,51 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# acq_backend_rotate_key — rotate the global USAi key (per ADR-0012)
+# ---------------------------------------------------------------------------
+# msb has no proxy-placeholder concept: the acq-owned secret store is the source
+# of truth, and msb binds it at provision via `--secret ENV@HOST` and re-feeds
+# running sandboxes with `msb modify --secret`. Rotation therefore = store the
+# new key in the acq store + re-feed running sandboxes (exactly the `acq secret
+# set -g usai` path) + validate. Never places the value on argv. Returns
+# non-zero on failure.
+acq_backend_rotate_key() {
+  if ! command -v acq_secret_set_interactive >/dev/null 2>&1; then
+    echo "acq(msb): internal error: secret store not loaded" >&2
+    return 1
+  fi
+
+  echo "Rotating the USAi key in the acq secret store (msb backend)." >&2
+
+  # Store the new key (TTY/stdin; never argv) and re-feed running sandboxes.
+  # acq_backend_secret_set already stores usai + runs `msb modify --secret` for
+  # every running sandbox, so reuse it rather than duplicating that logic.
+  acq_backend_secret_set -g usai || {
+    echo "acq(msb): failed to store the new USAi key." >&2
+    return 1
+  }
+
+  # Validate the new key in a fresh throwaway sandbox (backend-neutral helper).
+  echo "Validating new key in a temporary sandbox..." >&2
+  local status=""
+  if command -v check_fresh_sandbox_key >/dev/null 2>&1; then
+    status=$(check_fresh_sandbox_key)
+  fi
+
+  if [ -z "$status" ]; then
+    echo "Could not run a validation sandbox; skipping check." >&2
+    echo "The key was rotated. Re-run 'acq run' to validate on next attach." >&2
+    return 0
+  fi
+  if [ "$status" = "200" ]; then
+    echo "Key validated (HTTP 200). You're good to go." >&2
+    return 0
+  fi
+  echo "acq(msb): key validation failed (HTTP ${status}). Double-check the key and rotate again." >&2
+  return 1
+}
+
+# ---------------------------------------------------------------------------
 # acq_backend_version / acq_backend_doctor
 # ---------------------------------------------------------------------------
 

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -749,6 +749,143 @@ _acq_sbx_secret_exists() {
 }
 
 # ---------------------------------------------------------------------------
+# acq_backend_rotate_key — rotate the global USAi key (per ADR-0012)
+# ---------------------------------------------------------------------------
+# Rotate the global USAI_API_KEY custom secret in sbx, PRESERVING its proxy
+# placeholder so existing sandboxes keep resolving to the new value. Carried
+# verbatim from the former scripts/rotate-apikey (which is now a thin shim that
+# calls `acq usai-rotate-api-key`). Never places the secret value on argv — sbx
+# prompts for the new key at its own prompt. Returns non-zero on failure.
+acq_backend_rotate_key() {
+  local usai_host="api.gsa.usai.gov"
+  local usai_models_url="https://${usai_host}/api/v1/models"
+
+  # Read the current secret table once (avoids a TOCTOU window + a second call).
+  local secret_ls
+  secret_ls=$(sbx secret ls -g) || {
+    echo "acq(sbx): could not read the sbx secret table ('sbx secret ls -g')." >&2
+    return 1
+  }
+
+  # Grab the existing placeholder, anchoring on the USAI_API_KEY token rather
+  # than a fixed column, taking only the FIRST match so a duplicated state can't
+  # produce a multi-line value. Preserved across rotation so running sandboxes
+  # that already injected it keep resolving to the new secret.
+  local placeholder
+  placeholder=$(printf '%s\n' "$secret_ls" \
+    | awk '{ for (i = 1; i <= NF; i++) if ($i == "USAI_API_KEY") { print $(i+1); exit } }')
+
+  if [ -z "$placeholder" ]; then
+    echo "acq(sbx): USAI_API_KEY not found. Run 'acq secret ls' to check." >&2
+    return 1
+  fi
+
+  # Count USAI_API_KEY rows. More than one means a previous rotation (before the
+  # fix in ADR-0008) left duplicate/ghost entries; the proxy can then resolve the
+  # placeholder to an empty entry and validation fails with 401.
+  local row_count
+  row_count=$(printf '%s\n' "$secret_ls" \
+    | grep -cE '[[:space:]]USAI_API_KEY[[:space:]]' || true)
+
+  if [ "${row_count:-0}" -gt 1 ]; then
+    # --- Cleanup path for data corrupted by the pre-fix rotation bug ----------
+    # Only taken when duplicates exist. We must remove every custom secret for
+    # the host (`sbx secret rm -g --host` deletes ALL matching entries) and
+    # recreate a single one — there's no in-place "dedupe". This is destructive
+    # and non-atomic: between the rm and the set-custom the host has NO USAi
+    # secret, so a Ctrl-C or a failed/cancelled set-custom would leave the host
+    # with no key at all. Guard that window with a trap that prints exact
+    # recovery steps, and disarm it once set-custom succeeds.
+    echo "Found $row_count USAI_API_KEY entries; consolidating to a single secret." >&2
+
+    local _ph="$placeholder" _host="$usai_host"
+    # shellcheck disable=SC2064
+    trap "{
+      echo '' >&2
+      echo 'ERROR: rotation was interrupted while the USAI_API_KEY secret was removed' >&2
+      echo 'but before the new value was set. Your sandboxes currently have NO USAi key.' >&2
+      echo 'Recover by re-running this rotation, or manually:' >&2
+      echo '  sbx secret set-custom -g --host ${_host} --env USAI_API_KEY --placeholder ${_ph}' >&2
+    }" EXIT
+
+    local rm_err
+    if ! rm_err=$(sbx secret rm -g --host "$usai_host" -f 2>&1); then
+      trap - EXIT
+      echo "acq(sbx): failed to remove existing secrets: $rm_err" >&2
+      return 1
+    fi
+
+    # Recreate the single secret with the preserved placeholder. Omitting
+    # --value makes sbx prompt for the new key (keeps it out of shell history).
+    sbx secret set-custom -g --host "$usai_host" \
+          --env USAI_API_KEY --placeholder "$placeholder" || {
+      echo "acq(sbx): 'sbx secret set-custom' failed. See recovery steps above." >&2
+      return 1
+    }
+
+    trap - EXIT
+  else
+    # Healthy single-row case: set-custom updates the existing entry in place, so
+    # there's no need for the destructive rm (which would only add risk here).
+    # Omitting --value makes sbx prompt for the new key (no shell-history leak).
+    sbx secret set-custom -g --host "$usai_host" \
+          --env USAI_API_KEY --placeholder "$placeholder" || {
+      echo "acq(sbx): 'sbx secret set-custom' failed." >&2
+      return 1
+    }
+  fi
+
+  # Validate the new key in a throwaway sandbox so we don't depend on any
+  # particular pre-existing sandbox. Created here, removed on exit.
+  local validation_sbx="acq-keycheck-$$"
+  # shellcheck disable=SC2064
+  trap "sbx rm '$validation_sbx' >/dev/null 2>&1 || true" EXIT
+
+  echo "Validating new key in a temporary sandbox..." >&2
+  # `sbx create` needs an authenticated sbx session. If it has expired, sbx
+  # triggers an interactive browser login — and if its output is swallowed and
+  # it's unbounded, rotation appears to hang with no explanation (quickstart
+  # #211). Two guards: (1) do NOT silence stderr, so any login prompt is
+  # visible; (2) bound the create with a timeout so an interactive-login
+  # handshake can never hang indefinitely. sbx has no non-interactive
+  # auth-status probe, so the timeout is the safety net.
+  local create_timeout="${ROTATE_VALIDATE_TIMEOUT:-120}"
+  local rc=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$create_timeout" sbx create --name "$validation_sbx" shell . >/dev/null || rc=$?
+  else
+    sbx create --name "$validation_sbx" shell . >/dev/null || rc=$?
+  fi
+  if [ "$rc" != "0" ]; then
+    if [ "$rc" = "124" ]; then
+      echo "Validation timed out after ${create_timeout}s — sbx likely needed an interactive login." >&2
+      echo "Run 'sbx login', then 'acq run' (it validates the key on next attach)." >&2
+    else
+      echo "Could not create a validation sandbox; skipping check." >&2
+      echo "The key was rotated. Run 'sbx login' if needed, then 'acq run' — it validates on next attach." >&2
+    fi
+    trap - EXIT
+    return 0
+  fi
+
+  local status
+  status=$(sbx exec "$validation_sbx" -- sh -c \
+     "curl -sS -o /dev/null -w '%{http_code}' \
+      -H \"Authorization: Bearer \$USAI_API_KEY\" \
+      $usai_models_url" 2>/dev/null || true)
+
+  sbx rm "$validation_sbx" >/dev/null 2>&1 || true
+  trap - EXIT
+
+  if [ "$status" = "200" ]; then
+    echo "Key validated (HTTP 200). You're good to go." >&2
+    return 0
+  fi
+  echo "acq(sbx): key validation failed (HTTP ${status:-unknown}). Double-check the key and rotate again." >&2
+  return 1
+}
+
+# ---------------------------------------------------------------------------
 # acq_backend_version / acq_backend_doctor
 # ---------------------------------------------------------------------------
 

--- a/docs/adr/0008-usai-placeholder-recovery.md
+++ b/docs/adr/0008-usai-placeholder-recovery.md
@@ -129,4 +129,7 @@ never done.
   pinned reference), [KNOWN_FAILURE_MODES.md §14](../KNOWN_FAILURE_MODES.md#14-sbx-proxy-doesnt-work-with-custom-baseurl-security-implication)
   (custom-secret injection), [§20](../KNOWN_FAILURE_MODES.md#20-authentication-failed-after-copying-a-new-key)
 - Rotation helper that preserves the placeholder: `scripts/rotate-apikey`
+  (now a thin shim; the placeholder-preserving logic moved into
+  `acq.backends/sbx.sh` as `acq_backend_rotate_key` per
+  [ADR-0012](0012-backend-neutral-key-rotation.md))
 - Upstream custom-service support: [docker/sbx-releases#35](https://github.com/docker/sbx-releases/issues/35)

--- a/docs/adr/0010-acq-pluggable-backends.md
+++ b/docs/adr/0010-acq-pluggable-backends.md
@@ -87,6 +87,11 @@ capability flag variables:
 | `acq_backend_version` | Echo backend version string |
 | `acq_backend_doctor` | Echo one matrix row for `acq doctor` output |
 
+> **Contract addition ([ADR-0012](0012-backend-neutral-key-rotation.md)):**
+> `acq_backend_rotate_key` — rotate the USAi API key using the backend's native
+> secret mechanism and validate the new key. Added so key rotation stays
+> backend-neutral (the core dispatch no longer shells out to `sbx` directly).
+
 Capability flags (`ACQ_BACKEND_SUPPORTS_PORT_FORWARD`, etc.) allow `common.sh`
 to gate features and future backends to declare gaps.
 

--- a/docs/adr/0012-backend-neutral-key-rotation.md
+++ b/docs/adr/0012-backend-neutral-key-rotation.md
@@ -1,0 +1,150 @@
+---
+title: "Make USAi Key Rotation Backend-Neutral via acq_backend_rotate_key"
+status: accepted
+date: 2026-07-22
+decision_makers: ["Bret Mogilefsky"]
+category: architecture
+nist_controls: ["CM-3", "CM-6", "CM-7", "SA-8", "SA-15", "SA-17", "IA-5"]
+impact_level: low
+ato_relevance: no
+risk_treatment: mitigate
+supersedes: []
+---
+
+# ADR-0012: Make USAi Key Rotation Backend-Neutral via acq_backend_rotate_key
+
+## Context and Problem Statement
+
+ADR-0010 established the `acq` pluggable-backend seam: the core dispatch calls
+`acq_backend_*` functions and holds no backend-specific CLI knowledge, so a
+backend (sbx, msb) is substituted purely by loading a different adapter. ADR-0011
+added the `msb` adapter.
+
+One code path was left coupled to `sbx`: **USAi key rotation.**
+`scripts/rotate-apikey` is hardcoded to the `sbx` CLI end-to-end (`sbx secret
+ls/rm/set-custom`, `sbx create/exec/rm` for validation). Two dispatch points
+invoke it unconditionally, *after* the backend has already been resolved:
+
+- `acq usai-rotate-api-key` (`acq`) — `exec "$ROTATE_SCRIPT"`
+- `ensure_valid_key` (`acq.backends/common.sh`) — runs on `acq run` for **every**
+  backend when the pre-attach key check fails
+
+A user on the `msb` backend who runs `acq run` with an expired key (USAi keys
+expire every 7 days) is therefore funneled into `sbx` commands. If `sbx` is not
+installed — or has no available seats — rotation fails and blocks the user from
+launching their agent, even though nothing about their setup should touch `sbx`.
+This is a violation of the ADR-0010 invariant ("no backend dependency outside the
+adapters").
+
+The rotation *mechanism* also differs by backend and cannot simply be
+name-swapped:
+
+- **sbx** owns a proxy placeholder that must be preserved across rotation so
+  running sandboxes keep resolving the injected value. Rotation = re-feed the sbx
+  proxy for `USAI_API_KEY@api.gsa.usai.gov` while keeping the placeholder.
+- **msb** has no proxy-placeholder concept. The acq-owned secret store
+  (`secret-store.sh`) is the source of truth; msb binds it at provision via
+  `--secret ENV@HOST` and re-feeds running sandboxes with `msb modify --secret`.
+  This is already exactly what `acq secret set -g usai` does on msb
+  (`acq.backends/msb.sh`).
+
+## Decision Drivers
+
+- **Restore the ADR-0010 invariant** — no `sbx` (or any backend) knowledge
+  outside `acq.backends/<name>.sh` (SA-8/SA-17).
+- **Additive to the adapter contract** — extend the contract with one function,
+  matching the existing `acq_backend_*` pattern rather than special-casing.
+- **Preserve each backend's real rotation semantics** — sbx placeholder
+  preservation; msb store re-feed. Not a lowest-common-denominator rewrite.
+- **Fail closed, no silent fallback** — a missing rotation capability must report
+  clearly, never quietly shell out to the wrong backend.
+
+## Considered Options
+
+1. **Add `acq_backend_rotate_key` to the adapter contract; dispatch through it.**
+   Chosen. `scripts/rotate-apikey` becomes a thin `acq usai-rotate-api-key`
+   shim (back-compat) that routes to the resolved backend. sbx keeps its
+   placeholder-preserving logic inside `sbx.sh`; msb reuses its store re-feed.
+2. **Branch on `ACQ_RESOLVED_BACKEND` at each call site.** Rejected: reintroduces
+   backend knowledge into the neutral core (`acq`, `common.sh`) — the exact smell
+   ADR-0010 removed — and duplicates the branch at two sites.
+3. **Leave rotation sbx-only, document it.** Rejected: leaves msb users blocked
+   on a routine (7-day) operation and contradicts the pluggable-backend promise.
+
+## Decision Outcome
+
+**Chosen: Option 1.**
+
+- Extend the ADR-0010 adapter contract with one function:
+
+  | Function | Purpose |
+  |----------|---------|
+  | `acq_backend_rotate_key` | Rotate the USAi API key using the backend's native secret mechanism; validate the new key; return non-zero on failure. |
+
+- `acq usai-rotate-api-key` resolves the backend (already does) and calls
+  `acq_backend_rotate_key` instead of `exec`ing the sbx-only script.
+- `ensure_valid_key` (`common.sh`) calls `acq_backend_rotate_key` instead of the
+  script, gated on the function being defined (fail closed with a clear message
+  if a backend does not implement it).
+- `acq.backends/sbx.sh` implements `acq_backend_rotate_key` by carrying the
+  existing placeholder-preserving logic verbatim (dedup of pre-fix duplicate
+  entries, in-place `set-custom`, throwaway-sandbox validation).
+- `acq.backends/msb.sh` implements `acq_backend_rotate_key` by prompting for the
+  new key into the acq store and re-feeding running sandboxes with
+  `msb modify --secret` (the `acq secret set -g usai` path), then validating in a
+  fresh sandbox via the shared `check_fresh_sandbox_key` helper.
+- `scripts/rotate-apikey` is reduced to a thin back-compat wrapper that execs
+  `acq usai-rotate-api-key` so existing muscle-memory / docs keep working, but it
+  no longer contains any `sbx` calls.
+
+### Adapter contract addition
+
+`acq_backend_rotate_key` takes no required arguments (rotation is a global-key
+operation). It MUST:
+- collect the new key without placing it on argv (TTY prompt / stdin), never log
+  the value;
+- update the backend's injection mechanism for `USAI_API_KEY@api.gsa.usai.gov`;
+- validate the new key against the USAi models API from inside a sandbox and
+  return non-zero if validation fails or cannot run.
+
+## Consequences
+
+### Positive Consequences
+
+- msb (and any future backend) users can rotate the USAi key without `sbx`
+  installed — the reported block is removed.
+- The neutral core (`acq`, `common.sh`) again holds zero backend CLI knowledge;
+  the ADR-0010 seam is complete.
+- Each backend keeps its correct rotation semantics (sbx placeholder, msb store
+  re-feed).
+
+### Negative Consequences
+
+- The adapter contract grows by one function; existing/future adapters must
+  implement it (enforced by fail-closed dispatch + a `scripts/test-acq` check).
+
+### Compliance Consequences
+
+- CM-7 (least functionality) / SA-8 (security engineering): removes an
+  unintended cross-backend dependency.
+- IA-5 (authenticator management): key rotation remains a first-class,
+  audited operation regardless of backend; the secret value never reaches argv
+  or logs.
+- No change to attack surface, external services, or data classification
+  (CM-3/CM-6). No ATO package impact.
+
+## Validation
+
+- `bash -n acq acq.backends/*.sh scripts/rotate-apikey scripts/test-acq` clean.
+- `./scripts/test-acq` passes, including new checks that
+  `acq usai-rotate-api-key` dispatches to `acq_backend_rotate_key` on both
+  backends and that the rotate path issues no `sbx` command on the msb backend.
+- **Deferred, requires a sandbox-capable host:** the live rotate→validate loop
+  (creates a throwaway validation sandbox) cannot run inside a sandbox — mirrors
+  the ADR-0010/0011 deferral. Tracked for `scripts/verify-*` coverage.
+
+## Links
+
+- Contract base: [ADR-0010](0010-acq-pluggable-backends.md) (Adapter contract)
+- msb adapter + neutral kits: [ADR-0011](0011-msb-backend-and-neutral-kits.md)
+- USAi placeholder recovery (sbx rotation semantics): [ADR-0008](0008-usai-placeholder-recovery.md)

--- a/scripts/rotate-apikey
+++ b/scripts/rotate-apikey
@@ -1,120 +1,30 @@
 #!/usr/bin/env bash
-# Rotate the global USAI_API_KEY custom secret in sbx, preserving its
-# placeholder so existing sandboxes keep working after the new value is set.
+# Back-compat shim. USAi key rotation is now backend-neutral: it dispatches
+# through the resolved acq backend's acq_backend_rotate_key (see ADR-0012).
+# This script simply forwards to `acq usai-rotate-api-key` so existing muscle
+# memory / docs keep working. It contains no backend-specific (sbx) logic.
+#
+# Prefer calling `acq usai-rotate-api-key` directly.
 
 set -euo pipefail
 
-USAI_HOST="api.gsa.usai.gov"
-USAI_MODELS_URL="https://${USAI_HOST}/api/v1/models"
+# Resolve the repo root (this script lives in <root>/scripts/), following symlinks.
+_src="${BASH_SOURCE[0]}"
+while [ -h "$_src" ]; do
+  _dir=$(cd -P "$(dirname "$_src")" >/dev/null 2>&1 && pwd)
+  _src=$(readlink "$_src")
+  case "$_src" in
+    /*) ;;
+    *) _src="$_dir/$_src" ;;
+  esac
+done
+_script_dir=$(cd -P "$(dirname "$_src")" >/dev/null 2>&1 && pwd)
+_repo_root=$(cd -P "${_script_dir}/.." >/dev/null 2>&1 && pwd)
 
-fail() {
-    echo "$@" >&2
-    exit 1
-}
-
-# Read the current secret table once (avoids a TOCTOU window and a second call).
-secret_ls=$(sbx secret ls -g)
-
-# Grab the existing placeholder, anchoring on the USAI_API_KEY token rather than
-# a fixed column, and take only the FIRST match so a duplicated state can't
-# produce a multi-line value. The placeholder is preserved across rotation so
-# running sandboxes that already injected it keep resolving to the new secret.
-placeholder=$(printf '%s\n' "$secret_ls" \
-  | awk '{ for (i = 1; i <= NF; i++) if ($i == "USAI_API_KEY") { print $(i+1); exit } }')
-
-if [ -z "$placeholder" ]; then
-   fail "Error: USAI_API_KEY not found. Run 'sbx secret ls -g' to check."
+ACQ="${_repo_root}/acq"
+if [ ! -x "$ACQ" ]; then
+  echo "rotate-apikey: cannot find the acq entry point at ${ACQ}" >&2
+  exit 1
 fi
 
-# Count USAI_API_KEY rows. More than one means a previous rotation (before this
-# bug was fixed) left duplicate/ghost entries; the proxy can then resolve the
-# placeholder to an empty entry and validation fails with 401.
-row_count=$(printf '%s\n' "$secret_ls" \
-  | grep -cE '[[:space:]]USAI_API_KEY[[:space:]]' || true)
-
-if [ "${row_count:-0}" -gt 1 ]; then
-  # --- Cleanup path for data corrupted by the pre-fix rotation bug -----------
-  # Only taken when duplicates exist. We must remove every custom secret for the
-  # host (`sbx secret rm -g --host` deletes ALL matching entries) and recreate a
-  # single one — there's no in-place "dedupe". This is destructive and
-  # non-atomic: between the rm and the set-custom the host has NO USAi secret, so
-  # a Ctrl-C or a failed/cancelled set-custom would leave the host with no key at
-  # all. Guard that window with a trap that prints exact recovery steps, and
-  # disarm it once set-custom succeeds.
-  echo "Found $row_count USAI_API_KEY entries; consolidating to a single secret." >&2
-
-  recover_msg() {
-    echo "" >&2
-    echo "ERROR: rotation was interrupted while the USAI_API_KEY secret was removed" >&2
-    echo "but before the new value was set. Your sandboxes currently have NO USAi key." >&2
-    echo "Recover by re-running this script, or manually:" >&2
-    echo "  sbx secret set-custom -g --host $USAI_HOST --env USAI_API_KEY --placeholder $placeholder" >&2
-  }
-  trap recover_msg EXIT
-
-  # Surface rm failures (e.g. an sbx flag change) instead of silently swallowing
-  # them and recreating on top of the duplicates.
-  if ! rm_err=$(sbx secret rm -g --host "$USAI_HOST" -f 2>&1); then
-    trap - EXIT
-    fail "Failed to remove existing secrets: $rm_err"
-  fi
-
-  # Recreate the single secret with the preserved placeholder. Omitting --value
-  # makes sbx prompt for the new key (keeps it out of shell history).
-  sbx secret set-custom -g --host "$USAI_HOST" \
-        --env USAI_API_KEY --placeholder "$placeholder"
-
-  trap - EXIT
-else
-  # Healthy single-row case: set-custom updates the existing entry in place, so
-  # there's no need for the destructive rm (which would only add risk here).
-  # Omitting --value makes sbx prompt for the new key (no shell-history leak).
-  sbx secret set-custom -g --host "$USAI_HOST" \
-        --env USAI_API_KEY --placeholder "$placeholder"
-fi
-
-# Validate the new key in a throwaway sandbox so we don't depend on any
-# particular pre-existing sandbox. Created here, removed on exit.
-validation_sbx="qsbx-keycheck-$$"
-cleanup() {
-  sbx rm "$validation_sbx" >/dev/null 2>&1 || true
-}
-trap cleanup EXIT
-
-echo "Validating new key in a temporary sandbox..."
-# `sbx create` needs an authenticated sbx session. If the session has expired,
-# `sbx create` triggers an interactive browser login — and if its output is
-# swallowed and it's unbounded, the script appears to hang with no explanation
-# (#211). Two guards: (1) do NOT silence stderr, so any login prompt is visible;
-# (2) bound the create with a timeout so an interactive-login handshake can never
-# hang the script indefinitely. sbx has no non-interactive auth-status probe, so
-# the timeout is the safety net.
-_sbx_create_timeout="${ROTATE_VALIDATE_TIMEOUT:-120}"
-if command -v timeout >/dev/null 2>&1; then
-  _run_create() { timeout "$_sbx_create_timeout" sbx create --name "$validation_sbx" shell . >/dev/null; }
-else
-  _run_create() { sbx create --name "$validation_sbx" shell . >/dev/null; }
-fi
-rc=0
-_run_create || rc=$?
-if [ "$rc" != "0" ]; then
-  if [ "$rc" = "124" ]; then
-    echo "Validation timed out after ${_sbx_create_timeout}s — sbx likely needed an interactive login." >&2
-    echo "Run 'sbx login', then 'acq run' (it validates the key on next attach)." >&2
-  else
-    echo "Could not create a validation sandbox; skipping check." >&2
-    echo "The key was rotated. Run 'sbx login' if needed, then 'acq run' — it validates on next attach." >&2
-  fi
-  exit 0
-fi
-
-status=$(sbx exec "$validation_sbx" -- sh -c \
-   "curl -sS -o /dev/null -w '%{http_code}' \
-    -H \"Authorization: Bearer \$USAI_API_KEY\" \
-    $USAI_MODELS_URL" 2>/dev/null || true)
-
-if [ "$status" = "200" ]; then
-  echo "Key validated (HTTP 200). You're good to go."
-else
-  fail "Key validation failed (HTTP ${status:-unknown}). Double-check the key and rotate again."
-fi
+exec "$ACQ" usai-rotate-api-key "$@"

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -982,6 +982,63 @@ assert_not_contains "msb: empty DNS nameserver omits the flag" "$(cat "$CALLS")"
 cleanup_stubs
 
 # ===========================================================================
+# 8r. acq usai-rotate-api-key — backend-neutral dispatch (ADR-0012)
+# ===========================================================================
+# The rotate path must go through the resolved backend's acq_backend_rotate_key,
+# NOT a hardcoded sbx script. On the sbx backend it preserves the placeholder
+# via `sbx secret set-custom`; on the msb backend it must issue NO sbx command.
+
+# 8r1. sbx backend: rotate dispatches to sbx secret set-custom (placeholder
+#      preserved), and validates in a throwaway sandbox.
+make_stubs
+printf 'placeholder-token USAI_API_KEY {}\n' > "$STUBDIR/sbx_ls"
+export SBX_LS_FIXTURE="$STUBDIR/sbx_ls"
+out=$(ACQ_BACKEND=sbx "$ACQ" usai-rotate-api-key </dev/null 2>&1 || true)
+unset SBX_LS_FIXTURE
+log=$(cat "$CALLS")
+assert_contains "rotate(sbx): uses sbx secret set-custom" "$log" "sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY"
+assert_contains "rotate(sbx): validates in a throwaway sandbox" "$log" "sbx create --name acq-keycheck-"
+cleanup_stubs
+
+# 8r2. msb backend: rotate issues NO sbx command (the reported bug), stores the
+#      key in the acq store, and re-feeds running sandboxes via msb modify.
+make_stubs
+# Seed one running sandbox so the re-feed loop (`msb list -q` -> `msb modify`) runs.
+printf 'runningbox\n' > "$STUBDIR/.msb_sandbox_list"
+out=$(ACQ_SECRET_TEST_VALUE="new-usai-key" ACQ_BACKEND=msb "$ACQ" usai-rotate-api-key </dev/null 2>&1 || true)
+log=$(cat "$CALLS")
+assert_not_contains "rotate(msb): issues NO sbx command" "$log" "sbx "
+assert_contains "rotate(msb): re-feeds via msb modify --secret" "$log" "msb modify"
+if [ -f "$STUBDIR/secrets/acq.usai" ]; then
+  pass "rotate(msb): stored new key in acq store"
+else
+  fail "rotate(msb): stored new key in acq store" "acq.usai not found"
+fi
+cleanup_stubs
+
+# 8r3. Both adapters define the acq_backend_rotate_key contract function.
+make_stubs; load_acq
+if command -v acq_backend_rotate_key >/dev/null 2>&1; then
+  pass "rotate: sbx adapter defines acq_backend_rotate_key"
+else
+  fail "rotate: sbx adapter defines acq_backend_rotate_key" "function missing"
+fi
+cleanup_stubs
+make_stubs; load_acq
+( . "${REPO_ROOT}/acq.backends/msb.sh"
+  command -v acq_backend_rotate_key >/dev/null 2>&1
+) && pass "rotate: msb adapter defines acq_backend_rotate_key" \
+  || fail "rotate: msb adapter defines acq_backend_rotate_key" "function missing"
+cleanup_stubs
+
+# 8r4. scripts/rotate-apikey is a thin shim with NO direct sbx call.
+if grep -qE '(^|[^[:alnum:]_])sbx[[:space:]]+secret' "$REPO_ROOT/scripts/rotate-apikey"; then
+  fail "rotate: scripts/rotate-apikey has no direct sbx call" "found 'sbx secret' in the shim"
+else
+  pass "rotate: scripts/rotate-apikey has no direct sbx call"
+fi
+
+# ===========================================================================
 # 9. acq kit subcommands
 # ===========================================================================
 


### PR DESCRIPTION
A user on the msb backend found that rotating their USAi key still shelled out to sbx, which failed with "no available seats" and blocked them from launching opencode. The cause was that key rotation was hardcoded to the sbx CLI and ran unconditionally regardless of the active backend — even though `acq` is supposed to keep all backend-specific behavior inside its adapters. This change moves rotation behind a new `acq_backend_rotate_key` adapter function so each backend rotates using its own mechanism, and reduces `scripts/rotate-apikey` to a thin wrapper around `acq usai-rotate-api-key`. As a result, msb users (and any future backend) can rotate their key without sbx installed. See ADR-0012 for the design rationale.

The live rotate-and-validate path spins up a throwaway sandbox and so can't run inside CI; it's deferred to a sandbox-capable host, consistent with prior backend work. This is AI-assisted work and needs human review before merge.