### PR TITLE
fix(acq): intercept --kit <ref> on run/create and translate it

### DIFF
--- a/acq
+++ b/acq
@@ -7,8 +7,8 @@
 # sbx kits as qsbx, unchanged, for 1.1.x.
 #
 # Usage:
-#   acq run AGENT PATH [...] [-- AGENT_ARGS...]  # create+attach or re-attach
-#   acq create AGENT PATH [...]                   # create detached
+#   acq run AGENT PATH [...] [--kit REF]... [-- AGENT_ARGS...]  # create+attach
+#   acq create AGENT PATH [...] [--kit REF]...    # create detached
 #   acq ls                                        # list sandboxes
 #   acq stop NAME                                 # stop without removing
 #   acq rm NAME                                   # remove
@@ -25,6 +25,12 @@
 #
 # Global flag (before subcommand):
 #   --backend <name>    Override backend for this invocation
+#
+# run/create flag:
+#   --kit REF           Apply an extra kit (repeatable). REF is a local dir or a
+#                       git+https ref, same as an ACQ_EXTRA_KITS entry. acq
+#                       translates it (neutral hybrid/v1 -> backend); it is NOT
+#                       forwarded raw to the backend.
 
 set -euo pipefail
 
@@ -244,6 +250,27 @@ esac
 acq_resolve_backend "${explicit_backend}"
 
 # ---------------------------------------------------------------------------
+# Intercept user-supplied `--kit <ref>` on run/create (repeatable).
+# ---------------------------------------------------------------------------
+# A `--kit` flag must be handled BY ACQ, not forwarded to the backend: the
+# backend spells local-kit application the same way, so a user naturally writes
+# `acq run opencode --kit <dir> .`, but the backend cannot parse a NEUTRAL
+# hybrid/v1 kit. extract_kit_flags pulls the refs into ACQ_CLI_KITS and the
+# remaining (kit-stripped) args into ACQ_KIT_REMAINING. It must run in THIS
+# shell so the array assignments survive. acq_resolve_backend already built the
+# kit list once; re-run _build_kit_list to include the CLI kits.
+case "$subcommand" in
+  run|create)
+    _sub="$subcommand"
+    shift                       # drop the subcommand token; $@ is now its args
+    extract_kit_flags "$@"
+    [ "${#ACQ_CLI_KITS[@]}" -gt 0 ] && _build_kit_list   # re-fold with CLI kits
+    # Rebuild positional args as: <subcommand> <remaining args w/o --kit>.
+    set -- "$_sub" ${ACQ_KIT_REMAINING[@]+"${ACQ_KIT_REMAINING[@]}"}
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
 # Main dispatch
 # ---------------------------------------------------------------------------
 
@@ -449,6 +476,10 @@ Subcommands:
 
 Global flags (before subcommand):
   --backend <name>           Override the active backend
+
+run/create flag:
+  --kit REF                  Apply an extra kit (repeatable); local dir or
+                             git+https ref, translated by acq like ACQ_EXTRA_KITS
 
 Unknown subcommands are passed through to the active backend's CLI.
 

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -251,6 +251,9 @@ strip_backend_flag() {
 #   ACQ_CLI_KITS         — the kit refs, one per element
 #   ACQ_KIT_REMAINING    — the arg list with all --kit flags removed
 #
+# Scanning STOPS at the first `--` separator: everything after it is agent args
+# (which may legitimately contain their own `--kit`) and is forwarded verbatim.
+#
 # Why acq must intercept `--kit`: the backend spells local-kit application the
 # same way (`sbx create --kit <dir>`), so a user naturally writes
 # `acq run opencode --kit <dir> .`. If acq forwarded that flag verbatim, the
@@ -265,17 +268,24 @@ extract_kit_flags() {
   ACQ_CLI_KITS=()
   ACQ_KIT_REMAINING=()
   local expect_kit=0 arg
-  for arg in "$@"; do
+  while [ "$#" -gt 0 ]; do
+    arg="$1"
     if [ "$expect_kit" -eq 1 ]; then
       ACQ_CLI_KITS+=("$arg")
       expect_kit=0
+      shift
       continue
     fi
     case "$arg" in
+      # Stop scanning at the first `--` separator: everything after it is
+      # agent args (which may legitimately contain their own `--kit`) and MUST
+      # pass through untouched. Append the separator and the rest verbatim.
+      --)      ACQ_KIT_REMAINING+=("$@"); break ;;
       --kit)   expect_kit=1 ;;
       --kit=*) ACQ_CLI_KITS+=("${arg#--kit=}") ;;
       *)       ACQ_KIT_REMAINING+=("$arg") ;;
     esac
