### PR TITLE
feat(acq): scope GitHub token per-sandbox to mounted repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,15 @@ sbx policy allow network "api.gsa.usai.gov"
 sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
 
 # 4. Store GitHub token (for code access)
+#
+# RECOMMENDED — scope a token per-sandbox to just the repos you mount. On
+# `acq run`, if a sandbox has no repo-scoped token, acq detects the repos in
+# your workspace and walks you through creating a fine-grained token limited to
+# them. You can also do it explicitly:
+#   acq github-scope <sandbox-name> /path/to/your/project
+#
+# DEPRECATED (broad) — a single GLOBAL token grants EVERY sandbox access to ALL
+# your repositories. Kept for back-compat; prefer per-sandbox scoping above.
 # If you are using the GitHub CLI
 brew install gh # (if not already installed)
 gh auth login # (if not already authenticated to Github cli)
@@ -207,6 +216,16 @@ gh auth token | sbx secret set -g github --force
 # If you are using a personal access token (classic); you will be prompted
 sbx secret set -g github
 ```
+
+> [!WARNING]
+> `gh auth token` and classic PATs carry **account-wide** scopes (`repo`,
+> `workflow`, `delete_repo`, …). Stored globally (`-g`), that broad authority is
+> injected into **every** sandbox — an agent working on one project can act as
+> you on **all** your repositories. Prefer a per-sandbox fine-grained token
+> scoped to the mounted repos (see `acq github-scope` above and
+> [ADR-0013](docs/adr/0013-per-sandbox-github-token-downscoping.md)).
+> Fine-grained tokens can't contribute to public repos you're not a member of or
+> call the Checks API — fall back to the global token for those cases.
 
 **Check it worked:** run `sbx policy ls` — you should see `api.gsa.usai.gov`
 in the list of allowed network destinations.

--- a/acq
+++ b/acq
@@ -296,6 +296,12 @@ case "$subcommand" in
     [ -n "$local_name" ] || { echo "acq: could not determine sandbox name" >&2; exit 1; }
     acq_backend_provision "$local_name" "$@"
 
+    # Non-blocking USAi key advisory. `create` is detached and never attaches,
+    # so unlike `run` we don't gate on the key or offer interactive rotation —
+    # just warn if it's already invalid so a create-only user knows before they
+    # later `acq run`.
+    advise_valid_key "$local_name"
+
     # Nudge toward a per-sandbox scoped GitHub token, same as `run`. `create`
     # is detached (no attached agent), but the advisory is informational plus
     # an optional interactive prompt, so it applies equally here.

--- a/acq
+++ b/acq
@@ -290,10 +290,17 @@ case "$subcommand" in
     shift
     acq_backend_prepare
     # Pre-flight: validate the workspace path before provisioning (#issue).
-    preflight_workspace_path "$(workspace_path "$@")" || exit 1
+    ws=$(workspace_path "$@")
+    preflight_workspace_path "$ws" || exit 1
     local_name=$(derive_name "$@") || exit 1
     [ -n "$local_name" ] || { echo "acq: could not determine sandbox name" >&2; exit 1; }
     acq_backend_provision "$local_name" "$@"
+
+    # Nudge toward a per-sandbox scoped GitHub token, same as `run`. `create`
+    # is detached (no attached agent), but the advisory is informational plus
+    # an optional interactive prompt, so it applies equally here.
+    [ -n "$ws" ] || ws="$PWD"
+    advise_github_scope "$local_name" "$ws"
     ;;
 
   run)

--- a/acq
+++ b/acq
@@ -16,6 +16,7 @@
 #   acq cp SRC DST                                # copy in/out
 #   acq ports NAME [--publish ...]                # list/publish ports
 #   acq secret set SERVICE [...]                  # set a secret (see sbx.sh)
+#   acq github-scope SANDBOX [PATH]               # scope a GitHub token per-sandbox
 #   acq usai-rotate-api-key                       # rotate the USAi key
 #   acq version                                   # version + backend info
 #   acq doctor                                    # backend health + config
@@ -343,6 +344,7 @@ case "$subcommand" in
 
       [ -n "$ws" ] || ws="$PWD"
       warn_if_no_git_identity "$ws"
+      advise_github_scope "$local_name" "$ws"
 
       if [ "${#agent_args[@]}" -gt 0 ]; then
         acq_backend_attach "$local_name" -- "${agent_args[@]}"
@@ -457,6 +459,17 @@ SECRETUSAGE
     esac
     ;;
 
+  github-scope)
+    # Guide the user through minting a fine-grained PAT scoped to the workspace's
+    # repos and store it sandbox-scoped (ADR-0013).
+    shift
+    acq_backend_prepare
+    gs_sandbox="${1:-}"
+    [ -n "$gs_sandbox" ] || { echo "acq: github-scope: missing sandbox name" >&2; echo "     usage: acq github-scope SANDBOX [WORKSPACE_PATH]" >&2; exit 1; }
+    gs_ws="${2:-$PWD}"
+    github_scope_sandbox "$gs_sandbox" "$gs_ws"
+    ;;
+
   "")
     # No subcommand: print usage.
     cat >&2 <<'USAGE'
@@ -475,6 +488,7 @@ Subcommands:
   cp SRC DST                 Copy files in/out (NAME:path syntax)
   ports NAME [--publish ...]  List/publish ports
   secret set SERVICE [...]   Set a secret (--host/--env for custom)
+  github-scope SANDBOX [PATH] Scope a GitHub token to the workspace's repos
   usai-rotate-api-key        Rotate the USAi API key
   version                    Show acq version + backend info
   doctor                     Backend health check + write default config

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -738,6 +738,30 @@ preflight_workspace_path() {
 
 # Validate the sandbox's USAi key and walk the user through rotating it if
 # needed. Best-effort: warn and continue if we cannot run the check.
+# advise_valid_key NAME — non-blocking USAi key advisory for `acq create`.
+# Unlike ensure_valid_key (which gates attach and offers interactive rotation),
+# this only WARNS if the key isn't valid, then returns 0 regardless. `create`
+# is detached and never attaches, so there is nothing to gate; the point is to
+# give a create-only user a heads-up that their key is stale before they later
+# `acq run`. Silent on a healthy key or an inconclusive check (empty status).
+advise_valid_key() {
+  local name="$1"
+  local status
+  status=$(check_key "$name")
+
+  # 200 = healthy; empty = could not validate (network/tooling) — stay quiet in
+  # both cases to avoid noise. Only speak up on a definitive non-200.
+  [ "$status" = "200" ] && return 0
+  [ -z "$status" ] && return 0
+
+  echo "acq: note — your USAi API key looks invalid or expired (HTTP $status)." >&2
+  echo "      USAi keys expire every 7 days. This sandbox was created, but the" >&2
+  echo "      key must be valid before an agent can use it." >&2
+  echo "      To rotate: acq usai-rotate-api-key   (or re-run via 'acq run', which" >&2
+  echo "      validates and offers to rotate before attaching)." >&2
+  return 0
+}
+
 ensure_valid_key() {
   local name="$1"
   shift

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -494,6 +494,227 @@ warn_if_no_git_identity() {
   echo "      The sandbox home is isolated, so git identity is set per-repo." >&2
 }
 
+# ---------------------------------------------------------------------------
+# GitHub token down-scoping (ADR-0013)
+# ---------------------------------------------------------------------------
+# The global `sbx secret set -g github` path injects the user's broad gh token
+# into EVERY sandbox. These helpers instead detect the GitHub repos actually
+# present in the mounted workspace and guide the user to a fine-grained PAT
+# scoped to just those repos, stored sandbox-scoped (acq.<sandbox>.github).
+# See ADR-0013 for why this is guided (no API mints a fine-grained PAT) and why
+# the alternatives (token/scoped, App tokens, Jentic, firewall) were not used.
+
+# _acq_parse_github_nwo URL -> "owner/repo" on STDOUT (empty if not github.com).
+# Handles https://github.com/O/R(.git), git@github.com:O/R(.git),
+# ssh://git@github.com/O/R(.git). Pure string work — no network.
+_acq_parse_github_nwo() {
+  local url="$1" rest=""
+  case "$url" in
+    https://github.com/*|http://github.com/*) rest="${url#*github.com/}" ;;
+    git@github.com:*)                         rest="${url#git@github.com:}" ;;
+    ssh://git@github.com/*)                   rest="${url#ssh://git@github.com/}" ;;
+     git://github.com/*)                       rest="${url#git://github.com/}" ;;
+    *) return 0 ;;
+  esac
+  rest="${rest%.git}"        # strip trailing .git
+  rest="${rest%/}"           # strip trailing slash
+  # Keep only owner/repo (drop any deeper path), require exactly two segments.
+  local owner="${rest%%/*}" repo="${rest#*/}"
+  repo="${repo%%/*}"
+  [ -n "$owner" ] && [ -n "$repo" ] || return 0
+  printf '%s/%s\n' "$owner" "$repo"
+}
+
+# detect_workspace_repos PATH -> newline-separated deduped "owner/repo" list on
+# STDOUT for every github.com remote found. Mirrors warn_if_no_git_identity's
+# capped, symlink-safe classification: the path may itself be a repo, or a
+# parent whose depth-1 children are repos. Reads each repo's remote.origin.url
+# (falls back to the first configured remote). No network, no side effects.
+detect_workspace_repos() {
+  local path="${1:-}"
+  command -v git >/dev/null 2>&1 || return 0
+  [ -n "$path" ] && [ -d "$path" ] || return 0
+
+  local dirs=() d
+  if git -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    dirs=("$path")
+  else
+    local scanned=0
+    while IFS= read -r d; do
+      case "$(basename "$d")" in
+        node_modules|.venv|venv|vendor|target|dist|build) continue ;;
+      esac
+      scanned=$((scanned + 1))
+      [ "$scanned" -gt 200 ] && break
+      [ -e "$d/.git" ] && dirs+=("$d")
+    done < <(find "$path" -maxdepth 1 -mindepth 1 -type d ! -type l 2>/dev/null)
+  fi
+
+  local url nwo seen="" out=""
+  for d in ${dirs[@]+"${dirs[@]}"}; do
+    url=$(git -C "$d" config --get remote.origin.url 2>/dev/null || true)
+    if [ -z "$url" ]; then
+      url=$(git -C "$d" config --get-regexp '^remote\..*\.url$' 2>/dev/null \
+        | head -n1 | cut -d' ' -f2- || true)
+    fi
+    [ -n "$url" ] || continue
+    nwo=$(_acq_parse_github_nwo "$url") || true
+    [ -n "$nwo" ] || continue
+    case "$seen" in *"|$nwo|"*) continue ;; esac
+    seen="$seen|$nwo|"
+    out="$out$nwo
+"
+  done
+  printf '%s' "$out"
+}
+
+# URL-encode a string for a query parameter (RFC 3986 unreserved kept as-is).
+_acq_urlencode() {
+  local s="$1" i c out=""
+  for ((i = 0; i < ${#s}; i++)); do
+    c="${s:i:1}"
+    case "$c" in
+      [a-zA-Z0-9.~_-]) out="$out$c" ;;
+      *) out="$out$(printf '%%%02X' "'$c")" ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
+# Build a pre-filled fine-grained-PAT creation URL for one owner. Selects the
+# minimal default permissions for the normal agent loop — code, PRs, and issues
+# (write implies read; metadata:read is always included by GitHub). The user
+# still picks the specific repositories in the form (fine-grained PATs are
+# single-owner).
+# Args: OWNER SANDBOX_NAME
+_acq_github_pat_url() {
+  local owner="$1" sandbox="$2" name
+  name=$(_acq_urlencode "acq-${sandbox}")
+  printf 'https://github.com/settings/personal-access-tokens/new?name=%s&target_name=%s&expires_in=30&contents=write&pull_requests=write&issues=write\n' \
+    "$name" "$(_acq_urlencode "$owner")"
+}
+
+# github_scope_sandbox SANDBOX WORKSPACE — guide the user through minting a
+# fine-grained PAT scoped to the workspace's repos and store it sandbox-scoped.
+# Warn-not-block: returns 0 even if the user declines. Never places the token in
+# argv (delegates to acq_secret_set_interactive via the backend secret path).
+github_scope_sandbox() {
+  local sandbox="$1" ws="${2:-}"
+  local repos owners="" nwo owner
+
+  repos=$(detect_workspace_repos "$ws")
+  if [ -z "$repos" ]; then
+    echo "acq: no GitHub repositories detected in the workspace; nothing to scope." >&2
+    return 0
+  fi
+
+  # Distinct owners.
+  while IFS= read -r nwo; do
+    [ -n "$nwo" ] || continue
+    owner="${nwo%%/*}"
+    case "$owners" in *"|$owner|"*) ;; *) owners="$owners|$owner|" ;; esac
+  done <<EOF
+$repos
+EOF
+
+  echo "acq: scoping a GitHub token for sandbox '$sandbox'." >&2
+  echo "" >&2
+  echo "      GitHub has no API to mint a fine-grained PAT, so create it in the" >&2
+  echo "      browser. For EACH owner below, open the pre-filled link, select" >&2
+  echo "      'Only select repositories' and choose the repo(s) listed below," >&2
+  echo "      then generate the token and paste it back here." >&2
+  echo "      Default permissions: Contents=Read/Write, Pull requests=Read/Write," >&2
+  echo "      Issues=Read/Write (widen/narrow in the form as needed)." >&2
+
+  local o
+  local _oldifs="$IFS"; IFS='|'
+  # shellcheck disable=SC2086
+  set -- $owners
+  IFS="$_oldifs"
+  for o in "$@"; do
+    [ -n "$o" ] || continue
+    echo "" >&2
+    echo "      Owner '$o' — open:" >&2
+    printf '        %s\n' "$(_acq_github_pat_url "$o" "$sandbox")" >&2
+  done
+
+  echo "" >&2
+  echo "      Scope the token to just these repositories:" >&2
+  while IFS= read -r nwo; do [ -n "$nwo" ] && printf '        %s\n' "$nwo" >&2; done <<EOF
+$repos
+EOF
+
+  echo "" >&2
+  echo "      When you have a token, paste it at the prompt (input hidden)." >&2
+  echo "      To skip for now, press Enter on an empty line." >&2
+
+  # Store sandbox-scoped via the backend secret path (feeds the sbx proxy too).
+  # acq_backend_secret_set reads the value from the TTY (never argv). An empty
+  # entry aborts cleanly (warn-not-block).
+  if command -v acq_backend_secret_set >/dev/null 2>&1; then
+    acq_backend_secret_set "$sandbox" github || {
+      echo "acq: github scoping skipped or failed; continuing (you can re-run later" >&2
+      echo "      with: acq github-scope $sandbox $ws)." >&2
+      return 0
+    }
+  else
+    echo "acq: internal error: backend secret path not loaded; cannot store token." >&2
+    return 0
+  fi
+  echo "acq: stored a repo-scoped GitHub token for sandbox '$sandbox'." >&2
+  return 0
+}
+
+# advise_github_scope SANDBOX WORKSPACE — on acq run, nudge toward a per-sandbox
+# scoped GitHub token. Fires when the workspace has GitHub repos AND no
+# sandbox-scoped github secret exists yet (regardless of whether a broad global
+# one exists). Warn-not-block; interactive TTY gets a [continue/scope now]
+# prompt (default: continue). No-op in CI / non-TTY beyond printing the advisory.
+advise_github_scope() {
+  local sandbox="${1:-}" ws="${2:-}"
+  [ -n "$sandbox" ] || return 0
+
+  # Already scoped for this sandbox? Nothing to do.
+  if command -v acq_secret_get >/dev/null 2>&1 \
+      && acq_secret_get "$(_acq_secret_key github "$sandbox")" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local repos
+  repos=$(detect_workspace_repos "$ws")
+  [ -n "$repos" ] || return 0   # no GitHub repos → nothing to scope
+
+  local has_global="no"
+  if command -v acq_secret_get >/dev/null 2>&1 \
+      && acq_secret_get "$(_acq_secret_key github)" >/dev/null 2>&1; then
+    has_global="yes"
+  fi
+
+  echo "acq: note — this sandbox has no repo-scoped GitHub token." >&2
+  if [ "$has_global" = "yes" ]; then
+    echo "      A GLOBAL GitHub token is set; it grants this sandbox access to ALL" >&2
+    echo "      your repositories — broader than the repos mounted here." >&2
+  else
+    echo "      No GitHub token is set for this sandbox." >&2
+  fi
+  echo "      For least privilege, scope a token to just the mounted repo(s)." >&2
+
+  # Non-interactive (CI, piped): advise and continue.
+  if [ ! -t 0 ]; then
+    echo "      To scope it later: acq github-scope $sandbox $ws" >&2
+    return 0
+  fi
+
+  local ans=""
+  printf 'acq: scope a GitHub token for this sandbox now? [y/N] ' >&2
+  read -r ans 2>/dev/null || ans=""
+  case "$ans" in
+    y|Y|yes|YES) github_scope_sandbox "$sandbox" "$ws" ;;
+    *) echo "acq: continuing without scoping (run 'acq github-scope $sandbox $ws' anytime)." >&2 ;;
+  esac
+  return 0
+}
+
 # Pre-flight: validate the workspace path BEFORE provisioning. Fails fast on a
 # file or a missing path (with an actionable mkdir hint) rather than passing a
 # bad path to `sbx create` and surfacing an opaque backend error. Never creates

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -750,18 +750,37 @@ acq_backend_secret_set() {
 # _acq_sbx_secret_exists SCOPE_FLAG SCOPE_NAME SERVICE ENV_VAR -> 0 if present
 # ---------------------------------------------------------------------------
 # Best-effort existence check against `sbx secret ls`. Built-in services show
-# their service name; custom secrets show the env var name. Returns 0 (exists)
-# only on a confident match; on any listing failure, returns 1 (treat as absent)
-# so we don't block the user — sbx will still error clearly if it does exist.
+# their service name; custom secrets show the env var name. The match MUST be
+# constrained to the requested SCOPE — sbx secrets are scoped per-sandbox (plus
+# a global scope), so a `github` secret in sandbox A must NOT be reported as
+# "already exists" when we're setting `github` for sandbox B, or for the global
+# scope. `sbx secret ls` prints one row per secret with a leading SCOPE column
+# (the sandbox name, or `(global)` for global secrets). We match the row whose
+# scope equals the requested scope AND whose name/env column equals the needle.
+# Returns 0 (exists) only on a confident, scope-matched hit; on any listing
+# failure, returns 1 (treat as absent) so we don't block the user — sbx will
+# still error clearly if it does in fact exist.
 _acq_sbx_secret_exists() {
   local scope_flag="$1" scope_name="$2" service="$3" env_var="$4"
-  local listing needle
+  local listing needle want_scope
   listing=$(sbx secret ls 2>/dev/null) || return 1
   if [ -n "$env_var" ]; then needle="$env_var"; else needle="$service"; fi
-  case "$listing" in
-    *"$needle"*) return 0 ;;
-    *) return 1 ;;
-  esac
+
+  # The scope token as it appears in the SCOPE column: global secrets render as
+  # "(global)"; sandbox-scoped secrets render as the sandbox name.
+  if [ -n "$scope_flag" ]; then want_scope="(global)"; else want_scope="$scope_name"; fi
+
+  # Scan each row: field 1 is the scope, and the needle (service or env var)
+  # must appear as a whole field on that same row. Header/blank/section lines
+  # (e.g. "SCOPE ...", "CUSTOM SECRETS") don't match a real scope+needle pair,
+  # so they're naturally skipped.
+  printf '%s\n' "$listing" | awk -v scope="$want_scope" -v needle="$needle" '
+    {
+      if ($1 != scope) next
+      for (i = 2; i <= NF; i++) if ($i == needle) { found = 1; exit }
+    }
+    END { exit(found ? 0 : 1) }
+  '
 }
 
 # ---------------------------------------------------------------------------

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -129,6 +129,23 @@ sbx secret set -g anthropic
 
 ### Store GitHub Token (for code access)
 
+> **Prefer a per-sandbox scoped token.** A global GitHub token (below) is
+> injected into *every* sandbox, giving each one access to *all* your
+> repositories. For least privilege, let `acq` scope a **fine-grained** token to
+> just the repos in your workspace — on `acq run` it detects the mounted repos
+> and guides you, or run it explicitly:
+>
+> ```bash
+> acq github-scope <sandbox-name> /path/to/your/project
+> ```
+>
+> See [ADR-0013](adr/0013-per-sandbox-github-token-downscoping.md) for the
+> rationale and the alternatives considered. Fine-grained tokens can't
+> contribute to public repos you're not a member of or call the Checks API —
+> use the global token below for those cases.
+
+**Deprecated (broad, global) path** — kept for back-compat:
+
 ```bash
 # Recommended: pipe from gh cli (never touches shell history)
 brew install gh # (if not already installed)

--- a/docs/adr/0012-backend-neutral-key-rotation.md
+++ b/docs/adr/0012-backend-neutral-key-rotation.md
@@ -29,6 +29,13 @@ invoke it unconditionally, *after* the backend has already been resolved:
 - `ensure_valid_key` (`acq.backends/common.sh`) — runs on `acq run` for **every**
   backend when the pre-attach key check fails
 
+> **Note (non-rotation path):** `acq create` calls a sibling, `advise_valid_key`
+> (`common.sh`), which only *warns* on a definitively invalid key and never
+> rotates. Because `create` is detached and never attaches, there is nothing to
+> gate; it does not invoke `acq_backend_rotate_key` and so does not touch the
+> rotation mechanism this ADR governs. Interactive rotation remains exclusive to
+> the `acq run` / attach path via `ensure_valid_key`.
+
 A user on the `msb` backend who runs `acq run` with an expired key (USAi keys
 expire every 7 days) is therefore funneled into `sbx` commands. If `sbx` is not
 installed — or has no available seats — rotation fails and blocks the user from

--- a/docs/adr/0013-per-sandbox-github-token-downscoping.md
+++ b/docs/adr/0013-per-sandbox-github-token-downscoping.md
@@ -1,0 +1,169 @@
+---
+title: "Constrain the GitHub Token Per-Sandbox to the Mounted Repositories"
+status: accepted
+date: 2026-07-24
+decision_makers: ["Bret Mogilefsky"]
+category: security
+nist_controls: ["AC-3", "AC-6", "IA-5", "SC-12", "AU-2", "CM-7"]
+impact_level: low
+ato_relevance: yes-process
+risk_treatment: mitigate
+supersedes: []
+---
+
+# ADR-0013: Constrain the GitHub Token Per-Sandbox to the Mounted Repositories
+
+## Context and Problem Statement
+
+The quickstart's "Configure secrets and policy" step (README Step 3,
+`docs/QUICKSTART_SBX.md`) tells the user to store their GitHub credential **once,
+globally**:
+
+```bash
+gh auth token | sbx secret set -g github --force
+```
+
+`gh auth token` emits the user's `gh` CLI OAuth token, which carries broad
+account-wide scopes (typically `repo`, `workflow`, `delete_repo`, `gist`,
+`admin:ssh_signing_key`, `read:org`, …). Stored `-g` (global), the sbx proxy
+injects it into **every** sandbox for **every** project. The result: an agent
+working on project A can act as the user on **all** of the user's GitHub
+repositories — read private code, push, delete repos — none of which is in the
+sandbox's mounted workspace.
+
+This violates least privilege (AC-6). The sandbox's filesystem is already
+constrained to the mounted paths (ADR-0001); its GitHub authority should be
+similarly constrained to the repositories those paths actually contain.
+
+We want each sandbox to hold a GitHub credential scoped to only the repos in its
+mounted workspace, derived from the `.git` remotes found there.
+
+## Decision
+
+`acq` **detects the GitHub repositories in the mounted workspace** (by parsing
+`remote.origin.url` of each `.git` directory, reusing the capped, symlink-safe
+scan already in `warn_if_no_git_identity`) and, on `acq run`, **guides the user
+to mint a GitHub fine-grained personal access token (PAT) scoped to exactly
+those repositories**, stored **sandbox-scoped** (`acq.<sandbox>.github`) rather
+than globally.
+
+Concretely:
+
+- A new `github_scope_sandbox` flow builds a **pre-filled fine-grained-PAT
+  creation URL** (`https://github.com/settings/personal-access-tokens/new?…`)
+  with `target_name=<owner>`, a name derived from the sandbox, `expires_in=30`,
+  and the minimal default permissions `contents=write` + `pull_requests=write` +
+  `issues=write` (`metadata:read` and the read levels are implied). The user
+  clicks it, selects **only** the named repositories, generates the token, and
+  pastes it back.
+- The token is read from the TTY (never argv), stored in the acq-neutral secret
+  store keyed `acq.<sandbox>.github`, and fed to the sbx proxy as the `github`
+  built-in for that sandbox — the same injection path as a global github secret,
+  the agent never sees the value.
+- On `acq run`, when the workspace has GitHub repos **and no sandbox-scoped
+  github secret exists** (whether or not a broad global one exists), `acq` prints
+  an advisory and, on an interactive TTY, offers `[continue / scope now]`
+  (default: continue). This follows the repo's **warn-not-block** convention
+  (matching `warn_if_no_ssh_signing_key` / `warn_if_no_git_identity`) — it never
+  blocks a run and is a no-op in CI / non-TTY.
+- The global `sbx secret set -g github` path is **deprecated in the docs** (kept
+  working for back-compat), and the per-sandbox scoped flow becomes the
+  documented default.
+
+Multiple distinct owners in one workspace are handled by guiding one token per
+owner (fine-grained PATs are single-owner by design).
+
+## Considered Alternatives (rejected)
+
+Investigation (`docs/explorations/downscoping-github-credentials-for-local-agents.md`)
+established that most "automatic downscoping" paths are not available to a local
+wrapper that only holds the user's `gh` token:
+
+1. **`POST /applications/{client_id}/token/scoped`** ("create a scoped access
+   token") — *can* downscope a user-to-server OAuth token to specific
+   repos/permissions, **but requires OAuth-App HTTP Basic auth
+   (`client_id:client_secret`)**. A bare `gh` user token as bearer returns
+   `404` (verified). `acq` does not hold `gh`'s client secret, so this is not
+   usable. **Rejected.**
+
+2. **Downscope the `gh` token directly** — there is no `gh` subcommand or
+   supported API to narrow an existing user token. **Rejected.**
+
+3. **Programmatically mint a fine-grained PAT** — there is **no API and no `gh`
+   command** to create a fine-grained (or classic) PAT; creation is web-UI only.
+   The org endpoints only approve/deny/list/revoke. We therefore **guide** the
+   web-UI creation (with a pre-filled URL) rather than automate it. This is the
+   accepted approach; the "no API" limitation is why it is guided, not silent.
+
+4. **GitHub App installation token** (`POST /app/installations/{id}/access_tokens`
+   with `repositories`/`permissions`) — the *only* fully-automatable per-repo
+   path (JWT auth, 1-hour TTL, no client secret, no web UI). Mature local tooling
+   exists (`Link-/gh-token`, `AmadeusITGroup/gh-app-auth`,
+   `bdellegrazie/git-credential-github-app`). **Deferred, not rejected:** it
+   requires a registered GitHub App, the App installed on the GSA-TTS account,
+   and `acq` holding the App's private key — an org-admin dependency that would
+   block shipping. This is the recommended future evolution once such an App
+   exists; at that point the same `github_scope_sandbox` seam can mint an
+   installation token automatically instead of guiding a PAT.
+
+5. **Jentic One credential broker** — brokers **REST/HTTP** calls with
+   per-operation `allow`/`deny` below the token's own scopes, and the agent never
+   holds the upstream token. But it **cannot broker git-over-HTTPS**
+   (`git clone`/`fetch`/`push` use the smart-HTTP protocol, which is not
+   OpenAPI-describable and not registrable), must run **outside** the agent's
+   sandbox to preserve its trust boundary, and is **Public Beta** ("not
+   recommended for production"). It would only constrain `gh api`-style REST
+   actions, not the core git loop. **Out of scope.**
+
+6. **Network egress firewall** (Anthropic Claude Code's `init-firewall.sh`
+   pattern; and this repo's existing `sbx policy allow network`) — constrains
+   **where** traffic goes (allowlist GitHub + USAi, drop the rest), which is a
+   valuable exfiltration control, but **cannot** constrain **which repository**
+   an authenticated GitHub request touches. It does not solve this problem.
+   **Out of scope for this ADR** (the SBX/egress boundary remains the complementary
+   control per ADR-0001).
+
+## Consequences
+
+- **Least privilege (AC-6):** a compromised or prompt-injected agent in one
+  sandbox can only reach the repositories that sandbox mounts, with the
+  permissions the user granted — not the user's entire GitHub account.
+- **One manual step per new sandbox:** minting a fine-grained PAT is web-UI only,
+  so scoping a new sandbox requires a browser round-trip. The pre-filled URL and
+  named repo list minimize the friction; the flow is skippable (warn-not-block).
+- **Fine-grained PAT limitations apply:** fine-grained PATs cannot contribute to
+  public repos where the user is not a member, cannot be used by outside
+  collaborators, cannot access multiple orgs at once, and cannot call the Checks
+  API. The docs note these so users know when to fall back to the (broader)
+  global token.
+- **msb backend:** `msb` does not bind the `github` secret at all
+  (`msb.sh` — upstream microsandbox git-substitution limitation, ADR-0011). The
+  scoped token is still stored in the acq-neutral store on msb, and the flow
+  notes that msb does not inject it. No behavior regression for msb.
+- **Deprecation, not removal:** the global path keeps working, so existing setups
+  are not broken; new guidance steers to per-sandbox scoping.
+- **Audit (AU-2):** scoping is per-sandbox and named, so which credential a
+  sandbox holds is discoverable via the acq secret store keys.
+
+## Validation
+
+- Offline unit coverage in `scripts/test-acq`: remote-URL → `owner/repo` parsing
+  (https + ssh + `.git` suffix), pre-filled-URL construction, multi-owner
+  handling, and that the advisory fires exactly when
+  (workspace has repos) ∧ (no sandbox-scoped github secret) — independent of
+  whether a global secret exists.
+- Live end-to-end (minting a real PAT, injecting it, and confirming a
+  scoped push succeeds while an out-of-scope repo is denied) is a manual
+  verification step recorded in the PR, since it requires a real GitHub account
+  and browser.
+
+## Links
+
+- Exploration: `docs/explorations/downscoping-github-credentials-for-local-agents.md`
+- Related: ADR-0001 (SBX isolation is the complementary boundary),
+  ADR-0005 (github token needed for the private playbook clone),
+  ADR-0011 (msb does not bind the github secret),
+  ADR-0012 (backend-neutral secret handling)
+- GitHub docs: "Managing your personal access tokens" (fine-grained PAT URL
+  pre-fill parameters), "Create a scoped access token" (requires client secret),
+  "Create an installation access token for an app".

--- a/docs/adr/0013-per-sandbox-github-token-downscoping.md
+++ b/docs/adr/0013-per-sandbox-github-token-downscoping.md
@@ -42,10 +42,10 @@ mounted workspace, derived from the `.git` remotes found there.
 
 `acq` **detects the GitHub repositories in the mounted workspace** (by parsing
 `remote.origin.url` of each `.git` directory, reusing the capped, symlink-safe
-scan already in `warn_if_no_git_identity`) and, on `acq run`, **guides the user
-to mint a GitHub fine-grained personal access token (PAT) scoped to exactly
-those repositories**, stored **sandbox-scoped** (`acq.<sandbox>.github`) rather
-than globally.
+scan already in `warn_if_no_git_identity`) and, on `acq run` and `acq create`,
+**guides the user to mint a GitHub fine-grained personal access token (PAT)
+scoped to exactly those repositories**, stored **sandbox-scoped**
+(`acq.<sandbox>.github`) rather than globally.
 
 Concretely:
 
@@ -60,10 +60,11 @@ Concretely:
   store keyed `acq.<sandbox>.github`, and fed to the sbx proxy as the `github`
   built-in for that sandbox — the same injection path as a global github secret,
   the agent never sees the value.
-- On `acq run`, when the workspace has GitHub repos **and no sandbox-scoped
-  github secret exists** (whether or not a broad global one exists), `acq` prints
-  an advisory and, on an interactive TTY, offers `[continue / scope now]`
-  (default: continue). This follows the repo's **warn-not-block** convention
+- On `acq run` and `acq create`, when the workspace has GitHub repos **and no
+  sandbox-scoped github secret exists** (whether or not a broad global one
+  exists), `acq` prints an advisory and, on an interactive TTY, offers
+  `[continue / scope now]` (default: continue). This follows the repo's
+  **warn-not-block** convention
   (matching `warn_if_no_ssh_signing_key` / `warn_if_no_git_identity`) — it never
   blocks a run and is a no-op in CI / non-TTY.
 - The global `sbx secret set -g github` path is **deprecated in the docs** (kept

--- a/docs/explorations/downscoping-github-credentials-for-local-agents.md
+++ b/docs/explorations/downscoping-github-credentials-for-local-agents.md
@@ -1,0 +1,190 @@
+# Down-scoping GitHub credentials for local AI coding agents / sandboxes
+
+**Status:** research note (informational — not a decision)
+**Question:** How do people automate *down-scoping* of GitHub credentials for a **local** wrapper (like `sbx`/devcontainer) that mounts local directories and injects a token, so an agent can only act on the repositories in the mounted workspace rather than the developer's whole GitHub account? (Not GitHub Actions CI — that's the easy case.)
+
+> Scope note: This is a survey of *primary sources* (GitHub REST docs, GitHub CLI source, tool READMEs). All claims below are cited. Anything not directly stated in a source is flagged as inference.
+
+---
+
+## TL;DR
+
+- The only GitHub mechanism that natively means **"a short-lived token scoped to a specific set of repos with specific permissions"** and can be minted **fully non-interactively from a local CLI** is a **GitHub App installation access token** (`POST /app/installations/{id}/access_tokens` with `repositories`/`permissions` in the body). It requires a **GitHub App + private key + the app installed** on the target account, but **no client secret and no web UI at token-mint time**. TTL is **1 hour**. This is the mainstream approach and there is mature local tooling for it (git credential helpers, `gh` extensions).
+- `POST /applications/{client_id}/token/scoped` ("Create a scoped access token") **can** down-scope a user-to-server OAuth token to specific repos/permissions, **but it requires OAuth-App/GitHub-App HTTP Basic auth (`client_id:client_secret`)** — the client secret. A bare user OAuth token as bearer returns **404** (which is the documented behavior for invalid credentials on the `/applications/{client_id}/...` family). So it is **not** usable by a local wrapper that only holds the `gh` user token.
+- `gh`'s own token comes from GitHub's **public OAuth App** (`client_id 178c6fc778ccc68e1d6a`). The client secret **is embedded in the open-source binary**, but using it to down-scope `gh`'s token is not a supported/first-class path and is fragile (see caveats). There is **no `gh` command** that down-scopes its own token.
+- **Fine-grained PATs cannot be created programmatically.** There is **no REST/GraphQL/`gh` endpoint to create a fine-grained (or classic) PAT**; creation is strictly the web UI (`github.com/settings/personal-access-tokens/new`). Org-level PAT endpoints only *approve/deny/list/revoke* tokens users created — they do not mint them.
+
+---
+
+## 1. `POST /applications/{client_id}/token/scoped` — "Create a scoped access token"
+
+**What it is (from the docs):** "Use a non-scoped user access token to create a repository-scoped and/or permission-scoped user access token. You can specify which repositories the token can access and which permissions are granted to the token. Invalid tokens will return 404 NOT FOUND." Body: `access_token` (required), `target`/`target_id`, `repositories`/`repository_ids`, `permissions{…}`.
+Source: <https://docs.github.com/en/rest/apps/oauth-applications#create-a-scoped-access-token>
+
+**Auth requirement (the key constraint):** The whole `/applications/{client_id}/...` endpoint family is authenticated with **HTTP Basic auth using the app's `client_id` as username and `client_secret` as password** — not the user token as bearer. GitHub's authentication guide states this explicitly: *"Some REST API endpoints for GitHub Apps and OAuth apps require you to use basic authentication… You will use the app's client ID as the username and the app's client secret as the password,"* with the example `curl … --user "YOUR_CLIENT_ID:YOUR_CLIENT_SECRET" … /applications/YOUR_CLIENT_ID/token`.
+Source: <https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api#using-basic-authentication>
+
+**Why a bare `gh` user token returns 404:** The same guide says a request with insufficient/invalid credentials to these endpoints returns **404 Not Found** (the endpoints deliberately return 404 for invalid tokens; see the "Check a token" endpoint note "Invalid tokens will return 404 NOT FOUND" and the "Failed login limit" section).
+Sources:
+- <https://docs.github.com/en/rest/apps/oauth-applications#check-a-token> (404 for invalid)
+- <https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api#failed-login-limit>
+
+**What it can do:** Yes — it down-scopes a **user-to-server** token (i.e. a GitHub-App user token, `ghu_`, or an OAuth-App token, `gho_`) to a subset of repos and a subset of permissions the user+app already hold. The response's `installation` object echoes the scoped `permissions` and `repository_selection`. This is genuinely a "downscope this user token" primitive.
+Source (response schema with `Scoped Installation`): <https://docs.github.com/en/rest/apps/oauth-applications#check-a-token>
+
+**Real-world constraints:**
+- **Requires the client secret** (Basic auth). A local sandbox wrapper that only injects the developer's `gh`/user token cannot call it. (Inference from the Basic-auth requirement above.)
+- Only works for **user-to-server** tokens tied to *that* `client_id`. You cannot down-scope an arbitrary PAT this way. (Inference from endpoint semantics — it is under `/applications/{client_id}/`.)
+- The octokit strategy that wraps token creation/reset for OAuth explicitly says it **requires `client_secret` and "must not be exposed"** and cannot run in a browser/client — reinforcing that this whole family is a *confidential-client* (server-side) operation, not a local-client one.
+  Source: <https://github.com/octokit/auth-oauth-user.js> ("`@octokit/auth-oauth-user` requires your app's `client_secret`, which must not be exposed…").
+
+**Verdict for a local wrapper:** Not viable unless the wrapper is willing to hold an OAuth/GitHub-App **client secret** locally (which defeats much of the point and is a confidential-client anti-pattern on a dev machine).
+
+---
+
+## 2. Can a user down-scope the `gh` CLI token without the client secret?
+
+**`gh`'s token identity:** `gh` performs an OAuth web/device flow against **GitHub's public "GitHub CLI" OAuth app**. In `cli/cli`'s source:
+
+```go
+// The "GitHub CLI" OAuth app
+oauthClientID     = "178c6fc778ccc68e1d6a"
+// This value is safe to be embedded in version control
+oauthClientSecret = "34ddeff2b558a23d38fba8a6de74f086ede1cc0b"
+minimumScopes := []string{"repo", "read:org", "gist"}
+```
+
+Source: <https://github.com/cli/cli/blob/trunk/internal/authflow/flow.go>
+
+So `gh`'s token is a broad **OAuth-App user token** with `repo` scope (whole account), not a fine-grained token.
+
+**Down-scoping it:**
+- There is **no `gh` subcommand** to down-scope its own token. (Inference — no such command exists in the CLI; `gh` exposes `gh auth token` to *print* it, not to scope it.)
+- Because `gh` is an **OAuth App** (not a fine-grained/GitHub App), even calling `POST /applications/178c6fc.../token/scoped` would need `client_id:client_secret` Basic auth (§1). The client secret is famously embedded in the binary ("This value is safe to be embedded in version control" per the source above), so it is *technically* obtainable — but:
+  - OAuth-App tokens scoped via this endpoint are still **OAuth scopes** semantics, and the `repo` scope is all-or-nothing at the account level for *classic* scope; the endpoint's `repositories`/`permissions` do produce a repo-restricted token, but you are relying on an **undocumented-for-this-purpose** use of GitHub's own app credentials.
+  - Relying on another product's embedded secret is fragile (it can rotate) and is **not a supported integration path**. (Inference / caveat.)
+
+**Verdict:** No clean, supported technique. Treat `gh`'s token as broad and non-downscopable in practice.
+
+---
+
+## 3. Fine-grained PATs — any programmatic/non-interactive creation?
+
+**Creation:** There is **no API to create a PAT** (fine-grained or classic). GitHub's own docs route creation exclusively through the web UI, and the fine-grained-PAT endpoint list contains only *read/approve/deny/revoke* operations, never a "create token" call.
+
+- The org-level endpoints (`GET/POST /orgs/{org}/personal-access-token-requests`, `GET/POST /orgs/{org}/personal-access-tokens`) are for an **org admin (via a GitHub App) to list, approve, deny, or revoke** members' fine-grained PATs — **"Limited to revoking a token's existing access"** and **"Only GitHub Apps can use this endpoint."** None mints a token.
+  Source: <https://docs.github.com/en/rest/orgs/personal-access-tokens>
+- The list of endpoints a fine-grained PAT can *call* does not include any self-mint endpoint.
+  Source: <https://docs.github.com/en/rest/authentication/endpoints-available-for-fine-grained-personal-access-tokens>
+
+**Verdict:** Fine-grained PATs are **web-UI-only to create** — unusable for non-interactive local minting. Org automation can only *govern* (approve/revoke) them, not create them.
+
+---
+
+## 4. GitHub App installation tokens — the mainstream "downscope to specific repos, 1-hour" approach
+
+**Endpoint:** `POST /app/installations/{installation_id}/access_tokens`, authenticated with a **JWT signed by the App's private key** (not a client secret). Body may include:
+- `repositories` / `repository_ids` — "specify individual repositories that the installation access token can access… up to 500 repositories." Cannot exceed what the installation was granted.
+- `permissions` — subset of the app's granted permissions.
+- **TTL: "Installation tokens expire one hour from the time you create them."**
+
+Sources:
+- <https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app>
+- <https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app>
+
+This is exactly "downscope to specific repos + specific permissions, short-lived." It is fully non-interactive given `{app_id/client_id, private_key, installation_id}`.
+
+> Note (2026): GitHub is rolling out a stateless installation-token format (`ghs_APPID_JWT`); tools that assume a 40-char token may break. Source: the endpoint doc above.
+
+### Tools that do this OUTSIDE Actions (local CLI)
+
+| Tool | Lang | What it does | Source |
+|---|---|---|---|
+| **`Link-/gh-token`** | Go | `gh` CLI extension **and** standalone binary: `gh token generate --key key.pem --app-id … --installation-id …` → prints `{token, expires_at, permissions}`. Also `revoke`, `installations`. Works with GHES. | <https://github.com/Link-/gh-token> |
+| **`actions/create-github-app-token`** | JS | Official Action; "creates an installation access token using `POST /app/installations/{id}/access_tokens`," supports `repositories:` and `permission-*:` inputs, auto-revokes in `post`. Local use is possible but it's an Action wrapper. | <https://github.com/actions/create-github-app-token> |
+| **`slawekzachcial/gha-token`** | Go | CLI to mint installation tokens (listed as similar-art by `gh-token`). | <https://github.com/slawekzachcial/gha-token> |
+| **`jakewilkins/apptokit`** | Ruby | CLI for app/installation tokens. | <https://github.com/jakewilkins/apptokit> |
+| **`@octokit/auth-app`** (implied) | JS | Octokit strategy that mints/refreshes installation tokens from `{appId, privateKey, installationId}` — no client secret. | <https://github.com/octokit> (auth-app) |
+
+`octoherd`, `peter-murray/workflow-application-token-action`, `getsentry/action-github-app-token`, `navikt/github-app-token-generator` are all Action-oriented variants of the same primitive (listed by `gh-token`'s "similar projects").
+Source: <https://github.com/Link-/gh-token> ("Similar projects").
+
+---
+
+## 5. Devcontainer / sandbox / "AI agent" per-workspace credential scoping
+
+Concrete prior art found:
+
+- **`AmadeusITGroup/gh-app-auth`** — a `gh` CLI extension that is *purpose-built* for the exact pattern in question: it is a **git credential helper** that mints **GitHub-App installation tokens** and routes them **per repository URL prefix** ("longest-prefix matching"), so different orgs/repos get different apps. Tokens are cached **in-memory only (55-min TTL, not persisted to disk)**, private keys held in the OS keyring. It ships a `.devcontainer/`. Config example routes `github.com/myorg/` → a specific `app_id`/`installation_id`.
+  Source: <https://github.com/AmadeusITGroup/gh-app-auth>
+  - Usage: `git config --global credential."https://github.com/myorg".helper "!gh app-auth git-credential --pattern 'github.com/myorg/*'"`.
+  - This is the closest thing to "scope git credentials per-workspace" as a maintained tool.
+
+- **Anthropic Claude Code devcontainer** — does **not** scope the token; it scopes the **network** instead. `init-firewall.sh` builds an `ipset` allowlist from `api.github.com/meta` and drops all other egress, so a broad token can only talk to GitHub (and a few allowlisted hosts). This is the "network boundary instead of credential boundary" approach — relevant because it's the same trust model as this repo's SBX boundary.
+  Source: <https://github.com/anthropics/claude-code/blob/main/.devcontainer/init-firewall.sh>
+
+- General pattern (inference): none of the mainstream sandbox tools down-scope the *user's* token to the mounted repos automatically; they either (a) inject a broad token and rely on an **isolation/network boundary** (Claude Code, and this repo's SBX model per `AGENTS.md`), or (b) swap in a **GitHub-App installation token via a credential helper** (`gh-app-auth`, `git-credential-github-app`).
+
+---
+
+## 6. `gh` extensions / community tools that mint scoped/installation tokens locally
+
+- **`Link-/gh-token`** (`gh token generate …`) — §4. 400★. <https://github.com/Link-/gh-token>
+- **`AmadeusITGroup/gh-app-auth`** (`gh app-auth …`) — §5, credential-helper + per-prefix routing. <https://github.com/AmadeusITGroup/gh-app-auth>
+
+No community tool was found that mints a **fine-grained PAT** or that down-scopes the **`gh` user token** locally (consistent with §2/§3 constraints).
+
+---
+
+## 7. Git credential-helper approaches (dynamic, per-remote, short-lived token)
+
+Yes — this is well-trodden **for GitHub Apps** (not for user tokens). A credential helper is invoked by git per-remote with the host/path, so it can hand out a **repo/org-scoped installation token** keyed on the remote:
+
+| Helper | Lang | Notes | Source |
+|---|---|---|---|
+| **`bdellegrazie/git-credential-github-app`** | Go | Credential helper for GitHub Apps; **per-installation credential contexts** with `useHttpPath=true` so each `github.com/<org>` maps to its own installation; pairs with `git-credential-cache` (token TTL 1h → cache ≥2h). Can `generate` the recommended gitconfig. | <https://github.com/bdellegrazie/git-credential-github-app> |
+| **`ericnorris/git-credential-github-app`** | Go | Credential helper with **GCP KMS** support (private key never on disk; IAM controls *use* of the key). `--client-id --installation-id`. | <https://github.com/ericnorris/git-credential-github-app> |
+| **`mackee/git-credential-github-apps`** | Go | Credential helper; can resolve installation ID from org name; caches token until expiry. | <https://github.com/mackee/git-credential-github-apps> |
+| **`westphahl/git-credential-github-app-auth`** | Rust | Same idea. | <https://github.com/westphahl/git-credential-github-app-auth> |
+| **`uw-ipd/git-credential-github-app-auth`** | Python | Same idea. | <https://github.com/uw-ipd/git-credential-github-app-auth> |
+
+Key design detail (from `bdellegrazie`): set **narrow `credential.<context>` first** with `useHttpPath = true`, put the broad `https://github.com` cache last. This gives you *per-org/per-repo* token issuance driven by the remote URL — i.e. effectively "per-workspace" if the workspace's remotes determine which installation is used.
+Source: <https://github.com/bdellegrazie/git-credential-github-app>
+
+`hub`/`gfold` are **not** relevant here (`hub` is a legacy wrapper; `gfold` is a repo-status tool) — no dynamic scoped-token issuance. (Inference — neither advertises credential-helper token minting.)
+
+---
+
+## Structured comparison
+
+| Mechanism | (a) What | (b) Fully automatable from local CLI, no web UI? | (c) Prerequisites | (d) Token TTL | (e) Sources |
+|---|---|---|---|---|---|
+| **GitHub App installation token** (`POST /app/installations/{id}/access_tokens`) | Short-lived token scoped to chosen repos + permissions | **Yes** (JWT from private key; `repositories`/`permissions` in body) | GitHub App + private key + app installed on target; `installation_id` | **1 hour** | docs/apps#create-an-installation-access-token; generating-an-installation-access-token |
+| **`token/scoped`** (`POST /applications/{client_id}/token/scoped`) | Downscope an existing user-to-server token to repos/perms | **No** — needs `client_id:client_secret` Basic auth | OAuth/GitHub App **client secret** + a user-to-server token for that app | Inherits/echoes user token (no independent short TTL) | rest/apps/oauth-applications#create-a-scoped-access-token; authentication#using-basic-authentication |
+| **`gh` user token down-scope** | Scope `gh`'s OAuth token | **No supported path** | Would need `gh`'s embedded client secret; fragile | n/a | cli/cli authflow/flow.go |
+| **Fine-grained PAT** | Repo/permission-scoped PAT | **No** — web-UI-only to create | Human at github.com; org can only approve/revoke | up to 1 year (user-chosen) | rest/orgs/personal-access-tokens; endpoints-available-for-fine-grained-pats |
+| **Git credential helper (App-based)** | Per-remote dynamic installation token | **Yes** | Same as installation token (App+key+install) + git config | 1 hour (cached) | bdellegrazie / ericnorris / mackee credential helpers |
+| **Network boundary (no downscope)** | Broad token, restrict egress | **Yes** | Firewall/sandbox | n/a | claude-code init-firewall.sh |
+
+---
+
+## Which approaches are realistic for a local sandbox wrapper (`acq`/`sbx`) to adopt
+
+1. **GitHub App installation token, minted at sandbox start, scoped to the mounted repos** — *the realistic "true down-scope" option.*
+   - Wrapper reads the workspace's git remotes → resolves `owner/repo` → calls `POST /app/installations/{id}/access_tokens` with `repository_ids` + minimal `permissions` (e.g. `contents:write, pull_requests:write`).
+   - Inject the resulting `ghs_…` token (1-hour TTL) instead of the broad `gh` token.
+   - Prereqs the org must accept: **register one GitHub App, install it, hold its private key** (ideally in KMS/keyring, cf. `ericnorris`). No client secret, no web UI at runtime.
+   - Reuse existing tooling rather than build: `Link-/gh-token` (mint) or `AmadeusITGroup/gh-app-auth` (credential-helper + per-prefix routing) or `bdellegrazie/git-credential-github-app` (pure helper). Watch the 2026 `ghs_APPID_JWT` token-format change.
+
+2. **Git-credential-helper (App-based), configured per-org context** — same primitive as (1) but issued lazily per-remote; good when a workspace spans multiple orgs. `bdellegrazie` / `AmadeusITGroup` patterns.
+
+3. **Keep the broad token but rely on the isolation/network boundary** — this is what Claude Code does and matches this repo's stated model (`AGENTS.md`: "SBX is the security boundary"). Lowest friction, but does **not** limit which repos the token can touch — only which *hosts* it can reach. Acceptable only if the sandbox boundary is trusted and the token can't exfiltrate.
+
+**Not realistic:** `token/scoped` (needs a client secret on the dev box), down-scoping the `gh` token (no supported path), and programmatic fine-grained-PAT creation (web-UI-only).
+
+---
+
+## Follow-ups worth tracking (not done here)
+
+- Verify the 2026 stateless installation-token format (`ghs_APPID_JWT`) against whatever consumes the token in the sandbox.
+- If option (1) is pursued: file an ADR (new external dependency + new auth flow → ADR trigger per repo `AGENTS.md` §Engineering Discipline) covering GitHub App registration, private-key storage (KMS/keyring vs file), and installation-ID discovery.

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -483,16 +483,57 @@ else
 fi
 cleanup_stubs
 
-# 5d. `-g github` when it ALREADY exists -> stop with rm hint, no set call.
+# 5d. `-g github` when it ALREADY exists (in the GLOBAL scope) -> stop with rm
+#     hint, no set call. The `secret ls` fixture mirrors sbx's real layout: a
+#     leading SCOPE column ("(global)" for global secrets).
 make_stubs
-# Make the sbx stub's `secret ls` report github present.
-printf 'github\n' > "$STUBDIR/sbx_ls"
+# Make the sbx stub's `secret ls` report a GLOBAL github secret present.
+printf 'SCOPE      TYPE      NAME     SECRET\n(global)   service   github   (stored)\n' > "$STUBDIR/sbx_ls"
 export SBX_LS_FIXTURE="$STUBDIR/sbx_ls"
 out=$(printf 'ghp_x\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g github 2>&1 || true)
 unset SBX_LS_FIXTURE
 log=$(cat "$CALLS")
 assert_contains "secret: existing github -> rm hint" "$out" "sbx secret rm -g github"
 assert_not_contains "secret: existing github -> no set call" "$log" "sbx secret set -g github"
+cleanup_stubs
+
+# 5d-1. REGRESSION (issue #229): a github secret scoped to a DIFFERENT sandbox
+#     must NOT be treated as an existing secret when setting github for THIS
+#     sandbox. Previously the existence check matched the whole listing, so a
+#     `github` secret for sandbox A blocked setting `github` for sandbox B (and
+#     for the global scope). It must feed sbx and store the new scoped secret.
+make_stubs
+printf 'SCOPE                      TYPE      NAME     SECRET\nopencode-pic-blm-cxworks   service   github   (stored)\n' > "$STUBDIR/sbx_ls"
+export SBX_LS_FIXTURE="$STUBDIR/sbx_ls"
+out=$(printf 'ghp_x\n' | ACQ_BACKEND=sbx "$ACQ" secret set opencode-agentic-coding github 2>&1 || true)
+unset SBX_LS_FIXTURE
+log=$(cat "$CALLS")
+assert_not_contains "secret: other-sandbox github -> no false rm hint" "$out" "won't overwrite"
+assert_contains "secret: other-sandbox github -> feeds sbx for THIS sandbox" "$log" "sbx secret set opencode-agentic-coding github"
+cleanup_stubs
+
+# 5d-2. REGRESSION (issue #229): a github secret scoped to a sandbox must NOT
+#     block setting the GLOBAL github secret.
+make_stubs
+printf 'SCOPE                      TYPE      NAME     SECRET\nopencode-pic-blm-cxworks   service   github   (stored)\n' > "$STUBDIR/sbx_ls"
+export SBX_LS_FIXTURE="$STUBDIR/sbx_ls"
+out=$(printf 'ghp_x\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g github 2>&1 || true)
+unset SBX_LS_FIXTURE
+log=$(cat "$CALLS")
+assert_not_contains "secret: sandbox github -> no false rm hint for global" "$out" "won't overwrite"
+assert_contains "secret: sandbox github -> feeds sbx for global" "$log" "sbx secret set -g github"
+cleanup_stubs
+
+# 5d-3. Same sandbox name, existing scoped secret -> correctly detected as a
+#     collision (positive case for the scope-aware check).
+make_stubs
+printf 'SCOPE                      TYPE      NAME     SECRET\nopencode-agentic-coding    service   github   (stored)\n' > "$STUBDIR/sbx_ls"
+export SBX_LS_FIXTURE="$STUBDIR/sbx_ls"
+out=$(printf 'ghp_x\n' | ACQ_BACKEND=sbx "$ACQ" secret set opencode-agentic-coding github 2>&1 || true)
+unset SBX_LS_FIXTURE
+log=$(cat "$CALLS")
+assert_contains "secret: same-sandbox github -> rm hint" "$out" "sbx secret rm opencode-agentic-coding github"
+assert_not_contains "secret: same-sandbox github -> no set call" "$log" "sbx secret set opencode-agentic-coding github"
 cleanup_stubs
 
 # 5e. `-g usai` (custom, non-interactive/piped) -> stored + prints sbx command,

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1544,6 +1544,73 @@ rm -rf "$wt"
 unset -f _id _pf _pfo
 
 # ===========================================================================
+# 13. GitHub token down-scoping helpers (ADR-0013)
+# ===========================================================================
+# Pure string / filesystem logic — no backend, no network. Covers remote-URL
+# parsing, pre-filled PAT URL construction, workspace repo detection, and the
+# advisory gate (fires iff repos present AND no sandbox-scoped github secret,
+# regardless of a global one).
+
+gwt=$(mktemp -d "${TMPDIR:-/tmp}/acq-gh.XXXXXX")
+(
+  mkdir -p "$gwt/repoGH" "$gwt/wsMulti/a" "$gwt/wsMulti/b" "$gwt/wsGL" "$gwt/empty"
+  ( cd "$gwt/repoGH" && git init -q && git remote add origin https://github.com/GSA-TTS/quickstart.git )
+  ( cd "$gwt/wsMulti/a" && git init -q && git remote add origin git@github.com:orgOne/repo1.git )
+  ( cd "$gwt/wsMulti/b" && git init -q && git remote add origin https://github.com/orgTwo/repo2 )
+  ( cd "$gwt/wsGL" && git init -q && git remote add origin https://gitlab.com/x/y.git )
+)
+
+# _acq_parse_github_nwo
+_pnwo() { ( export ACQ_SCRIPT_DIR="$REPO_ROOT"; . "${REPO_ROOT}/acq.backends/common.sh"; _acq_parse_github_nwo "$1" ); }
+assert_eq   "gh-parse: https + .git"      "GSA-TTS/quickstart" "$(_pnwo 'https://github.com/GSA-TTS/quickstart.git')"
+assert_eq   "gh-parse: scp-style ssh"     "owner/repo"         "$(_pnwo 'git@github.com:owner/repo.git')"
+assert_eq   "gh-parse: ssh:// url"        "o/r"                "$(_pnwo 'ssh://git@github.com/o/r')"
+assert_eq   "gh-parse: deep path trimmed" "o/r"                "$(_pnwo 'https://github.com/o/r/tree/main')"
+assert_eq   "gh-parse: non-github empty"  ""                   "$(_pnwo 'https://gitlab.com/x/y.git')"
+
+# _acq_github_pat_url
+_purl() { ( export ACQ_SCRIPT_DIR="$REPO_ROOT"; . "${REPO_ROOT}/acq.backends/common.sh"; _acq_github_pat_url "$1" "$2" ); }
+assert_contains "gh-url: targets the owner"       "$(_purl 'GSA-TTS' 'opencode-proj')" "target_name=GSA-TTS"
+assert_contains "gh-url: names token after sandbox" "$(_purl 'GSA-TTS' 'opencode-proj')" "name=acq-opencode-proj"
+assert_contains "gh-url: default contents=write"  "$(_purl 'o' 's')" "contents=write"
+assert_contains "gh-url: default pull_requests=write" "$(_purl 'o' 's')" "pull_requests=write"
+assert_contains "gh-url: default issues=write"     "$(_purl 'o' 's')" "issues=write"
+
+# detect_workspace_repos
+_dwr() { ( export ACQ_SCRIPT_DIR="$REPO_ROOT"; . "${REPO_ROOT}/acq.backends/common.sh"; detect_workspace_repos "$1" ); }
+assert_eq       "gh-detect: single repo"          "GSA-TTS/quickstart" "$(_dwr "$gwt/repoGH" | tr -d '\n')"
+assert_contains "gh-detect: multi finds orgOne"   "$(_dwr "$gwt/wsMulti")" "orgOne/repo1"
+assert_contains "gh-detect: multi finds orgTwo"   "$(_dwr "$gwt/wsMulti")" "orgTwo/repo2"
+assert_eq       "gh-detect: non-github repo empty" ""  "$(_dwr "$gwt/wsGL" | tr -d '\n')"
+assert_eq       "gh-detect: empty dir empty"      ""  "$(_dwr "$gwt/empty" | tr -d '\n')"
+
+# advise_github_scope gate — force file secret store into a temp dir so we can
+# plant/remove sandbox-scoped and global github secrets deterministically. Each
+# call is given an EXPLICIT unique store dir by the caller (a shared counter
+# wouldn't survive the command-substitution subshell the asserts run in, and
+# $RANDOM can repeat across sequential subshells and leak a planted secret).
+_advise() {
+  # $1 = workspace, $2 = unique tag, $3 = "global"?, $4 = "scoped"?
+  ( export ACQ_SCRIPT_DIR="$REPO_ROOT"
+    unset ACQ_SECRET_STORE_DIR
+    export ACQ_SECRET_FORCE_FILE=1
+    export ACQ_SECRET_FILE_DIR="$gwt/secrets.$2"
+    . "${REPO_ROOT}/acq.backends/common.sh"
+    [ "${3:-}" = "global" ] && printf 'gho_x\n' | acq_secret_store "$(_acq_secret_key github)" >/dev/null 2>&1
+    [ "${4:-}" = "scoped" ] && printf 'ghp_x\n' | acq_secret_store "$(_acq_secret_key github sb1)" >/dev/null 2>&1
+    # non-TTY (stdin not a tty here) so it advises + returns without prompting
+    advise_github_scope sb1 "$1" 2>&1 )
+}
+assert_contains "gh-advise: fires when repos + no scoped (no global)" "$(_advise "$gwt/repoGH" t1)" "no repo-scoped GitHub token"
+assert_contains "gh-advise: warns broad when global present"          "$(_advise "$gwt/repoGH" t2 global)" "grants this sandbox access to ALL"
+assert_contains "gh-advise: no-global path says none set"             "$(_advise "$gwt/repoGH" t3)" "No GitHub token is set for this sandbox"
+assert_eq       "gh-advise: silent when already scoped"               ""  "$(_advise "$gwt/repoGH" t4 global scoped)"
+assert_eq       "gh-advise: silent when no github repos"              ""  "$(_advise "$gwt/wsGL" t5)"
+
+rm -rf "$gwt"
+unset -f _pnwo _purl _dwr _advise
+
+# ===========================================================================
 echo ""
 echo "  passed: $PASS   failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -289,6 +289,19 @@ assert_contains "dispatch: create includes usai kit" "$log" "acq-kits/usai-provi
 rm -rf "$_projdir"
 cleanup_stubs
 
+# `acq create` must also run the github-scope advisory (same as `run`). Use a
+# workspace that has a GitHub remote so advise_github_scope has something to say,
+# and force the file secret store so no real global/scoped secret is consulted.
+# Non-TTY here (stdout captured), so it advises + returns without prompting.
+make_stubs
+_ghproj=$(mktemp -d "${TMPDIR:-/tmp}/acq-ghcreate.XXXXXX")
+( cd "$_ghproj" && git init -q && git remote add origin https://github.com/GSA-TTS/quickstart.git )
+out=$(ACQ_BACKEND=sbx ACQ_SECRET_FORCE_FILE=1 ACQ_SECRET_FILE_DIR="$_ghproj/.secrets" \
+  "$ACQ" create opencode "$_ghproj" 2>&1)
+assert_contains "dispatch: create runs github-scope advisory" "$out" "no repo-scoped GitHub token"
+rm -rf "$_ghproj"
+cleanup_stubs
+
 # Verify `acq stop mybox` calls sbx stop.
 make_stubs
 out=$(ACQ_BACKEND=sbx "$ACQ" stop mybox 2>/dev/null)

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -302,6 +302,22 @@ assert_contains "dispatch: create runs github-scope advisory" "$out" "no repo-sc
 rm -rf "$_ghproj"
 cleanup_stubs
 
+# `acq create` runs a NON-BLOCKING USAi key advisory: it warns on a definitively
+# invalid key but never aborts (create is detached). Drive the stub's key status
+# via STUB_KEY_STATUS. Use a bare temp workspace (no git remote) so the github
+# advisory stays quiet and doesn't confuse the assertion.
+make_stubs
+_keyproj=$(mktemp -d "${TMPDIR:-/tmp}/acq-keycreate.XXXXXX")
+# Bad key -> advisory fires, but create still succeeds (exit 0).
+out=$(STUB_KEY_STATUS=401 ACQ_BACKEND=sbx "$ACQ" create opencode "$_keyproj" 2>&1); rc=$?
+assert_contains "dispatch: create warns on invalid USAi key" "$out" "invalid or expired (HTTP 401)"
+assert_eq       "dispatch: create does not abort on invalid key" "0" "$rc"
+# Healthy key -> no advisory.
+out=$(STUB_KEY_STATUS=200 ACQ_BACKEND=sbx "$ACQ" create opencode "$_keyproj" 2>&1)
+assert_not_contains "dispatch: create silent on valid USAi key" "$out" "invalid or expired"
+rm -rf "$_keyproj"
+cleanup_stubs
+
 # Verify `acq stop mybox` calls sbx stop.
 make_stubs
 out=$(ACQ_BACKEND=sbx "$ACQ" stop mybox 2>/dev/null)


### PR DESCRIPTION
## Context

README Step 3 tells users to store their GitHub credential **globally**:

```bash
gh auth token | sbx secret set -g github --force
```

`gh auth token` carries account-wide scopes (`repo`, `workflow`, `delete_repo`, …), and storing it `-g` injects it into **every** sandbox for **every** project. An agent working on project A can act as the user on **all** their repositories — far broader than the repos actually mounted in the sandbox. This violates least privilege (AC-6); the sandbox's GitHub authority should be constrained to the repos its workspace contains, just as its filesystem already is.

## Change

`acq` now detects the GitHub repositories in the mounted workspace (parsing each `.git` remote) and constrains the token to them per-sandbox:

- **`acq github-scope SANDBOX [PATH]`** — guided flow that builds a **pre-filled fine-grained-PAT URL** (`target_name=<owner>`, `expires_in=30`, `contents=write` + `pull_requests=write` + `issues=write`), lists the exact repos to select, reads the pasted token from the TTY (never argv), and stores it **sandbox-scoped** (`acq.<sandbox>.github`).
- **`acq run`** prints an advisory and, on an interactive TTY, offers to scope now — firing whenever a sandbox has GitHub repos and no sandbox-scoped token yet (with or without a global one). Warn-not-block, matching the existing git-identity / SSH-key advisories; a no-op in CI/non-TTY.
- The global `sbx secret set -g github` path is **deprecated in the docs** but kept working for back-compat.

Default permissions cover the normal agent loop — code, PRs, and issues.

## Why guided (not automatic)

GitHub has **no API** to mint a fine-grained PAT (web-UI only), and the `gh` token can't be downscoped without an OAuth client secret. The only fully-automatic per-repo path is a **GitHub App installation token**, which needs a registered+installed org App and a private key acq holds — an org-admin dependency deferred to future work. The **Jentic** broker is REST-only (can't broker `git clone/push`) and Public Beta; a **network firewall** constrains *where* traffic goes, not *which repo*. All alternatives are recorded in ADR-0013 with supporting research.

## Verification

- `scripts/test-acq` — **215 passed, 0 failed** (added coverage: remote-URL parsing incl. https/ssh/`.git`, PAT-URL construction incl. `issues=write`, workspace repo detection, and the advisory gate independent of a global secret).
- `scripts/test-migrate-or-halt` — PASS.
- `bash -n` clean on `acq` and `acq.backends/common.sh`.
- markdownlint — 0 errors on the ADR, README, and QUICKSTART_SBX.
- Manual multi-owner dry-run confirms instruction/repo-list ordering and the scoped PAT URLs.
- **Deferred (manual):** end-to-end mint of a real PAT + confirming a scoped push succeeds while an out-of-scope repo is denied (needs a real GitHub account + browser).

## Rollback

Revert this commit. No persisted state changes; the deprecated global path still works, and no existing secrets are modified or removed.

## Security impact

Improves least privilege for GitHub access (AC-3, AC-6). Tokens are read from the TTY and stored via the existing acq-neutral secret store (never in argv, never in the guest). No change to the SBX isolation boundary, which remains the complementary control.

AI-assisted (OpenCode); reviewed by the author.