+    shift
   done
   # A trailing `--kit` with no value: warn but don't crash.
   if [ "$expect_kit" -eq 1 ]; then

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -49,6 +49,14 @@ ACQ_KIT_NAMES=(usai-provider agentic-coding-playbook zscaler-ca-certificate git-
 ACQ_EXTRA_KITS="${ACQ_EXTRA_KITS:-}"
 ACQ_EXTRA_KIT_SOURCES="${ACQ_EXTRA_KIT_SOURCES:-}"
 
+# Kits supplied on the command line via `--kit <ref>` (repeatable) on
+# run/create. These are extracted from the arg list by extract_kit_flags (below)
+# BEFORE the args reach the backend, so a neutral kit ref is translated by acq
+# rather than passed raw to the backend CLI (which would fail to parse the
+# neutral schema). Folded into the kit list by _build_kit_list, alongside
+# ACQ_EXTRA_KITS. One ref per element.
+ACQ_CLI_KITS=()
+
 KIT_SOURCE_PREFIX="github.com/GSA-TTS/"
 KIT_SOURCE_PREFIXES=("$KIT_SOURCE_PREFIX")
 
@@ -102,6 +110,12 @@ _build_kit_list() {
     split_noglob _extra_kits "$ACQ_EXTRA_KITS"
     # shellcheck disable=SC2154
     KITS+=("${_extra_kits[@]}")
+  fi
+  # Kits given on the command line via `--kit <ref>` (extracted by
+  # extract_kit_flags before dispatch). Same treatment as ACQ_EXTRA_KITS:
+  # translated by acq, source-allowlisted, never forwarded raw to the backend.
+  if [ "${#ACQ_CLI_KITS[@]}" -gt 0 ]; then
+    KITS+=("${ACQ_CLI_KITS[@]}")
   fi
 
   # Also build the allowed sources list.
@@ -229,6 +243,44 @@ strip_backend_flag() {
     esac
     STRIPPED_ARGS+=("$arg")
   done
+}
+
+# Extract user-supplied `--kit <ref>` / `--kit=<ref>` flags from a run/create
+# arg list. Populates two arrays IN THE CURRENT SHELL (so callers must not run
+# this in a subshell/pipeline):
+#   ACQ_CLI_KITS         — the kit refs, one per element
+#   ACQ_KIT_REMAINING    — the arg list with all --kit flags removed
+#
+# Why acq must intercept `--kit`: the backend spells local-kit application the
+# same way (`sbx create --kit <dir>`), so a user naturally writes
+# `acq run opencode --kit <dir> .`. If acq forwarded that flag verbatim, the
+# backend would receive a NEUTRAL hybrid/v1 kit it cannot parse. Treating it like
+# an ACQ_EXTRA_KITS entry routes it through acq's translation instead.
+#
+# Usage:
+#   extract_kit_flags "$@"
+#   _build_kit_list                        # fold ACQ_CLI_KITS into KITS
+#   set -- "${ACQ_KIT_REMAINING[@]}"        # args without --kit
+extract_kit_flags() {
+  ACQ_CLI_KITS=()
+  ACQ_KIT_REMAINING=()
+  local expect_kit=0 arg
+  for arg in "$@"; do
+    if [ "$expect_kit" -eq 1 ]; then
+      ACQ_CLI_KITS+=("$arg")
+      expect_kit=0
+      continue
+    fi
+    case "$arg" in
+      --kit)   expect_kit=1 ;;
+      --kit=*) ACQ_CLI_KITS+=("${arg#--kit=}") ;;
+      *)       ACQ_KIT_REMAINING+=("$arg") ;;
+    esac
+  done
+  # A trailing `--kit` with no value: warn but don't crash.
+  if [ "$expect_kit" -eq 1 ]; then
+    echo "acq: --kit given with no value; ignoring" >&2
+  fi
 }
 
 # ============================================================================

--- a/acq.backends/kit-translate.sh
+++ b/acq.backends/kit-translate.sh
@@ -33,6 +33,7 @@
 # ---------------------------------------------------------------------------
 #   kit_spec_field       SPEC KEY            -> top-level scalar (name, kind, …)
 #   kit_spec_net_allow   SPEC                -> one host[:port] per line
+#   kit_spec_published_ports SPEC            -> one "container<TAB>proto<TAB>name" per line
 #   kit_spec_files       SPEC                -> one "path|mode|phase|source" per line
 #   kit_spec_commands    SPEC                -> command records (see format below)
 #   kit_spec_env         SPEC                -> one "NAME<TAB>value" per line
@@ -168,6 +169,64 @@ kit_spec_net_allow() {
         in_allow=0                            # dedent ends the list
       }
     }
+  ' "$spec"
+}
+
+# ---------------------------------------------------------------------------
+# kit_spec_published_ports SPEC
+# ---------------------------------------------------------------------------
+# Echo one record per backend_extras.sbx.publishedPorts[] entry, tab-separated:
+#   container <TAB> protocol <TAB> name
+# protocol/name are empty if unspecified. Only the sbx backend's block is read
+# (the neutral spec leaves backend_extras as free-form per-backend objects; the
+# sbx adapter is the consumer of this well-known shape). The list lives at:
+#   backend_extras:
+#     sbx:
+#       publishedPorts:
+#         - container: 3000
+#           protocol: tcp
+#           name: openchamber
+kit_spec_published_ports() {
+  local spec="$1"
+  [ -f "$spec" ] || return 0
+  awk '
+    function trim(s){ sub(/^[[:space:]]+/,"",s); sub(/[[:space:]]+$/,"",s); gsub(/^"|"$/,"",s); return s }
+    function flush(){ if (cur_c != "") printf "%s\t%s\t%s\n", cur_c, cur_p, cur_n; cur_c=""; cur_p=""; cur_n="" }
+    function indent_of(s,   i){ i=match(s,/[^ ]/); return (i==0? 0 : i-1) }
+    /^backend_extras:/  { in_be=1; next }
+    /^[A-Za-z]/         { if (in_be) { flush(); in_be=0; in_sbx=0; in_pp=0 } }
+    in_be {
+      # `  sbx:` at one indent level under backend_extras.
+      if ($0 ~ /^[[:space:]]+sbx:[[:space:]]*$/) { in_sbx=1; in_pp=0; sbx_ind=indent_of($0); next }
+      # Another backend key at the same indent as sbx ends the sbx block.
+      if (in_sbx && $0 ~ /^[[:space:]]+[A-Za-z_]+:/ && indent_of($0) <= sbx_ind && $0 !~ /publishedPorts:/) {
+        # Could be a sibling backend (msb:/ppp:) or a sibling sbx key (background:).
+        # Only leave the sbx block if this key is at sbx_ind (a sibling backend).
+        if (indent_of($0) == sbx_ind) { flush(); in_sbx=0; in_pp=0 }
+      }
+      if (in_sbx && $0 ~ /publishedPorts:[[:space:]]*$/) { in_pp=1; flush(); next }
+      if (in_pp) {
+        # A new list item: "        - container: 3000"
+        if ($0 ~ /^[[:space:]]+-[[:space:]]/) {
+          flush()
+          line=$0; sub(/^[[:space:]]*-[[:space:]]*/,"",line)
+          k=line; sub(/:.*/,"",k); k=trim(k)
+          v=line; sub(/^[^:]*:[[:space:]]*/,"",v); sub(/[[:space:]]*#.*/,"",v); v=trim(v)
+          if (k=="container") cur_c=v; else if (k=="protocol") cur_p=v; else if (k=="name") cur_n=v
+          next
+        }
+        # Continuation keys of the current item.
+        if ($0 ~ /^[[:space:]]+[A-Za-z]/) {
+          k=$0; sub(/:.*/,"",k); k=trim(k)
+          v=$0; sub(/^[^:]*:[[:space:]]*/,"",v); sub(/[[:space:]]*#.*/,"",v); v=trim(v)
+          if (k=="container") cur_c=v; else if (k=="protocol") cur_p=v; else if (k=="name") cur_n=v
+          # A dedent to sbx-level key (e.g. background:) ends the port list.
+          if (indent_of($0) <= sbx_ind + 2 && k != "container" && k != "protocol" && k != "name") { flush(); in_pp=0 }
+          next
+        }
+      }
+    }
+    END { if (in_be) flush() }
   ' "$spec"
 }
 
@@ -525,6 +584,7 @@ kit_spec_agent_context() {
 #   commands[phase=initFiles]       -> commands.initFiles[]  (command form)
 #   commands[phase=startup]         -> commands.startup[]
 #   agentContext                    -> agentContext            (identical)
+#   backend_extras.sbx.publishedPorts -> publishedPorts[]      (top-level, sbx-v2)
 #   backend_shortcuts.sbx           -> (none defined for the four kits; ignored)
 #
 # Usage: kit_translate_to_sbx NEUTRAL_KIT_DIR OUT_DIR
@@ -559,13 +619,18 @@ kit_translate_to_sbx() {
     [ -n "$display" ] && printf 'displayName: %s\n' "$(_kit_yaml_quote "$display")"
     [ -n "$desc" ] && printf 'description: %s\n' "$(_kit_yaml_quote "$desc")"
 
-    # caps.network.allow
+    # caps.network.allow. Route each host through _kit_yaml_quote: a neutral
+    # allow entry may legitimately contain a YAML-special character — most
+    # commonly a leading `*` for a wildcard subdomain (e.g. "*.npmjs.org"). Emit
+    # it bare and YAML reads the `*` as an ALIAS, producing an invalid sbx spec
+    # ("did not find expected alphabetic or numeric character"). Quoting keeps
+    # plain hostnames bare and single-quotes only the special ones.
     local hosts
     hosts=$(kit_spec_net_allow "$spec")
     if [ -n "$hosts" ]; then
       printf 'caps:\n  network:\n    allow:\n'
       printf '%s\n' "$hosts" | while IFS= read -r h; do
-        [ -n "$h" ] && printf '      - %s\n' "$h"
+        [ -n "$h" ] && printf '      - %s\n' "$(_kit_yaml_quote "$h")"
       done
     fi
 
@@ -577,6 +642,22 @@ kit_translate_to_sbx() {
       printf '%s\n' "$envrecs" | while IFS="$(printf '\t')" read -r ekey eval; do
         [ -n "$ekey" ] || continue
         printf '    %s: %s\n' "$ekey" "$(_kit_yaml_quote "$eval")"
+      done
+    fi
+
+    # backend_extras.sbx.publishedPorts -> sbx-v2 top-level publishedPorts. sbx
+    # maps each declared CONTAINER port to an ephemeral host loopback port at
+    # create time. Without this, an acq-applied kit that exposes a service is
+    # unreachable from the host until the user runs `acq ports --publish`.
+    local portrecs
+    portrecs=$(kit_spec_published_ports "$spec")
+    if [ -n "$portrecs" ]; then
+      printf 'publishedPorts:\n'
+      printf '%s\n' "$portrecs" | while IFS="$(printf '\t')" read -r pcont pproto pname; do
+        [ -n "$pcont" ] || continue
+        printf '  - container: %s\n' "$pcont"
+        [ -n "$pproto" ] && printf '    protocol: %s\n' "$pproto"
+        [ -n "$pname" ]  && printf '    name: %s\n' "$(_kit_yaml_quote "$pname")"
       done
     fi
   } > "$sbxspec"

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -555,11 +555,14 @@ acq_backend_provision() {
   # Fetch each built-in kit and gather its create-time contributions.
   local kitref kitdir
   local kits=("$USAI_KIT" "$PLAYBOOK_KIT" "$ZSCALER_KIT" "$GITSSHSIGN_KIT")
-  # Include any extra kits.
+  # Include any extra kits (env-supplied) and CLI-supplied --kit refs.
   if [ -n "${ACQ_EXTRA_KITS:-}" ]; then
     local _extras=()
     split_noglob _extras "$ACQ_EXTRA_KITS"
     kits+=("${_extras[@]}")
+  fi
+  if [ "${#ACQ_CLI_KITS[@]}" -gt 0 ]; then
+    kits+=("${ACQ_CLI_KITS[@]}")
   fi
 
   for kitref in "${kits[@]}"; do

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -189,6 +189,19 @@ export ACQ_EXTRA_KITS="./my-local-kit git+https://github.com/acme/kits.git#ref=<
 export ACQ_EXTRA_KIT_SOURCES="github.com/acme/"
 ```
 
+You can also apply an extra kit for a single `run`/`create` with `--kit`
+(repeatable), instead of the env var:
+
+```bash
+# One-off: apply a local kit dir (or a git+https ref)
+acq run opencode --kit ./my-local-kit .
+acq create opencode --kit ./kit-a --kit git+https://github.com/acme/kits.git#ref=<sha>&dir=some-kit /proj
+```
+
+`--kit` refs are translated by `acq` exactly like `ACQ_EXTRA_KITS` entries (a
+neutral `hybrid/v1` kit is converted to the active backend's format), so they
+work with any backend — they are **not** forwarded raw to the backend CLI.
+
 ---
 
 ## Exec timeout tuning

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -323,24 +323,29 @@ cleanup_stubs
 # pass through untranslated, so the ref appears in the sbx create line as a
 # `--kit <ref>` token pair; the point of these tests is WHERE it appears and that
 # the create positionals are clean.
+#
+# NOTE: the workspace positional MUST be a real, existing directory — acq's
+# pre-flight (#216) aborts create/run on a nonexistent path before it ever
+# reaches `sbx create`. Use a throwaway temp dir as the workspace.
+_kitproj=$(mktemp -d "${TMPDIR:-/tmp}/acq-kitproj.XXXXXX")
 make_stubs
-out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit /tmp/mykit /proj 2>/dev/null)
+out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit /tmp/mykit "$_kitproj" 2>/dev/null)
 log=$(cat "$CALLS")
 create_line=$(printf '%s\n' "$log" | grep '^sbx create')
 # The kit ref is present (folded into the kit list, emitted as a --kit flag).
 assert_contains "kit-flag: create folds --kit ref into kit list (#222)" "$create_line" "--kit /tmp/mykit"
 # The workspace positional survives.
-assert_contains "kit-flag: create keeps workspace positional (#222)" "$create_line" "/proj"
+assert_contains "kit-flag: create keeps workspace positional (#222)" "$create_line" "$_kitproj"
 # The kit ref must NOT trail as a raw positional after the workspace (i.e. the
-# create args are opencode + /proj only, with all --kit pairs among the leading
-# translated kit flags). Assert the ref does not appear immediately after /proj.
-assert_not_contains "kit-flag: --kit not left as trailing raw arg (#222)" "$create_line" "/proj --kit /tmp/mykit"
-assert_not_contains "kit-flag: no dangling ref after workspace (#222)" "$create_line" "/proj /tmp/mykit"
+# create args are opencode + <workspace> only, with all --kit pairs among the
+# leading translated kit flags). Assert the ref does not appear after the path.
+assert_not_contains "kit-flag: --kit not left as trailing raw arg (#222)" "$create_line" "$_kitproj --kit /tmp/mykit"
+assert_not_contains "kit-flag: no dangling ref after workspace (#222)" "$create_line" "$_kitproj /tmp/mykit"
 cleanup_stubs
 
 # --kit=<ref> (equals form) is also intercepted.
 make_stubs
-out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit=/tmp/eqkit /proj 2>/dev/null)
+out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit=/tmp/eqkit "$_kitproj" 2>/dev/null)
 log=$(cat "$CALLS")
 create_line=$(printf '%s\n' "$log" | grep '^sbx create')
 assert_contains "kit-flag: create folds --kit=<ref> form (#222)" "$create_line" "--kit /tmp/eqkit"
@@ -349,35 +354,35 @@ cleanup_stubs
 
 # Multiple --kit flags are all intercepted.
 make_stubs
-out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit /tmp/k1 --kit /tmp/k2 /proj 2>/dev/null)
+out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit /tmp/k1 --kit /tmp/k2 "$_kitproj" 2>/dev/null)
 log=$(cat "$CALLS")
 create_line=$(printf '%s\n' "$log" | grep '^sbx create')
 assert_contains "kit-flag: first repeated --kit folded (#222)" "$create_line" "--kit /tmp/k1"
 assert_contains "kit-flag: second repeated --kit folded (#222)" "$create_line" "--kit /tmp/k2"
-assert_contains "kit-flag: workspace still present with repeated --kit (#222)" "$create_line" "/proj"
+assert_contains "kit-flag: workspace still present with repeated --kit (#222)" "$create_line" "$_kitproj"
 cleanup_stubs
 
 # run form also intercepts --kit (routes through provision -> sbx create).
 make_stubs
-out=$(ACQ_BACKEND=sbx "$ACQ" run opencode --kit /tmp/runkit /proj 2>/dev/null)
+out=$(ACQ_BACKEND=sbx "$ACQ" run opencode --kit /tmp/runkit "$_kitproj" 2>/dev/null)
 log=$(cat "$CALLS")
 create_line=$(printf '%s\n' "$log" | grep '^sbx create')
 assert_contains "kit-flag: run folds --kit ref into kit list (#222)" "$create_line" "--kit /tmp/runkit"
-assert_not_contains "kit-flag: run --kit not left as trailing raw arg (#222)" "$create_line" "/proj --kit /tmp/runkit"
+assert_not_contains "kit-flag: run --kit not left as trailing raw arg (#222)" "$create_line" "$_kitproj --kit /tmp/runkit"
 cleanup_stubs
 
 # A `--kit` AFTER the `--` separator belongs to the AGENT, not acq: it MUST NOT
 # be hijacked into the kit list, and it MUST survive intact in the agent args.
 make_stubs
-out=$(ACQ_BACKEND=sbx "$ACQ" run opencode /proj -- --kit evil-agent-arg 2>/dev/null)
+out=$(ACQ_BACKEND=sbx "$ACQ" run opencode "$_kitproj" -- --kit evil-agent-arg 2>/dev/null)
 log=$(cat "$CALLS")
 create_line=$(printf '%s\n' "$log" | grep '^sbx create')
-run_line=$(printf '%s\n' "$log" | grep '^sbx run' || true)
 # acq must not fold the agent's --kit into the sandbox kit list.
 assert_not_contains "kit-flag: agent --kit after -- not hijacked (#222)" "$create_line" "--kit evil-agent-arg"
 # The agent's flag must be forwarded verbatim to the agent invocation.
 assert_contains "kit-flag: agent --kit after -- forwarded intact (#222)" "$log" "--kit evil-agent-arg"
 cleanup_stubs
+rm -rf "$_kitproj"
 
 # ===========================================================================
 # 4. qsbx deprecation notice

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -364,6 +364,19 @@ assert_contains "kit-flag: run folds --kit ref into kit list (#222)" "$create_li
 assert_not_contains "kit-flag: run --kit not left as trailing raw arg (#222)" "$create_line" "/proj --kit /tmp/runkit"
 cleanup_stubs
 
+# A `--kit` AFTER the `--` separator belongs to the AGENT, not acq: it MUST NOT
+# be hijacked into the kit list, and it MUST survive intact in the agent args.
+make_stubs
+out=$(ACQ_BACKEND=sbx "$ACQ" run opencode /proj -- --kit evil-agent-arg 2>/dev/null)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^sbx create')
+run_line=$(printf '%s\n' "$log" | grep '^sbx run' || true)
+# acq must not fold the agent's --kit into the sandbox kit list.
+assert_not_contains "kit-flag: agent --kit after -- not hijacked (#222)" "$create_line" "--kit evil-agent-arg"
+# The agent's flag must be forwarded verbatim to the agent invocation.
+assert_contains "kit-flag: agent --kit after -- forwarded intact (#222)" "$log" "--kit evil-agent-arg"
+cleanup_stubs
+
 # ===========================================================================
 # 4. qsbx deprecation notice
 # (Added to qsbx in §7 of the handoff)

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -315,6 +315,55 @@ log=$(cat "$CALLS")
 assert_contains "dispatch: unknown passthrough -> sbx" "$log" "sbx policy"
 cleanup_stubs
 
+# --kit interception (#222): a user-supplied `--kit <ref>` on run/create MUST be
+# folded into acq's translated kit list, NOT forwarded to the backend as a raw
+# flag+value trailing the create args. With ACQ_SBX_KIT_PASSTHROUGH=1 kit refs
+# pass through untranslated, so the ref appears in the sbx create line as a
+# `--kit <ref>` token pair; the point of these tests is WHERE it appears and that
+# the create positionals are clean.
+make_stubs
+out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit /tmp/mykit /proj 2>/dev/null)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^sbx create')
+# The kit ref is present (folded into the kit list, emitted as a --kit flag).
+assert_contains "kit-flag: create folds --kit ref into kit list (#222)" "$create_line" "--kit /tmp/mykit"
+# The workspace positional survives.
+assert_contains "kit-flag: create keeps workspace positional (#222)" "$create_line" "/proj"
+# The kit ref must NOT trail as a raw positional after the workspace (i.e. the
+# create args are opencode + /proj only, with all --kit pairs among the leading
+# translated kit flags). Assert the ref does not appear immediately after /proj.
+assert_not_contains "kit-flag: --kit not left as trailing raw arg (#222)" "$create_line" "/proj --kit /tmp/mykit"
+assert_not_contains "kit-flag: no dangling ref after workspace (#222)" "$create_line" "/proj /tmp/mykit"
+cleanup_stubs
+
+# --kit=<ref> (equals form) is also intercepted.
+make_stubs
+out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit=/tmp/eqkit /proj 2>/dev/null)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^sbx create')
+assert_contains "kit-flag: create folds --kit=<ref> form (#222)" "$create_line" "--kit /tmp/eqkit"
+assert_not_contains "kit-flag: --kit= not left as raw arg (#222)" "$create_line" "--kit=/tmp/eqkit"
+cleanup_stubs
+
+# Multiple --kit flags are all intercepted.
+make_stubs
+out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit /tmp/k1 --kit /tmp/k2 /proj 2>/dev/null)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^sbx create')
+assert_contains "kit-flag: first repeated --kit folded (#222)" "$create_line" "--kit /tmp/k1"
+assert_contains "kit-flag: second repeated --kit folded (#222)" "$create_line" "--kit /tmp/k2"
+assert_contains "kit-flag: workspace still present with repeated --kit (#222)" "$create_line" "/proj"
+cleanup_stubs
+
+# run form also intercepts --kit (routes through provision -> sbx create).
+make_stubs
+out=$(ACQ_BACKEND=sbx "$ACQ" run opencode --kit /tmp/runkit /proj 2>/dev/null)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^sbx create')
+assert_contains "kit-flag: run folds --kit ref into kit list (#222)" "$create_line" "--kit /tmp/runkit"
+assert_not_contains "kit-flag: run --kit not left as trailing raw arg (#222)" "$create_line" "/proj --kit /tmp/runkit"
+cleanup_stubs
+
 # ===========================================================================
 # 4. qsbx deprecation notice
 # (Added to qsbx in §7 of the handoff)

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1156,6 +1156,7 @@ caps:
   network:
     allow:
       - api.example.com:443
+      - "*.example.com"
 files:
   - path: /home/agent/tool/config
     mode: "0644"
@@ -1175,6 +1176,16 @@ commands:
     command:
       - node
       - /home/agent/tool/run.mjs
+backend_extras:
+  sbx:
+    publishedPorts:
+      - container: 3000
+        protocol: tcp
+        name: web-ui
+      - container: 4096
+        protocol: tcp
+        name: api
+    background: true
 SPEC
 tout="$STUBDIR/tout"
 ( . "${REPO_ROOT}/acq.backends/kit-translate.sh"
@@ -1185,6 +1196,18 @@ assert_contains "translate: carries caps.network.allow" "$sbxspec" "api.example.
 assert_contains "translate: has install phase" "$sbxspec" "install:"
 assert_contains "translate: has startup phase" "$sbxspec" "startup:"
 assert_contains "translate: preserves multi-line block body" "$sbxspec" "line two"
+# Regression (#220): a wildcard-subdomain allow host (leading `*`) MUST be
+# quoted, or YAML parses the `*` as an alias and the sbx spec is invalid. The
+# host:port form also contains a `:` and must survive. Assert both are quoted.
+assert_contains "translate: quotes wildcard allow host (#220)" "$sbxspec" "- '*.example.com'"
+assert_contains "translate: quotes host:port allow entry (#220)" "$sbxspec" "- 'api.example.com:443'"
+# Regression (#219): backend_extras.sbx.publishedPorts MUST be emitted as a
+# top-level sbx-v2 publishedPorts block so acq-applied kits get host port maps.
+assert_contains "translate: emits publishedPorts block (#219)" "$sbxspec" "publishedPorts:"
+assert_contains "translate: publishedPorts carries container 3000 (#219)" "$sbxspec" "- container: 3000"
+assert_contains "translate: publishedPorts carries container 4096 (#219)" "$sbxspec" "- container: 4096"
+assert_contains "translate: publishedPorts carries protocol (#219)" "$sbxspec" "protocol: tcp"
+assert_contains "translate: publishedPorts carries name (#219)" "$sbxspec" "name: web-ui"
 # The static payload file is copied under files/.
 if [ -f "$tout/files/home/tool/config" ]; then
   pass "translate: copies files/ payload tree"


### PR DESCRIPTION
Makes `acq run`/`acq create` intercept a user-supplied `--kit <ref>` (repeatable)
and route it through acq's neutral→backend translation, instead of forwarding it
raw to the backend — which broke neutral `hybrid/v1` kits. Refs are treated like
`ACQ_EXTRA_KITS` entries (translation + source allowlisting), for both backends.

Found running the openchamber kit locally: `acq run opencode --kit <dir> .`
reached `sbx create --kit` untranslated and sbx rejected the neutral spec.

### Testing
- `./scripts/test-acq` — 174 passed, 0 failed (adds --kit coverage: space/equals
  forms, repeated flags, run + create, ref not left as a trailing positional)
- Exercised end-to-end against a stub `sbx` with the real translator: the
  openchamber kit passed via `--kit` is translated to sbx-v2 and the create
  positionals stay clean; sandbox-name derivation and `-- AGENT_ARGS` unaffected.

### AI assistance
Authored with OpenCode agent assistance; disclosed per policy.

Closes #222
