### PR TITLE
fix(msb): install/launch the agent + mount workspaces at their host path

### DIFF
--- a/acq
+++ b/acq
@@ -2,35 +2,9 @@
 #
 # acq — pluggable-backend wrapper for agentic-coding-quickstart
 #
-# acq is the forward path; qsbx is frozen and deprecated (see §8 of the
-# handoff doc). acq defaults to the sbx backend and reuses the same four
-# sbx kits as qsbx, unchanged, for 1.1.x.
-#
-# Usage:
-#   acq run AGENT PATH [...] [--kit REF]... [-- AGENT_ARGS...]  # create+attach
-#   acq create AGENT PATH [...] [--kit REF]...    # create detached
-#   acq ls                                        # list sandboxes
-#   acq stop NAME                                 # stop without removing
-#   acq rm NAME                                   # remove
-#   acq exec NAME -- CMD...                       # run command inside
-#   acq cp SRC DST                                # copy in/out
-#   acq ports NAME [--publish ...]                # list/publish ports
-#   acq secret set SERVICE [...]                  # set a secret (see sbx.sh)
-#   acq usai-rotate-api-key                       # rotate the USAi key
-#   acq version                                   # version + backend info
-#   acq doctor                                    # backend health + config
-#   acq backend list                              # list detected backends
-#   acq backend set NAME                          # persist default backend
-#   *                                             # pass through to backend CLI
-#
-# Global flag (before subcommand):
-#   --backend <name>    Override backend for this invocation
-#
-# run/create flag:
-#   --kit REF           Apply an extra kit (repeatable). REF is a local dir or a
-#                       git+https ref, same as an ACQ_EXTRA_KITS entry. acq
-#                       translates it (neutral hybrid/v1 -> backend); it is NOT
-#                       forwarded raw to the backend.
+# acq is the forward path; qsbx is frozen and deprecated. acq wraps a sandbox
+# backend (sbx or msb) and applies the shared neutral kits. See `acq help` for
+# usage, or docs/QUICKSTART.md and docs/BACKEND_GUIDE.md.
 
 set -euo pipefail
 
@@ -86,6 +60,81 @@ print_version() {
 }
 
 # ---------------------------------------------------------------------------
+# print_help — acq's own usage. Emitted for `acq help`, `acq --help`, `acq -h`,
+# and a bare `acq`. When a backend is resolved, the caller also appends the
+# backend's own help below this (so `acq --help` shows acq + backend usage).
+# ---------------------------------------------------------------------------
+print_help() {
+  cat <<'HELP'
+acq — agentic coding quickstart wrapper
+
+acq wraps a sandbox backend (sbx or msb) and applies the shared federal
+"kits" (USAi provider, playbook, git-ssh-sign, zscaler CA) to each sandbox.
+
+Usage:
+  acq [--backend sbx|msb] <subcommand> [args...]
+
+Subcommands:
+  run AGENT PATH [...] [-- AGENT_ARGS...]  Create+attach a sandbox, or re-attach
+                                           an existing one, and launch AGENT
+                                           (e.g. opencode) or a shell.
+  create AGENT PATH [...]                  Create a sandbox (detached).
+  ls                                       List sandboxes.
+  stop NAME                                Stop a sandbox (without removing).
+  rm NAME                                  Remove a sandbox.
+  exec NAME -- CMD...                      Run a command inside a sandbox.
+  cp SRC DST                               Copy files in/out (NAME:path syntax).
+  ports NAME [--publish ...]               List or publish ports.
+  secret set [-g|SANDBOX] SERVICE [...]    Store a secret (--host/--env for a
+                                           custom endpoint).
+  secret rm  [-g|SANDBOX] SERVICE          Remove a secret acq manages.
+  usai-rotate-api-key                      Rotate the USAi API key.
+  version                                  Show acq version + backend info.
+  doctor                                   Backend health check + write config.
+  backend list                             List detected backends (sbx, msb).
+  backend set NAME                         Persist the default backend.
+  kit list                                 Show the pinned kits (+ extras).
+  kit validate PATH                        Validate a neutral hybrid/v1 kit.
+  kit apply NAME KITREF                    Apply a kit to an existing sandbox.
+  help                                     Show this help.
+
+Any other subcommand is passed through to the active backend's CLI.
+
+Global flags (before the subcommand):
+  --backend sbx|msb    Override the active backend for this invocation.
+                       Default: the persisted backend (`acq backend set`),
+                       else sbx. `sbx` runs Docker sandboxes via the sbx CLI;
+                       `msb` runs microVMs via the microsandbox (msb) CLI.
+
+run/create flag:
+  --kit REF            Apply an extra kit (repeatable). REF is a local dir or a
+                       git+https ref (like an ACQ_EXTRA_KITS entry); acq
+                       translates it to the backend — it is NOT forwarded raw.
+
+See docs/QUICKSTART.md and docs/BACKEND_GUIDE.md for more.
+HELP
+}
+
+# _acq_backend_help SUBCOMMAND — best-effort: print the resolved backend's own
+# help for SUBCOMMAND (or its top-level help when SUBCOMMAND is empty), under a
+# labeled separator. Never fails the acq help output if the backend has no such
+# help.
+_acq_backend_help() {
+  local sub="${1:-}"
+  local be="${ACQ_RESOLVED_BACKEND:-}"
+  [ -n "$be" ] || return 0
+  command -v "$be" >/dev/null 2>&1 || return 0
+  echo ""
+  if [ -n "$sub" ]; then
+    echo "──────── ${be} ${sub} --help ────────"
+    "$be" "$sub" --help 2>&1 || true
+  else
+    echo "──────── ${be} --help ────────"
+    "$be" --help 2>&1 || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Allow tests to source this script without running the dispatch.
 # ---------------------------------------------------------------------------
 if [ -n "${ACQ_SOURCE_ONLY:-}" ]; then return 0 2>/dev/null || exit 0; fi
@@ -112,6 +161,38 @@ while [ "$#" -gt 0 ]; do
 done
 
 subcommand="${1:-}"
+
+# ---------------------------------------------------------------------------
+# Help: `acq help`, `acq --help`, `acq -h`, or a bare `acq` (no args) print
+# acq's OWN usage, then delegate to the resolved backend's help (for the same
+# subcommand when one was given, else the backend's top-level help). Resolve the
+# backend best-effort so help works even if config/health is imperfect.
+#   acq help [SUBCOMMAND]   acq --help / -h   acq SUBCOMMAND --help
+# ---------------------------------------------------------------------------
+_acq_wants_help=""
+_acq_help_topic=""
+case "$subcommand" in
+  help|--help|-h|"")
+    _acq_wants_help=1
+    _acq_help_topic="${2:-}"   # `acq help run` -> backend `run --help`
+    ;;
+  *)
+    # `acq <sub> --help|-h` anywhere in the args -> help for that subcommand.
+    for _a in "$@"; do
+      case "$_a" in
+        --help|-h) _acq_wants_help=1; _acq_help_topic="$subcommand"; break ;;
+      esac
+    done
+    ;;
+esac
+if [ -n "$_acq_wants_help" ]; then
+  print_help
+  acq_resolve_backend "${explicit_backend}" 2>/dev/null || true
+  _acq_backend_help "$_acq_help_topic"
+  # A bare `acq` (no subcommand) is a usage error (exit 2); an explicit help
+  # request is success (exit 0).
+  [ -z "$subcommand" ] && exit 2 || exit 0
+fi
 
 # ---------------------------------------------------------------------------
 # Subcommands that don't need a backend resolved first.
@@ -475,44 +556,10 @@ SECRETUSAGE
     ;;
 
   "")
-    # No subcommand: print usage.
-    cat >&2 <<'USAGE'
-acq — agentic coding quickstart wrapper (sbx backend)
-
-Usage:
-  acq [--backend <name>] <subcommand> [args...]
-
-Subcommands:
-  run AGENT PATH [...]       Create+attach or re-attach a sandbox
-  create AGENT PATH [...]    Create a sandbox (detached)
-  ls                         List sandboxes
-  stop NAME                  Stop a sandbox
-  rm NAME                    Remove a sandbox
-  exec NAME -- CMD...        Run a command inside a sandbox
-  cp SRC DST                 Copy files in/out (NAME:path syntax)
-  ports NAME [--publish ...]  List/publish ports
-  secret set SERVICE [...]   Set a secret (--host/--env for custom)
-  usai-rotate-api-key        Rotate the USAi API key
-  version                    Show acq version + backend info
-  doctor                     Backend health check + write default config
-  backend list               List detected backends
-  backend set NAME           Persist the default backend
-  kit list                   Show the pinned kits
-  kit validate PATH          Validate a neutral hybrid/v1 kit
-  kit apply NAME KITREF      Apply a kit to an existing sandbox
-
-Global flags (before subcommand):
-  --backend <name>           Override the active backend
-
-run/create flag:
-  --kit REF                  Apply an extra kit (repeatable); local dir or
-                             git+https ref, translated by acq like ACQ_EXTRA_KITS
-
-Unknown subcommands are passed through to the active backend's CLI.
-
-See docs/QUICKSTART.md and docs/BACKEND_GUIDE.md for more.
-USAGE
-    exit 1
+    # Unreachable: a bare `acq` (no subcommand) is handled by the help block
+    # above (prints acq + backend help, exits 2). Kept as a defensive guard.
+    print_help
+    exit 2
     ;;
 
   *)

--- a/acq
+++ b/acq
@@ -177,9 +177,14 @@ case "$subcommand" in
     _acq_help_topic="${2:-}"   # `acq help run` -> backend `run --help`
     ;;
   *)
-    # `acq <sub> --help|-h` anywhere in the args -> help for that subcommand.
+    # `acq <sub> --help|-h` -> help for that subcommand. Only honor a help flag
+    # that belongs to acq/the subcommand itself — STOP at the `--` separator, so
+    # args meant for the agent/inner command (`acq run opencode /app -- tool -h`,
+    # `acq exec box -- cmd --help`) pass through verbatim instead of being
+    # hijacked into acq's help.
     for _a in "$@"; do
       case "$_a" in
+        --) break ;;
         --help|-h) _acq_wants_help=1; _acq_help_topic="$subcommand"; break ;;
       esac
     done
@@ -523,9 +528,11 @@ case "$subcommand" in
         fi
         ;;
       ls|import|set-custom)
-        # Pass through to the backend secret CLI unchanged.
-        acq_backend_run "" secret "$sub2" "$@" 2>/dev/null || \
-          command "${ACQ_RESOLVED_BACKEND}" secret "$sub2" "$@"
+        # Pass through to the backend secret CLI unchanged. shift so $sub2 is not
+        # ALSO left in $@ (that would double the subcommand token, e.g.
+        # `sbx secret ls ls`); re-supply it explicitly.
+        shift
+        command "${ACQ_RESOLVED_BACKEND}" secret "$sub2" "$@"
         ;;
       --help|-h|"")
         # Print acq's own summary, then delegate to backend for full detail.

--- a/acq
+++ b/acq
@@ -427,10 +427,24 @@ case "$subcommand" in
         shift
         acq_backend_secret_set "$@"
         ;;
-      ls|rm|import|set-custom)
+      rm)
+        shift
+        # `acq secret rm [-g | SANDBOX] SERVICE` removes an acq-owned secret from
+        # the acq store (and clears the sbx proxy entry). If the args look like a
+        # scope + service (a known acq service, with -g or a sandbox name), route
+        # to the backend rm. Otherwise (e.g. a raw sbx placeholder token) pass
+        # through to the backend secret CLI unchanged for back-compat.
+        if _acq_is_managed_secret_rm "$@"; then
+          acq_backend_secret_rm "$@"
+        else
+          acq_backend_run "" secret rm "$@" 2>/dev/null || \
+            command "${ACQ_RESOLVED_BACKEND}" secret rm "$@"
+        fi
+        ;;
+      ls|import|set-custom)
         # Pass through to the backend secret CLI unchanged.
-        acq_backend_run "" secret "$@" 2>/dev/null || \
-          command "${ACQ_RESOLVED_BACKEND}" secret "$@"
+        acq_backend_run "" secret "$sub2" "$@" 2>/dev/null || \
+          command "${ACQ_RESOLVED_BACKEND}" secret "$sub2" "$@"
         ;;
       --help|-h|"")
         # Print acq's own summary, then delegate to backend for full detail.
@@ -439,12 +453,15 @@ acq secret — manage sandbox secrets
 
 Usage:
   acq secret set [-g | SANDBOX] SERVICE [--host HOST --env ENV]
+  acq secret rm  [-g | SANDBOX] SERVICE      # remove an acq-managed secret
+  acq secret rm  [-g | SANDBOX] <placeholder>  # (raw sbx placeholder → passthrough)
   acq secret ls
-  acq secret rm [-g | SANDBOX] <placeholder>
   acq secret import [SERVICE] [--all] [--force] [--dry-run]
   acq secret set-custom [-g | SANDBOX] --host HOST --env ENV
 
-All other subcommands pass through directly to sbx secret.
+`acq secret rm SERVICE` (usai/github/gitlab) deletes the value from the acq
+store and clears the backend's injector. All other subcommands pass through
+directly to sbx secret.
 
 Full sbx reference:
 SECRETUSAGE

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -212,6 +212,46 @@ workspace_path() {
   done
 }
 
+# List ALL workspace positionals in an AGENT-form create/run arg list: every
+# non-flag positional AFTER the agent (primary workspace first, then any extra
+# mounts). Each is emitted on its own line, VERBATIM (including any `:ro`
+# suffix) so a caller can preserve read-only intent. Mirrors sbx's
+# multi-workspace syntax: `acq run opencode ~/app ~/lib:ro`.
+workspace_paths() {
+  local agent="" prev=""
+  for arg in "$@"; do
+    if _takes_value "$prev"; then prev="$arg"; continue; fi
+    case "$arg" in
+      --backend=*) prev="$arg"; continue ;;
+      -*) prev="$arg"; continue ;;
+    esac
+    if [ -z "$agent" ]; then
+      agent="$arg"
+    else
+      printf '%s\n' "$arg"
+    fi
+    prev="$arg"
+  done
+}
+
+# Canonicalize a filesystem path to its real, symlink-free absolute form.
+# Echoes the resolved path, or the input unchanged if it cannot be resolved
+# (e.g. a nonexistent path, or no realpath/readlink available). Pure stdout;
+# never mutates the filesystem. Used so a backend mounts the REAL host path —
+# e.g. on macOS $TMPDIR is a /var -> /private/var symlink, and msb cannot mount
+# the symlinked form (see docs/BACKEND_GUIDE.md, msb workspace mounting).
+canonicalize_path() {
+  local p="${1:-}"
+  [ -n "$p" ] || return 0
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$p" 2>/dev/null && return 0
+  fi
+  if command -v readlink >/dev/null 2>&1; then
+    readlink -f "$p" 2>/dev/null && return 0
+  fi
+  printf '%s\n' "$p"
+}
+
 # Find the first non-flag positional in a create/run arg list.
 first_positional() {
   local prev=""

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -85,10 +85,13 @@ fi
 
 # Debug trace. Set ACQ_DEBUG=1 to emit "acq[debug]: ..." diagnostics to stderr
 # (backend CLI invocations, kit fetch/translate steps). Off by default; safe to
-# leave in — it never prints secret VALUES, only command shapes.
+# leave in — it never prints secret VALUES, only command shapes. Each line is
+# timestamped (HH:MM:SS) so that when a step hangs, the LAST debug line shows
+# both which sub-call was entered and when — the gap to the wall clock is the
+# stall. (verify-backends -x relies on this to localize a hang.)
 acq_debug() {
   [ -n "${ACQ_DEBUG:-}" ] || return 0
-  printf 'acq[debug]: %s\n' "$*" >&2
+  printf 'acq[debug %s]: %s\n' "$(date +%H:%M:%S 2>/dev/null || printf '??:??:??')" "$*" >&2
 }
 
 # Word-split a whitespace-separated env value into the named array WITHOUT

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -28,9 +28,19 @@
 # Pinning to a release tag mirrors Phase 1 (which pinned patterns v1.5.0). The
 # acq-kits and the kit-hybrid-v1 schema (with `environment`) are present at this
 # commit (verified).
+#
+# TEMPORARY PIN — FINALIZE AFTER patterns#269 MERGES:
+#   This is currently pinned to the TIP of patterns `feat/fix-playbook-clones`
+#   (PR #269: playbook kit REST-tarball fetch, fixes quickstart#203), NOT a
+#   release commit. Once #269 merges to patterns `main`, bump this to the merge
+#   commit (or the next patterns release tag) and RESTORE the two pin assertions
+#   in scripts/test-acq ("version: patterns kit ref" / "kit: list shows patterns
+#   ref") that check for the release SHA. Tracked so it is not forgotten.
 # ============================================================================
 PATTERNS_KIT_REPO="git+https://github.com/GSA-TTS/agentic-coding-patterns.git"
-PATTERNS_KIT_REF="9c277c09ed4ad45fd11709d6b048a58adc785443"   # patterns v1.7.0 (adds environment vocabulary / #227)
+# TEMP (patterns#269): finalize to the merge commit once #269 lands. See note above.
+PATTERNS_KIT_REF="379756ae77f979f55e464de30e61681ffaf27b9e"
+# PATTERNS_KIT_REF="9c277c09ed4ad45fd11709d6b048a58adc785443"   # patterns v1.7.0 (adds environment vocabulary / #227)
 PATTERNS_KIT_DIR="integrations/isolation/acq-kits"
 
 USAI_KIT="${PATTERNS_KIT_REPO}#ref=${PATTERNS_KIT_REF}&dir=${PATTERNS_KIT_DIR}/usai-provider"
@@ -92,6 +102,34 @@ fi
 acq_debug() {
   [ -n "${ACQ_DEBUG:-}" ] || return 0
   printf 'acq[debug %s]: %s\n' "$(date +%H:%M:%S 2>/dev/null || printf '??:??:??')" "$*" >&2
+}
+
+# Services acq manages in its own secret store (and knows how to inject). Used to
+# decide whether `acq secret rm` should route to the acq-owned removal path vs.
+# pass a raw placeholder token through to the backend secret CLI.
+ACQ_MANAGED_SECRET_SERVICES=" usai github gitlab "
+
+# _acq_is_managed_secret_rm ARGS... -> 0 if the `acq secret rm` args name an
+# acq-managed secret (scope + known service), else 1 (pass through to backend).
+# Recognizes:  -g SERVICE  |  --global SERVICE  |  SANDBOX SERVICE
+_acq_is_managed_secret_rm() {
+  local a1="${1:-}" a2="${2:-}" svc=""
+  case "$a1" in
+    -g|--global) svc="$a2" ;;
+    -*)          return 1 ;;              # some other flag/placeholder
+    *)
+      # SANDBOX SERVICE form only (two positionals); a lone token is a raw
+      # placeholder for the backend to handle.
+      [ -n "$a2" ] || return 1
+      case "$a2" in -*) return 1 ;; esac
+      svc="$a2"
+      ;;
+  esac
+  [ -n "$svc" ] || return 1
+  case "$ACQ_MANAGED_SECRET_SERVICES" in
+    *" $svc "*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 # Word-split a whitespace-separated env value into the named array WITHOUT

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -30,7 +30,9 @@
 PATTERNS_KIT_REPO="git+https://github.com/GSA-TTS/agentic-coding-patterns.git"
 # patterns main @ 3fcde8e — playbook REST-tarball fetch (#269, quickstart#203),
 # on top of the environment vocabulary (#227) and neutral acq-kits (#221/#224).
-PATTERNS_KIT_REF="3fcde8e"
+# Full 40-char SHA (not an abbreviation): this ref drives a credential-bearing
+# cross-repo kit fetch, so pin it unambiguously for reproducibility.
+PATTERNS_KIT_REF="3fcde8ee396bf9841de47f6f7886db088164243d"
 PATTERNS_KIT_DIR="integrations/isolation/acq-kits"
 
 USAI_KIT="${PATTERNS_KIT_REPO}#ref=${PATTERNS_KIT_REF}&dir=${PATTERNS_KIT_DIR}/usai-provider"

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -90,6 +90,27 @@ ACQ_MSB_EXEC_READY_TIMEOUT="${ACQ_MSB_EXEC_READY_TIMEOUT:-${ACQ_EXEC_READY_TIMEO
 # USAi models path (matches common.sh USAI_MODELS_URL host) for --secret host.
 ACQ_MSB_USAI_HOST="api.gsa.usai.gov"
 
+# GitHub credential host for the msb --secret binding. We bind the github token
+# to the REST API host ONLY (api.github.com), which msb substitutes on the wire
+# (verified msb 0.6.7). We deliberately do NOT bind github.com/codeload.github.com
+# because msb does not substitute git's smart-HTTP transport there (quickstart#203)
+# and a multi-host binding also trips microsandbox #1170 (ineligible entry blocks
+# eligible). Kits that need github auth must use the REST API (e.g. the playbook
+# kit fetches a source tarball from api.github.com), not `git clone`. The env var
+# name is GITHUB_TOKEN (the neutral service→env mapping; kits also accept GH_TOKEN).
+ACQ_MSB_GITHUB_HOST="${ACQ_MSB_GITHUB_HOST:-api.github.com}"
+
+# _acq_msb_service_binding SERVICE -> "ENVVAR<TAB>HOST" for services the msb
+# adapter binds via `--secret ENV@HOST`, or empty for services it does not bind.
+# Single source of truth for the bind (provision) and unbind (secret rm) paths.
+_acq_msb_service_binding() {
+  case "$1" in
+    usai)   printf '%s\t%s\n' "USAI_API_KEY" "$ACQ_MSB_USAI_HOST" ;;
+    github) printf '%s\t%s\n' "GITHUB_TOKEN" "$ACQ_MSB_GITHUB_HOST" ;;
+    *)      printf '\t\n' ;;
+  esac
+}
+
 # The kits expect an unprivileged `agent` user with HOME=/home/agent (the sbx
 # agent-template contract). Plain OCI bases don't provide it, so the adapter
 # creates it at provision (see _acq_msb_ensure_agent_user). uid 1000 is the
@@ -319,14 +340,15 @@ EOF
 # path for a shortcut kit). Drops files and runs install/initFiles/startup
 # commands via `msb exec`.
 #
-# KNOWN LIMITATION (agentic-coding-playbook kit on msb): the playbook kit clones
-# a PRIVATE GitHub repo over HTTPS. msb 0.6.6 does not substitute the credential
-# placeholder for git's HTTPS smart-transport to github.com (the request is
-# blocked/unsubstituted regardless of request shape — verified extensively;
-# curl's Authorization-header path to api.gsa.usai.gov DOES work). So on msb the
-# clone is skipped and the kit warns (it is non-fatal by design). Tracked in
-# quickstart#203 (and upstream microsandbox #756/#768/#1170). USAi, git-ssh-sign,
-# and zscaler kits are unaffected.
+# RESOLVED (agentic-coding-playbook kit on msb): the playbook kit fetches a
+# PRIVATE GitHub repo. It used to `git clone` over HTTPS, but msb does not
+# substitute the credential placeholder for git's smart-HTTP transport to
+# github.com/codeload (quickstart#203). The kit now fetches the repo SOURCE
+# TARBALL via the REST API (api.github.com/repos/<repo>/tarball/<ref>), which msb
+# DOES substitute (verified msb 0.6.7), and acq binds GITHUB_TOKEN@api.github.com
+# above. So the playbook now works on msb. USAi, git-ssh-sign, and zscaler kits
+# are unaffected. (Upstream git-transport substitution remains unfixed —
+# microsandbox #756/#768/#1170 — but the kit no longer depends on it.)
 _acq_msb_apply_kit_dir() {
   local name="$1" kitdir="$2"
   local spec="${kitdir}/spec.yaml"
@@ -812,17 +834,18 @@ EOF
   # on the wire to the allowed host (requires --tls-intercept, set above). The
   # real value never enters the guest.
   #
-  # SCOPE (deliberately narrow, verified against msb 0.6.6):
+  # SCOPE (verified against msb 0.6.7):
   #   - USAi: bind USAI_API_KEY@api.gsa.usai.gov ONLY. The USAi provider sends the
   #     key as an `Authorization: Bearer` header, which msb substitutes correctly.
-  #   - GitHub: NOT bound here. msb 0.6.6 does not substitute the placeholder for
-  #     git's HTTPS clone to github.com (verified extensively: the request is
-  #     blocked/unsubstituted regardless of single/multi binding or request shape;
-  #     see the KNOWN LIMITATION note on _acq_msb_apply_kit_dir and the tracked
-  #     issue). Binding the same placeholder across multiple github hosts also
-  #     triggers microsandbox #1170 (ineligible-entry blocks eligible). So the
-  #     private playbook clone is expected to be skipped on msb until upstream git
-  #     substitution works; the kit is non-fatal and warns.
+  #   - GitHub: bind GITHUB_TOKEN@api.github.com ONLY. msb substitutes the token on
+  #     the wire to the REST API (verified: an authenticated GET to
+  #     api.github.com returns 5000-rate-limit headers; a private-repo tarball
+  #     fetch succeeds). msb does NOT substitute git's smart-HTTP transport to
+  #     github.com/codeload (a `git clone`/`gh repo clone` of a private repo fails
+  #     auth/TLS there) — this is quickstart#203. So kits authenticate via the REST
+  #     API, not git: the playbook kit fetches a source tarball from
+  #     api.github.com. Binding a single host also avoids microsandbox #1170
+  #     (multi-host binding: ineligible entry blocks eligible).
   local _secret_env_names=()   # env vars we set transiently, cleared after create
   if command -v acq_secret_resolve >/dev/null 2>&1; then
     local usai_val
@@ -836,9 +859,26 @@ EOF
       create_flags+=(--secret "USAI_API_KEY@${ACQ_MSB_USAI_HOST}")
       acq_debug "msb secret: binding USAI_API_KEY@${ACQ_MSB_USAI_HOST} (from env)"
     fi
-    # NOTE: GitHub token is intentionally NOT bound as an msb secret — see the
-    # scope note above. It remains in the acq store for the sbx backend and for
-    # a future msb path once upstream git substitution is fixed.
+
+    # GitHub: bind GITHUB_TOKEN@api.github.com so kits can authenticate to the
+    # REST API (the substituted path). Resolve from the acq store first, then a
+    # pre-exported GITHUB_TOKEN/GH_TOKEN (CI). Absent token => no binding; the
+    # playbook kit then degrades gracefully (warns, no rules/skills).
+    local gh_val
+    if gh_val=$(acq_secret_resolve github "$name" 2>/dev/null) && [ -n "$gh_val" ]; then
+      export GITHUB_TOKEN="$gh_val"; gh_val=""
+      _secret_env_names+=("GITHUB_TOKEN")
+      create_flags+=(--secret "GITHUB_TOKEN@${ACQ_MSB_GITHUB_HOST}")
+      acq_debug "msb secret: binding GITHUB_TOKEN@${ACQ_MSB_GITHUB_HOST} (from acq store)"
+    elif [ -n "${GITHUB_TOKEN:-}" ]; then
+      create_flags+=(--secret "GITHUB_TOKEN@${ACQ_MSB_GITHUB_HOST}")
+      acq_debug "msb secret: binding GITHUB_TOKEN@${ACQ_MSB_GITHUB_HOST} (from env)"
+    elif [ -n "${GH_TOKEN:-}" ]; then
+      export GITHUB_TOKEN="$GH_TOKEN"
+      _secret_env_names+=("GITHUB_TOKEN")
+      create_flags+=(--secret "GITHUB_TOKEN@${ACQ_MSB_GITHUB_HOST}")
+      acq_debug "msb secret: binding GITHUB_TOKEN@${ACQ_MSB_GITHUB_HOST} (from GH_TOKEN env)"
+    fi
   elif [ -n "${USAI_API_KEY:-}" ]; then
     create_flags+=(--secret "USAI_API_KEY@${ACQ_MSB_USAI_HOST}")
   fi
@@ -901,13 +941,19 @@ EOF
   _acq_msb_check_prereqs "$name"
   acq_debug "msb provision: prereqs checked ($name)"
 
-  # Ensure the `agent` user (uid ACQ_MSB_AGENT_UID) with HOME=/home/agent exists.
-  # The pinned kits stage files under /home/agent and run startup commands as
-  # that user (the sbx agent template guarantees this user). A plain OCI base
-  # (e.g. node:22-bookworm) has no `agent` user, so their `-u 1000` commands ran
-  # as the wrong user against a non-existent home. Create it once, idempotently.
+  # Ensure the `agent` user with HOME=/home/agent exists AND that /home/agent is
+  # writable by it. The pinned kits stage files under /home/agent and run startup
+  # commands as that user (the sbx agent template guarantees this user). A plain
+  # OCI base (e.g. node:22-bookworm) has no `agent` user — and uid 1000 is already
+  # taken there — so acq creates `agent` (any uid) and chowns its home. A failure
+  # here is FATAL: a root-owned /home/agent silently breaks every agent-user kit
+  # (playbook fetch, usai merge), which is exactly how the playbook stopped
+  # fetching. Abort provision rather than degrade silently.
   acq_debug "msb provision: ensuring agent user ($name)"
-  _acq_msb_ensure_agent_user "$name"
+  if ! _acq_msb_ensure_agent_user "$name"; then
+    echo "acq(msb): error: agent-user setup failed for '$name'; aborting provision." >&2
+    return 1
+  fi
   acq_debug "msb provision: agent user ready ($name)"
 
   # Install the requested agent binary (sbx bakes it into the template image; on
@@ -1058,27 +1104,43 @@ _acq_msb_ensure_agent_user() {
 
   acq_debug "msb: ensuring agent user + /home/agent + passwordless sudo + proxy-preserve in $name"
   # Idempotent, distro-agnostic. If an `agent` user already exists, reuse it.
-  # Otherwise create it: prefer uid 1000, but if that uid is taken, let the tool
-  # pick a free uid (the kits address the user by name via our exec translation,
-  # not strictly by 1000).
+  # Otherwise create it. NOTE: we do NOT pin uid 1000 — on common bases
+  # (node:22-bookworm) uid 1000 is already taken by a pre-existing user (`node`),
+  # so requesting -u 1000 fails and, worse, can leave /home/agent half-created or
+  # root-owned. The kits address the agent BY NAME (our exec translation maps
+  # user 1000/agent → `-u agent`), so the uid is irrelevant. What MUST hold is
+  # that /home/agent exists and is OWNED BY agent — otherwise every kit command
+  # that runs as the agent user (playbook fetch, usai merge) fails with
+  # Permission denied. So home creation + ownership is deterministic and its
+  # failure is FATAL (previously it was best-effort `|| true`, which silently
+  # degraded into a root-owned home and a playbook that never fetched).
   msb exec "$name" -u 0 -- sh -c '
     set -e
     if id agent >/dev/null 2>&1; then
       :
     elif command -v useradd >/dev/null 2>&1; then
-      # Debian/Ubuntu/RHEL. Try uid 1000 first; fall back to auto uid.
-      useradd -m -d /home/agent -s /bin/sh -u 1000 agent 2>/dev/null \
-        || useradd -m -d /home/agent -s /bin/sh agent
+      # Debian/Ubuntu/RHEL. Do NOT request a fixed uid (1000 may be taken); let
+      # the tool pick a free uid. -M: do not auto-create home here; we create and
+      # chown it explicitly below so ownership is unconditional.
+      useradd -M -d /home/agent -s /bin/sh agent
     elif command -v adduser >/dev/null 2>&1; then
       # Alpine/BusyBox.
-      adduser -h /home/agent -s /bin/sh -D -u 1000 agent 2>/dev/null \
-        || adduser -h /home/agent -s /bin/sh -D agent
+      adduser -h /home/agent -s /bin/sh -D -H agent
     else
       echo "acq(msb): no useradd/adduser in base image; cannot create agent user" >&2
       exit 1
     fi
+    # Home MUST exist and be owned by agent. Not best-effort: a root-owned home
+    # breaks every agent-user kit. `id -gn agent` resolves the primary group so
+    # chown works whether or not an `agent` group exists.
     mkdir -p /home/agent
-    chown -R agent:agent /home/agent 2>/dev/null || chown -R agent /home/agent 2>/dev/null || true
+    _agrp=$(id -gn agent 2>/dev/null || echo agent)
+    chown "agent:${_agrp}" /home/agent
+    chown -R "agent:${_agrp}" /home/agent
+    # Verify writability as the agent user (catches an exotic base where chown
+    # "succeeds" but the mount is read-only, etc.). Fatal on failure.
+    su agent -s /bin/sh -c "test -w /home/agent" 2>/dev/null \
+      || { echo "acq(msb): /home/agent is not writable by the agent user" >&2; exit 1; }
 
     # Passwordless sudo for agent (base-image requirement). Only if sudo exists;
     # a base without sudo still works for our purposes (kit/agent commands that
@@ -1095,13 +1157,13 @@ _acq_msb_ensure_agent_user() {
       chmod 0440 /etc/sudoers.d/91-acq-proxy-env
     fi
   ' || {
-    echo "acq(msb): warning: could not fully satisfy the agent-user base-image contract in '$name'." >&2
-    echo "acq(msb):   kit commands that run as the agent user (e.g. the usai merge)" >&2
-    echo "acq(msb):   or agent commands needing passwordless sudo may fail. Use an" >&2
-    echo "acq(msb):   ACQ_MSB_IMAGE built on docker/sandbox-templates:shell-docker (or one" >&2
-    echo "acq(msb):   providing an 'agent' user at uid 1000 with passwordless sudo and" >&2
-    echo "acq(msb):   HOME=/home/agent), or a base with useradd/adduser + sudo." >&2
-    return 0
+    echo "acq(msb): error: could not establish a writable agent home in '$name'." >&2
+    echo "acq(msb):   /home/agent must exist and be owned by the 'agent' user — kit" >&2
+    echo "acq(msb):   commands that run as agent (playbook fetch, usai merge) fail" >&2
+    echo "acq(msb):   otherwise. Use an ACQ_MSB_IMAGE built on" >&2
+    echo "acq(msb):   docker/sandbox-templates:shell-docker (agent user + sudo), or a" >&2
+    echo "acq(msb):   base with useradd/adduser. Re-run with ACQ_DEBUG=1 for details." >&2
+    return 1
   }
   msb exec "$name" -u 0 -- sh -c "mkdir -p /var/lib/acq && touch '$marker'" >/dev/null 2>&1 || true
 }
@@ -1347,50 +1409,151 @@ acq_backend_secret_set() {
   # Store into the acq-owned store (keychain/file); value read from TTY/stdin.
   acq_secret_set_interactive "$service" "$scope_name" || return 1
 
-  # Re-feed running sandboxes so a rotated secret takes effect without recreate
-  # (msb modify --secret; the guest keeps its placeholder, only the injected
-  # value changes). Only for services the msb adapter actually binds (usai).
-  case "$service" in
-    usai)
-      local val
-      if val=$(acq_secret_resolve usai "$scope_name" 2>/dev/null) && [ -n "$val" ]; then
-        local applied=0 sb
-        # Determine target sandboxes: a named scope, else all running sandboxes.
-        if [ -n "$scope_name" ]; then
-          if acq_backend_exists "$scope_name"; then
-            USAI_API_KEY="$val" msb modify "$scope_name" --secret "USAI_API_KEY@${ACQ_MSB_USAI_HOST}" >/dev/null 2>&1 \
-              && applied=$((applied + 1))
-          fi
-        else
-          while IFS= read -r sb; do
-            [ -n "$sb" ] || continue
-            USAI_API_KEY="$val" msb modify "$sb" --secret "USAI_API_KEY@${ACQ_MSB_USAI_HOST}" >/dev/null 2>&1 \
-              && applied=$((applied + 1))
-          done <<EOF
+  # Live add/rotate: re-feed running sandboxes so a newly-set or rotated secret
+  # takes effect without recreate (`msb modify --secret ENV@HOST`; the guest keeps
+  # its placeholder, only the injected value changes). Driven off the single
+  # binding table so EVERY bound service (usai, github, ...) rotates in place —
+  # not just usai. A named scope targets that sandbox; a global set sweeps all
+  # running sandboxes. The real value is read from the acq store into a TRANSIENT
+  # env var (never argv) that `msb modify` reads, then cleared.
+  local _env _host _binding val applied=0 sb
+  _binding=$(_acq_msb_service_binding "$service")
+  _env=$(printf '%s' "$_binding" | cut -f1)
+  _host=$(printf '%s' "$_binding" | cut -f2)
+  if [ -n "$_env" ] && [ -n "$_host" ]; then
+    if val=$(acq_secret_resolve "$service" "$scope_name" 2>/dev/null) && [ -n "$val" ]; then
+      if [ -n "$scope_name" ]; then
+        if acq_backend_exists "$scope_name"; then
+          env "$_env=$val" msb modify "$scope_name" --secret "${_env}@${_host}" </dev/null >/dev/null 2>&1 \
+            && applied=$((applied + 1))
+        fi
+      else
+        # stdin from /dev/null so `msb modify` can't consume the `while read`
+        # heredoc (else only the first sandbox is processed — a real msb drains
+        # stdin). Same trap guarded in acq_backend_secret_rm's sweep.
+        while IFS= read -r sb; do
+          [ -n "$sb" ] || continue
+          env "$_env=$val" msb modify "$sb" --secret "${_env}@${_host}" </dev/null >/dev/null 2>&1 \
+            && applied=$((applied + 1))
+        done <<EOF
 $(msb list -q 2>/dev/null)
 EOF
-        fi
-        val=""
-        [ "$applied" -gt 0 ] && acq_debug "msb modify: re-fed USAi secret to $applied sandbox(es)"
       fi
+      val=""
+      [ "$applied" -gt 0 ] && acq_debug "msb modify: re-fed $service (${_env}@${_host}) to $applied sandbox(es)"
+    fi
+  fi
+
+  # Service-specific guidance.
+  case "$service" in
+    usai)
       echo "acq(msb): stored USAi key in the acq secret store. At 'acq run/create'" >&2
       echo "      the msb backend binds it via --secret USAI_API_KEY@${ACQ_MSB_USAI_HOST};" >&2
       echo "      the real value is swapped in on the wire and never enters the guest." >&2
-      echo "      Running sandboxes were re-fed via 'msb modify' (no recreate needed)." >&2
+      [ "$applied" -gt 0 ] && echo "      Re-fed $applied running sandbox(es) via 'msb modify' (no recreate needed)." >&2
       ;;
     github)
-      echo "acq(msb): stored GitHub token in the acq secret store (used by the sbx" >&2
-      echo "      backend). NOTE: the msb backend does NOT bind GitHub as a secret —" >&2
-      echo "      msb 0.6.6 does not substitute the placeholder for git's HTTPS clone" >&2
-      echo "      to github.com, so the private playbook-clone kit is skipped on msb." >&2
-      echo "      Tracked for a fix (see docs/BACKEND_GUIDE.md, msb known limitations)." >&2
+      echo "acq(msb): stored GitHub token in the acq secret store. At 'acq run/create'" >&2
+      echo "      the msb backend binds it via --secret GITHUB_TOKEN@${ACQ_MSB_GITHUB_HOST};" >&2
+      echo "      the real value is swapped in on the wire to the REST API and never enters" >&2
+      echo "      the guest. Kits authenticate via the REST API (e.g. the playbook kit" >&2
+      echo "      fetches a source tarball from api.github.com) — NOT 'git clone', which" >&2
+      echo "      msb does not substitute for github.com/codeload (quickstart#203)." >&2
+      [ "$applied" -gt 0 ] && echo "      Re-fed $applied running sandbox(es) via 'msb modify' (no recreate needed)." >&2
       ;;
     *)
       echo "acq(msb): stored '$service' in the acq secret store. Note: the msb adapter" >&2
-      echo "      only auto-binds 'usai' at create today; other services are stored" >&2
-      echo "      but not yet wired to a --secret host mapping." >&2
+      echo "      only binds known services (usai, github) at create today; other" >&2
+      echo "      services are stored but not yet wired to a --secret host mapping." >&2
       ;;
   esac
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# acq_backend_secret_rm [-g | SANDBOX] SERVICE  (msb backend)
+# ---------------------------------------------------------------------------
+# Remove a secret from the acq store AND live-unbind it from running sandboxes.
+# msb binds a secret at create via `--secret ENV@HOST`; `msb modify --secret-rm
+# ENV` removes that binding from a running VM (verified: msb 0.6.7 modify has
+# --secret-rm <NAME>). So on rm we (1) delete the acq-store value (source of
+# truth for future creates) and (2) `msb modify --secret-rm ENV` the sandbox(es)
+# so the injected value stops flowing immediately — a named scope targets that
+# sandbox; a global rm sweeps all running sandboxes. Idempotent (absent secret /
+# absent binding are both success). Scope parsing mirrors acq_backend_secret_set.
+acq_backend_secret_rm() {
+  local service="${1:-}"
+  shift || true
+
+  local scope_name=""
+  case "$service" in
+    -g|--global)
+      service="${1:-}"; shift || true ;;
+    -*)
+      ;;
+    *)
+      local _next="${1:-}"
+      case "$_next" in
+        ""|-*) ;;
+        *) scope_name="$service"; service="$_next"; shift || true ;;
+      esac
+      ;;
+  esac
+
+  if [ -z "$service" ]; then
+    echo "acq(msb): secret rm: missing service name" >&2
+    echo "     usage: acq secret rm [-g | SANDBOX] <service>" >&2
+    return 1
+  fi
+
+  if ! command -v acq_secret_delete >/dev/null 2>&1; then
+    echo "acq(msb): internal error: secret store not loaded" >&2
+    return 1
+  fi
+
+  # 1) Delete the acq-store value (idempotent).
+  local key removed=0
+  key=$(_acq_secret_key "$service" "$scope_name")
+  acq_secret_delete "$key" && removed=1
+
+  # 2) Live-unbind from running sandboxes via `msb modify --secret-rm ENV`, for
+  #    services the adapter actually binds. A named scope targets that sandbox;
+  #    a global rm sweeps every running sandbox. Best-effort per sandbox.
+  local env_name unbound=0
+  env_name=$(_acq_msb_service_binding "$service" | cut -f1)
+  if [ -n "$env_name" ]; then
+    local sb
+    if [ -n "$scope_name" ]; then
+      if acq_backend_exists "$scope_name"; then
+        msb modify "$scope_name" --secret-rm "$env_name" >/dev/null 2>&1 \
+          && unbound=$((unbound + 1))
+      fi
+    else
+      # NOTE: redirect each `msb modify` stdin from /dev/null. Without it, the
+      # command inside the loop consumes the heredoc that feeds `while read`, so
+      # only the FIRST sandbox is processed (a real `msb` drains stdin). This is
+      # the same stdin-consumption trap the test stub deliberately reproduces.
+      while IFS= read -r sb; do
+        [ -n "$sb" ] || continue
+        msb modify "$sb" --secret-rm "$env_name" </dev/null >/dev/null 2>&1 \
+          && unbound=$((unbound + 1))
+      done <<EOF
+$(msb list -q 2>/dev/null)
+EOF
+    fi
+    [ "$unbound" -gt 0 ] && acq_debug "msb modify --secret-rm $env_name: unbound from $unbound sandbox(es)"
+  fi
+
+  local where="global"
+  [ -n "$scope_name" ] && where="sandbox '$scope_name'"
+  if [ "$removed" -eq 1 ]; then
+    echo "acq(msb): removed '$service' secret (${where}) from the acq store." >&2
+  else
+    echo "acq(msb): no '$service' secret found in the acq store (${where})." >&2
+  fi
+  if [ "$unbound" -gt 0 ]; then
+    echo "      Live-unbound it from $unbound running sandbox(es) (msb modify --secret-rm)." >&2
+  fi
   return 0
 }
 

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -481,7 +481,9 @@ _acq_msb_copy_file_verified() {
       *) echo "acq(msb): refusing chmod: non-octal mode '$mode' for '$path'" >&2; mode="" ;;
     esac
   fi
-  [ -n "$mode" ] && msb exec "$name" -u 0 -- chmod "$mode" "$path" >/dev/null 2>&1 || true
+  if [ -n "$mode" ]; then
+    msb exec "$name" -u 0 -- chmod "$mode" "$path" >/dev/null 2>&1 || true
+  fi
   case "$path" in
     /home/agent/*)
       msb exec "$name" -u 0 -- chown agent "$path" >/dev/null 2>&1 || true
@@ -500,13 +502,13 @@ _acq_msb_run_commands() {
   # already validates each NAME (^[A-Za-z_][A-Za-z0-9_]*$) and drops unsafe ones,
   # so these are safe to pass as exec env. Values are passed as a single argv
   # element (never re-split by a shell).
-  local _kit_env=() eline ekey eval
+  local _kit_env=() eline ekey eval_v
   while IFS= read -r eline; do
     [ -n "$eline" ] || continue
     ekey=$(printf '%s' "$eline" | cut -f1)
-    eval=$(printf '%s' "$eline" | cut -f2-)
+    eval_v=$(printf '%s' "$eline" | cut -f2-)
     [ -n "$ekey" ] || continue
-    _kit_env+=("${ekey}=${eval}")
+    _kit_env+=("${ekey}=${eval_v}")
   done <<EOF
 $(kit_spec_env "$spec")
 EOF
@@ -995,12 +997,21 @@ EOF
     esac
   fi
 
-  # Apply each kit's files + commands.
+  # Apply each kit's files + commands. Best-effort per kit: a single kit that
+  # fails to fully apply (e.g. a transient `msb copy` verify failure) must NOT
+  # abort provision under `set -e` and leave an already-created, agent-installed
+  # sandbox half-configured with no diagnostic. Warn and continue — the kits are
+  # individually non-fatal (the playbook kit already self-heals on next start),
+  # matching acq_backend_ensure_kits_applied's best-effort heal loop.
   local kd
   for kd in "${kitdirs[@]}"; do
     acq_debug "msb provision: applying kit dir $kd ($name)"
-    _acq_msb_apply_kit_dir "$name" "$kd"
-    acq_debug "msb provision: applied kit dir $kd ($name)"
+    if _acq_msb_apply_kit_dir "$name" "$kd"; then
+      acq_debug "msb provision: applied kit dir $kd ($name)"
+    else
+      echo "acq(msb): warning: kit did not fully apply: $kd" >&2
+      echo "acq(msb):   the sandbox is up; re-run 'acq run' to re-apply, or inspect with ACQ_DEBUG=1." >&2
+    fi
   done
   acq_debug "msb provision: all kits applied; provision complete ($name)"
 }
@@ -1287,7 +1298,7 @@ _acq_msb_attach() {
 
   # Read the agent recorded at provision. Default to `shell` if unset.
   local agent
-  agent=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/agent 2>/dev/null' </dev/null 2>/dev/null | tr -d '\r\n[:space:]')
+  agent=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/agent 2>/dev/null' </dev/null 2>/dev/null | tr -d '[:space:]')
   [ -n "$agent" ] || agent="shell"
 
   # Common flags for the interactive attach: PTY, agent user, workspace cwd, and

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -102,7 +102,16 @@ ACQ_MSB_GITHUB_HOST="${ACQ_MSB_GITHUB_HOST:-api.github.com}"
 
 # _acq_msb_service_binding SERVICE -> "ENVVAR<TAB>HOST" for services the msb
 # adapter binds via `--secret ENV@HOST`, or empty for services it does not bind.
-# Single source of truth for the bind (provision) and unbind (secret rm) paths.
+# Single source of truth for the bind (provision), rotate (set), and unbind
+# (secret rm) paths.
+#
+# NOTE (quickstart#226, gap C): this is still a fixed table (usai + github), not
+# generic. An arbitrary stored custom endpoint (`acq secret set SANDBOX --host
+# api.example.com --env API_KEY`) is NOT yet bound on msb — closing that requires
+# the acq secret store to persist the per-service host/env pair (msb's
+# `acq_backend_secret_set` does not yet accept/store --host/--env) and this
+# function to read it back. Tracked in #226; out of scope for this PR, which
+# generalized the re-feed/rotate machinery and added github via the REST path.
 _acq_msb_service_binding() {
   case "$1" in
     usai)   printf '%s\t%s\n' "USAI_API_KEY" "$ACQ_MSB_USAI_HOST" ;;
@@ -113,9 +122,9 @@ _acq_msb_service_binding() {
 
 # The kits expect an unprivileged `agent` user with HOME=/home/agent (the sbx
 # agent-template contract). Plain OCI bases don't provide it, so the adapter
-# creates it at provision (see _acq_msb_ensure_agent_user). uid 1000 is the
-# preferred id but not required — kit commands address the user by name.
-ACQ_MSB_AGENT_UID="${ACQ_MSB_AGENT_UID:-1000}"
+# creates it at provision (see _acq_msb_ensure_agent_user), addressing it by
+# NAME — the uid is whatever the base image leaves free (1000 is often taken by
+# a pre-existing user, e.g. `node` on node:22-bookworm).
 
 # Guest memory and vCPU allocation.
 # ---------------------------------------------------------------------------

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -112,6 +112,27 @@ ACQ_MSB_DNS_NAMESERVER="${ACQ_MSB_DNS_NAMESERVER-1.1.1.1}"
 # shellcheck disable=SC2034
 KNOWN_AGENTS=" claude codex copilot cursor docker-agent droid gemini kiro opencode shell "
 
+# Agent binary install.
+# ---------------------------------------------------------------------------
+# Unlike sbx (whose agent templates BAKE the agent binary into the image), msb
+# runs a plain OCI base, so the adapter must install the requested agent itself.
+# For `opencode`, install the npm package globally (node is a base-image
+# prerequisite the adapter already verifies). The registry host must be reachable
+# from the guest, so the adapter allow-lists it at create (kit net-rules are
+# default-deny). The install is idempotent (marker-gated + `command -v` guarded).
+#
+# Only agents with a known install recipe are auto-installed; `shell` is a no-op
+# (there is nothing to install), and an unknown agent is a clear, non-fatal warning
+# (the user can bake it into ACQ_MSB_IMAGE). Override the opencode package spec
+# (e.g. to pin a version like opencode-ai@1.2.3) with ACQ_MSB_OPENCODE_PKG.
+ACQ_MSB_OPENCODE_PKG="${ACQ_MSB_OPENCODE_PKG:-opencode-ai}"
+
+# Hosts the agent installer needs to reach, allow-listed at create so egress
+# (default-deny under kit net-rules) permits the npm download. registry.npmjs.org
+# serves metadata; the tarballs are on the same host for the public registry.
+# Override for an internal mirror via ACQ_MSB_NPM_HOSTS (space-separated).
+ACQ_MSB_NPM_HOSTS="${ACQ_MSB_NPM_HOSTS:-registry.npmjs.org}"
+
 # ---------------------------------------------------------------------------
 # Version comparison (shared shape with sbx.sh; kept local to avoid coupling)
 # ---------------------------------------------------------------------------
@@ -545,6 +566,14 @@ acq_backend_provision() {
   local name="$1"
   shift
 
+  # The AGENT token is the FIRST positional (e.g. `opencode`); the workspace path
+  # follows. Unlike sbx (whose template bakes the agent in), msb must install the
+  # agent itself after create — capture the token now so we know what to install
+  # and, later, what to launch on attach. Defaults to `shell` (no agent binary).
+  local agent
+  agent=$(first_positional "$@")
+  [ -n "$agent" ] || agent="shell"
+
   # Collect create-time flags: net rules (union of all kit caps), --trust-host-cas
   # (if any kit declares the msb zscaler shortcut), volume mounts (from paths),
   # and the USAi secret binding.
@@ -588,6 +617,22 @@ acq_backend_provision() {
   done
 
   [ "$trust_host_cas" -eq 1 ] && create_flags+=(--trust-host-cas)
+
+  # Allow-list the agent installer's registry host(s) so the (default-deny) guest
+  # egress permits the npm download. Only when we will actually install an agent
+  # (a known recipe exists); `shell` and unknown agents add no rule.
+  if _acq_msb_agent_has_install_recipe "$agent"; then
+    local _npm_host
+    for _npm_host in $ACQ_MSB_NPM_HOSTS; do
+      case "$_npm_host" in
+        ""|*[!A-Za-z0-9.*_-]*)
+          echo "acq(msb): warning: skipping non-hostname npm host: $_npm_host" >&2
+          continue
+          ;;
+      esac
+      create_flags+=(--net-rule "allow@${_npm_host}")
+    done
+  fi
 
   # TLS interception is REQUIRED for secret substitution: msb only swaps a
   # placeholder for the real value on a connection it can see into (the security
@@ -726,6 +771,20 @@ acq_backend_provision() {
   # as the wrong user against a non-existent home. Create it once, idempotently.
   _acq_msb_ensure_agent_user "$name"
 
+  # Install the requested agent binary (sbx bakes it into the template image; on
+  # a plain msb base acq must install it). Idempotent + marker-gated; a no-op for
+  # `shell`, a clear warning for an agent with no known recipe.
+  _acq_msb_install_agent "$name" "$agent"
+
+  # Record which agent this sandbox runs, so acq_backend_attach (which only gets
+  # the sandbox name) knows what to launch — the sbx equivalent is that
+  # `sbx run --name` re-launches the agent baked in at create. Written as root to
+  # a fixed guest path; validated charset (KNOWN_AGENTS tokens are word-safe).
+  case "$agent" in
+    *[!a-z-]*) : ;;  # defensive: never write an odd token
+    *) msb exec "$name" -u 0 -- sh -c "mkdir -p /var/lib/acq && printf '%s' '$agent' > /var/lib/acq/agent" >/dev/null 2>&1 || true ;;
+  esac
+
   # Apply each kit's files + commands.
   local kd
   for kd in "${kitdirs[@]}"; do
@@ -734,20 +793,104 @@ acq_backend_provision() {
 }
 
 # ---------------------------------------------------------------------------
-# _acq_msb_ensure_agent_user NAME — guarantee the kits' agent/uid-1000 contract
+# _acq_msb_agent_has_install_recipe AGENT — 0 if acq knows how to install AGENT
 # ---------------------------------------------------------------------------
-# The neutral kits assume the sbx agent-template contract: a user named `agent`
-# whose HOME is /home/agent, addressable as `-u 1000`. Plain OCI bases don't
-# provide it (node:22-bookworm ships `node` at uid 1000 with HOME=/home/node).
-# Create `agent` with home /home/agent, marker-gated so it runs once. Runs fully
-# offline (useradd/adduser need no network). The uid is configurable but
-# defaults to 1000; if 1000 is already taken by another user (e.g. `node`), we
-# still create `agent` at the next free uid AND ensure the kits' `-u 1000`
-# commands map to it by making `agent` own /home/agent and exporting HOME.
-#
-# The adapter runs kit commands via _acq_msb_exec_command, which translates a
-# kit `user: "1000"` to the agent user (see that function). So the guest only
-# needs: an `agent` user, /home/agent owned by it.
+# `shell` needs no binary; today only `opencode` has a recipe. Others are baked
+# into ACQ_MSB_IMAGE by the user (warned at install time). Keep this in sync with
+# _acq_msb_install_agent's case.
+_acq_msb_agent_has_install_recipe() {
+  case "$1" in
+    opencode) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# _acq_msb_install_agent NAME AGENT — install the agent binary into the guest
+# ---------------------------------------------------------------------------
+# sbx's agent templates ship the binary; msb runs a plain base, so acq installs
+# it. For `opencode`, install the npm package globally as root (node is a
+# verified base prerequisite; the registry host was allow-listed at create).
+# Idempotent: skip if the binary is already present (a pre-baked ACQ_MSB_IMAGE),
+# and marker-gate so a re-apply doesn't reinstall. `shell` is a no-op; an unknown
+# agent is a non-fatal warning (the sandbox still comes up; the user can bake the
+# binary into ACQ_MSB_IMAGE).
+_acq_msb_install_agent() {
+  local name="$1" agent="$2"
+
+  case "$agent" in
+    shell|"") acq_debug "msb: agent '$agent' needs no binary install"; return 0 ;;
+  esac
+
+  if ! _acq_msb_agent_has_install_recipe "$agent"; then
+    # Maybe the base image already provides it — don't warn if so.
+    if msb exec "$name" -u 0 -- sh -c "command -v '$agent'" >/dev/null 2>&1; then
+      acq_debug "msb: agent '$agent' already present in base image"
+      return 0
+    fi
+    echo "acq(msb): warning: no install recipe for agent '$agent' and it is not in the" >&2
+    echo "acq(msb):   base image. Attach will fail to launch it. Bake '$agent' into" >&2
+    echo "acq(msb):   ACQ_MSB_IMAGE, or use an agent acq can install (e.g. opencode)." >&2
+    return 0
+  fi
+
+  # Already installed (pre-baked image or a prior apply)? Then done.
+  if msb exec "$name" -u 0 -- sh -c "command -v '$agent'" >/dev/null 2>&1; then
+    acq_debug "msb: agent '$agent' already installed in $name"
+    return 0
+  fi
+
+  local marker="/var/lib/acq/agent-installed-${agent}"
+  if msb exec "$name" -u 0 -- sh -c "test -f '$marker'" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  case "$agent" in
+    opencode)
+      acq_debug "msb: installing opencode ($ACQ_MSB_OPENCODE_PKG) via npm in $name"
+      # Install globally as root so the binary lands on the system PATH for every
+      # user (the agent runs as `agent`). The package spec is passed as a single
+      # argv element (never re-split by a shell); ACQ_MSB_OPENCODE_PKG is a
+      # controlled tunable. `npm` is present (node prerequisite). npm needs the
+      # registry host, allow-listed at create.
+      if ! msb exec "$name" -u 0 -- npm install -g --no-fund --no-audit "$ACQ_MSB_OPENCODE_PKG" >/dev/null 2>&1; then
+        echo "acq(msb): warning: 'npm install -g $ACQ_MSB_OPENCODE_PKG' failed in '$name'." >&2
+        echo "acq(msb):   opencode will not be available on attach. Common causes: the npm" >&2
+        echo "acq(msb):   registry host (${ACQ_MSB_NPM_HOSTS}) is not reachable/allow-listed," >&2
+        echo "acq(msb):   or npm is missing. Set ACQ_MSB_NPM_HOSTS for an internal mirror," >&2
+        echo "acq(msb):   or bake opencode into ACQ_MSB_IMAGE." >&2
+        return 0
+      fi
+      ;;
+  esac
+
+  # Verify the binary is now on PATH before recording the marker.
+  if msb exec "$name" -u 0 -- sh -c "command -v '$agent'" >/dev/null 2>&1; then
+    msb exec "$name" -u 0 -- sh -c "mkdir -p /var/lib/acq && touch '$marker'" >/dev/null 2>&1 || true
+    acq_debug "msb: agent '$agent' installed and on PATH in $name"
+  else
+    echo "acq(msb): warning: installed '$agent' but it is not on PATH in '$name'." >&2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# _acq_msb_ensure_agent_user NAME — satisfy the sbx/Docker base-image contract
+# ---------------------------------------------------------------------------
+# sbx's agent templates are built on `docker/sandbox-templates:shell-docker`,
+# whose PUBLISHED base-image requirements are (Docker kit-reference,
+# "Base image requirements"):
+#   - a non-root `agent` user at UID 1000 with PASSWORDLESS SUDO
+#   - a /home/agent home directory owned by `agent`
+#   - HTTP proxy env (HTTP_PROXY/HTTPS_PROXY/NO_PROXY) PRESERVED ACROSS SUDO
+#   - the agent binary (baked in, or installed via commands.install)
+# A plain OCI base (e.g. node:22-bookworm, which ships `node` at uid 1000 and no
+# `agent`, and no sudoers rule) meets NONE of the first three. The msb adapter
+# therefore synthesizes them here so both the kits (which run as `-u 1000`) and
+# the agent behave as they do on sbx. Idempotent + marker-gated; runs fully
+# offline (useradd/adduser/sudoers edits need no network). The uid defaults to
+# 1000; if 1000 is taken (e.g. by `node`), `agent` is created at the next free
+# uid and the kits' `-u 1000` commands still map to it by NAME (see
+# _acq_msb_exec_command) with HOME exported.
 _acq_msb_ensure_agent_user() {
   local name="$1"
   local marker="/var/lib/acq/agent-user-ready"
@@ -755,7 +898,7 @@ _acq_msb_ensure_agent_user() {
     return 0
   fi
 
-  acq_debug "msb: ensuring agent user + /home/agent in $name"
+  acq_debug "msb: ensuring agent user + /home/agent + passwordless sudo + proxy-preserve in $name"
   # Idempotent, distro-agnostic. If an `agent` user already exists, reuse it.
   # Otherwise create it: prefer uid 1000, but if that uid is taken, let the tool
   # pick a free uid (the kits address the user by name via our exec translation,
@@ -778,11 +921,28 @@ _acq_msb_ensure_agent_user() {
     fi
     mkdir -p /home/agent
     chown -R agent:agent /home/agent 2>/dev/null || chown -R agent /home/agent 2>/dev/null || true
+
+    # Passwordless sudo for agent (base-image requirement). Only if sudo exists;
+    # a base without sudo still works for our purposes (kit/agent commands that
+    # need root are run by acq as -u 0 directly), so a missing sudo is non-fatal.
+    if command -v sudo >/dev/null 2>&1; then
+      mkdir -p /etc/sudoers.d
+      printf "agent ALL=(ALL) NOPASSWD:ALL\n" > /etc/sudoers.d/90-acq-agent
+      chmod 0440 /etc/sudoers.d/90-acq-agent
+      # Preserve HTTP proxy env across sudo (base-image requirement). msb sets
+      # HTTP_PROXY/HTTPS_PROXY/NO_PROXY for the TLS-intercepting proxy; without
+      # env_keep they are stripped on sudo, breaking egress from elevated cmds.
+      printf "Defaults env_keep += \"HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy\"\n" \
+        > /etc/sudoers.d/91-acq-proxy-env
+      chmod 0440 /etc/sudoers.d/91-acq-proxy-env
+    fi
   ' || {
-    echo "acq(msb): warning: could not create the 'agent' user in '$name'." >&2
+    echo "acq(msb): warning: could not fully satisfy the agent-user base-image contract in '$name'." >&2
     echo "acq(msb):   kit commands that run as the agent user (e.g. the usai merge)" >&2
-    echo "acq(msb):   may fail. Use an ACQ_MSB_IMAGE that provides an 'agent' user" >&2
-    echo "acq(msb):   with HOME=/home/agent, or a base with useradd/adduser." >&2
+    echo "acq(msb):   or agent commands needing passwordless sudo may fail. Use an" >&2
+    echo "acq(msb):   ACQ_MSB_IMAGE built on docker/sandbox-templates:shell-docker (or one" >&2
+    echo "acq(msb):   providing an 'agent' user at uid 1000 with passwordless sudo and" >&2
+    echo "acq(msb):   HOME=/home/agent), or a base with useradd/adduser + sudo." >&2
     return 0
   }
   msb exec "$name" -u 0 -- sh -c "mkdir -p /var/lib/acq && touch '$marker'" >/dev/null 2>&1 || true
@@ -835,16 +995,67 @@ acq_backend_run() {
 # ---------------------------------------------------------------------------
 # acq_backend_attach — interactive attach (TTY) via SSH
 # ---------------------------------------------------------------------------
-
+# sbx's `sbx run --name NAME` re-launches the agent baked into the sandbox at
+# create. msb's `msb ssh NAME` only opens a shell (as root, msb's default SSH
+# user), so acq must reproduce sbx's behavior itself: drop to the `agent` user,
+# cd into the workspace, and exec the recorded agent (opencode, …). A bare `acq
+# run <sandbox>` re-attach (no agent token) reads the agent recorded at provision
+# from /var/lib/acq/agent; `shell` (or a missing/failed agent) falls back to an
+# interactive shell as `agent` — never a root shell.
+#
+# Post-`--` args are forwarded to the agent (e.g. `-- --task "run tests"`).
 acq_backend_attach() {
   local name="$1"
   shift
+
+  # Explicit `-- CMD…` after the sandbox name: run exactly that (advanced/escape
+  # hatch), still as the agent user in the workspace.
   if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
     shift
-    msb ssh "$name" -- "$@"
-  else
-    msb ssh "$name"
+    _acq_msb_ssh_agent "$name" "$@"
+    return $?
   fi
+  _acq_msb_ssh_agent "$name"
+}
+
+# _acq_msb_ssh_agent NAME [AGENT_ARGS...] — SSH in as `agent`, cd to the
+# workspace, and launch the recorded agent (or a shell). AGENT_ARGS are appended
+# to the agent invocation. Uses a login shell so PATH picks up the globally
+# installed agent binary.
+_acq_msb_ssh_agent() {
+  local name="$1"
+  shift
+
+  local ws="${ACQ_MSB_WORKSPACE:-/home/agent/workspace}"
+
+  # Read the agent recorded at provision. Default to `shell` if unset (older
+  # sandbox, or a `shell` sandbox).
+  local agent
+  agent=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/agent 2>/dev/null' 2>/dev/null | tr -d '\r\n[:space:]')
+  [ -n "$agent" ] || agent="shell"
+
+  # Build the remote command run as the agent user. cd to the workspace if it
+  # exists; then exec the agent (or an interactive shell). If the agent binary is
+  # somehow absent, fall back to a shell rather than failing the attach — but say
+  # so, so the user isn't staring at a bare prompt wondering why.
+  local remote
+  if [ "$agent" = "shell" ]; then
+    remote="cd '$ws' 2>/dev/null; exec \$SHELL -l"
+  else
+    # AGENT_ARGS (already shell-safe from the user's own invocation) are joined
+    # with single-quote escaping so they survive the remote sh -c.
+    local extra=""
+    local a
+    for a in "$@"; do
+      extra="$extra '$(printf '%s' "$a" | sed "s/'/'\\\\''/g")'"
+    done
+    remote="cd '$ws' 2>/dev/null; if command -v '$agent' >/dev/null 2>&1; then exec '$agent'$extra; else echo \"acq(msb): '$agent' not found in sandbox; opening a shell instead.\" >&2; exec \$SHELL -l; fi"
+  fi
+
+  # `msb ssh NAME -- CMD` runs CMD (msb's default SSH user is root); we drop to
+  # the agent user via `su` so the agent runs unprivileged in its own HOME, the
+  # same posture as sbx. `su - agent` gives a login environment (PATH/HOME).
+  msb ssh "$name" -- su - agent -c "$remote"
 }
 
 # ---------------------------------------------------------------------------

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -96,6 +96,27 @@ ACQ_MSB_USAI_HOST="api.gsa.usai.gov"
 # preferred id but not required — kit commands address the user by name.
 ACQ_MSB_AGENT_UID="${ACQ_MSB_AGENT_UID:-1000}"
 
+# Guest memory and vCPU allocation.
+# ---------------------------------------------------------------------------
+# msb 0.6.x defaults a sandbox to 512 MiB RAM and 1 vCPU (see the microsandbox
+# config defaults DEFAULT_MEMORY_MIB=512 / DEFAULT_CPUS=1). The microVM has NO
+# swap, so a process that exceeds guest RAM is OOM-killed by the guest kernel and
+# simply prints "Killed". A Node.js agent TUI like opencode blows past 512 MiB
+# immediately, so a create with no memory flag left the user with an agent that
+# started and was instantly killed (quickstart#228 follow-up). sbx sizes its
+# agent templates generously; msb runs a plain base and must be told, so acq
+# passes a generous default here (4 GiB / 2 vCPU) and lets it be tuned.
+#
+# `msb create` accepts `-m/--memory SIZE` and `-c/--cpus N` (verified against the
+# microsandbox SandboxOpts). SIZE takes a single-char unit suffix: `G`/`g` = GiB,
+# `M`/`m` = MiB, and a bare number = MiB (there is NO multi-char MiB/GiB suffix).
+# So `4G`, `4096`, and `4g` are equivalent. Set ACQ_MSB_MEMORY empty to omit the
+# flag and fall back to msb's 512 MiB default (uses `-`, not `:-`, so an
+# explicitly-empty value disables the flag rather than re-defaulting). Same for
+# ACQ_MSB_CPUS.
+ACQ_MSB_MEMORY="${ACQ_MSB_MEMORY-4G}"
+ACQ_MSB_CPUS="${ACQ_MSB_CPUS-2}"
+
 # DNS nameserver for the guest. msb hands the guest the HOST's resolvers, but a
 # corporate/VPN resolver (e.g. 172.16.x, Zscaler) is typically unreachable from
 # the microVM's network namespace — so the guest cannot resolve even the
@@ -651,6 +672,36 @@ acq_backend_provision() {
   # ACQ_MSB_DNS_NAMESERVER note above.
   if [ -n "$ACQ_MSB_DNS_NAMESERVER" ]; then
     create_flags+=(--dns-nameserver "$ACQ_MSB_DNS_NAMESERVER")
+  fi
+
+  # Guest RAM / vCPU. msb defaults to 512 MiB / 1 vCPU — too small for a Node.js
+  # agent TUI (opencode), which the guest OOM-kills on launch (prints "Killed";
+  # the microVM has no swap). Pass a generous default (tunable via ACQ_MSB_MEMORY
+  # / ACQ_MSB_CPUS; empty = omit and use msb's own default). The memory value is
+  # validated to msb's SIZE grammar (digits with optional single-char G/M/g/m
+  # suffix) so a stray value can't smuggle another flag; cpus must be a positive
+  # integer.
+  if [ -n "$ACQ_MSB_MEMORY" ]; then
+    case "$ACQ_MSB_MEMORY" in
+      *[!0-9GMgm.]*|"")
+        echo "acq(msb): warning: ignoring invalid ACQ_MSB_MEMORY='$ACQ_MSB_MEMORY'" \
+             "(expected e.g. 4G, 4096, 512M)." >&2
+        ;;
+      *)
+        create_flags+=(--memory "$ACQ_MSB_MEMORY")
+        ;;
+    esac
+  fi
+  if [ -n "$ACQ_MSB_CPUS" ]; then
+    case "$ACQ_MSB_CPUS" in
+      *[!0-9]*|0|"")
+        echo "acq(msb): warning: ignoring invalid ACQ_MSB_CPUS='$ACQ_MSB_CPUS'" \
+             "(expected a positive integer)." >&2
+        ;;
+      *)
+        create_flags+=(--cpus "$ACQ_MSB_CPUS")
+        ;;
+    esac
   fi
 
   # Translate the caller's workspace path into a --volume mount. The agent token

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -236,15 +236,27 @@ acq_backend_exists() {
 # in the background. Copying files / running kit commands before exec works
 # races the boot. Poll a trivial exec until it succeeds (or time out). Mirrors
 # sbx.sh's _acq_sbx_wait_for_exec_ready.
+#
+# Each probe emits a timestamped acq_debug breadcrumb (attempt #, rc, output) so
+# that if provision ever stalls in this loop it is visible which probe hung —
+# use `ACQ_DEBUG=1` (or `verify-backends -x`) to see it.
 _acq_msb_wait_for_exec_ready() {
-  local name="$1" deadline out
+  local name="$1" deadline out _rc _attempt=0 _now
   deadline=$(( $(date +%s) + ACQ_MSB_EXEC_READY_TIMEOUT ))
   while :; do
+    _attempt=$(( _attempt + 1 ))
+    acq_debug "msb exec-ready probe #${_attempt} for $name"
     out=$(msb exec "$name" -- sh -c 'echo ok' </dev/null 2>/dev/null | tr -d '\r')
+    _rc=$?
+    acq_debug "msb exec-ready probe #${_attempt}: rc=${_rc} out='${out}'"
     case "$out" in
-      *ok*) acq_debug "msb exec-ready: $name"; return 0 ;;
+      *ok*) acq_debug "msb exec-ready: $name (after ${_attempt} probe(s))"; return 0 ;;
     esac
-    [ "$(date +%s)" -ge "$deadline" ] && return 1
+    _now=$(date +%s)
+    if [ "$_now" -ge "$deadline" ]; then
+      acq_debug "msb exec-ready: giving up on $name after ${_attempt} probe(s) / ${ACQ_MSB_EXEC_READY_TIMEOUT}s"
+      return 1
+    fi
     sleep 2
   done
 }
@@ -551,6 +563,21 @@ _acq_msb_exec_command() {
     eflag+=(-e "$_ev")
   done
 
+  # NON-INTERACTIVE ENFORCEMENT. Kit lifecycle commands run before the agent
+  # attaches, with no terminal, so they MUST NOT try to read from a TTY. Docker's
+  # kit-reference states startup commands are non-interactive; a kit that prompts
+  # (e.g. `git clone` of a private repo with no credential -> "Username for
+  # 'https://github.com':") would BLOCK provision forever (observed: the playbook
+  # kit hung here). Defense-in-depth alongside the kit's own prompt-suppression:
+  #   - stdin from /dev/null for every kit exec, so nothing can read the TTY.
+  #   - GIT_TERMINAL_PROMPT=0 (+ GIT_ASKPASS/SSH_ASKPASS=false) so git fails fast
+  #     instead of prompting. These are injected only if the kit did not already
+  #     set GIT_TERMINAL_PROMPT (kits may override intentionally).
+  case " ${_kit_env[*]-} " in
+    *" GIT_TERMINAL_PROMPT="*) : ;;
+    *) eflag+=(-e "GIT_TERMINAL_PROMPT=0" -e "GIT_ASKPASS=/bin/false" -e "SSH_ASKPASS=/bin/false") ;;
+  esac
+
   if [ "$phase" = "install" ]; then
     # Idempotency marker keyed by a hash of the argv. The marker lives under
     # /var/lib/acq (root-owned) and is both TESTED and WRITTEN as uid 0, so the
@@ -559,19 +586,26 @@ _acq_msb_exec_command() {
     # root-created marker, which would otherwise re-run it every apply).
     local marker
     marker="/var/lib/acq/install-$(printf '%s\0' "$@" | cksum | cut -d' ' -f1)"
-    if msb exec "$name" -u 0 -- sh -c "test -f '$marker'" >/dev/null 2>&1; then
+    if msb exec "$name" -u 0 -- sh -c "test -f '$marker'" </dev/null >/dev/null 2>&1; then
+      acq_debug "msb cmd[install] already done (marker hit): $*"
       return 0
     fi
-    msb exec "$name" "${uflag[@]}" ${eflag[@]+"${eflag[@]}"} -- "$@" || {
+    acq_debug "msb cmd[install] START (user=${user:-0}): $*"
+    msb exec "$name" "${uflag[@]}" ${eflag[@]+"${eflag[@]}"} -- "$@" </dev/null || {
+      acq_debug "msb cmd[install] FAILED: $*"
       echo "acq(msb): warning: install command failed for '$name'" >&2
       return 0
     }
-    msb exec "$name" -u 0 -- sh -c "mkdir -p /var/lib/acq && touch '$marker'" >/dev/null 2>&1 || true
+    acq_debug "msb cmd[install] DONE: $*"
+    msb exec "$name" -u 0 -- sh -c "mkdir -p /var/lib/acq && touch '$marker'" </dev/null >/dev/null 2>&1 || true
   else
     # initFiles / startup — run every apply (they are written idempotent).
-    msb exec "$name" "${uflag[@]}" ${eflag[@]+"${eflag[@]}"} -- "$@" || {
+    acq_debug "msb cmd[${phase}] START (user=${user:-0}): $*"
+    msb exec "$name" "${uflag[@]}" ${eflag[@]+"${eflag[@]}"} -- "$@" </dev/null || {
+      acq_debug "msb cmd[${phase}] FAILED: $*"
       echo "acq(msb): warning: ${phase} command failed for '$name'" >&2
     }
+    acq_debug "msb cmd[${phase}] DONE: $*"
   fi
 }
 
@@ -816,7 +850,9 @@ EOF
   # below ever run.
   acq_debug "msb create --name $name ${create_flags[*]} $ACQ_MSB_IMAGE"
   local _create_rc=0
+  acq_debug "msb create: invoking (this returns fast; guest boots in background)"
   msb create --name "$name" "${create_flags[@]}" "$ACQ_MSB_IMAGE" || _create_rc=$?
+  acq_debug "msb create: returned rc=${_create_rc}"
   # Clear the transient secret env vars immediately after create reads them
   # (runs on both success and failure so the exported key never lingers).
   local _ev
@@ -843,6 +879,7 @@ EOF
   # `msb exec` works. Treat a non-ready sandbox as a HARD provision failure —
   # otherwise kit application (and every downstream check) runs against a
   # sandbox that isn't really up, which looks like success but silently isn't.
+  acq_debug "msb provision: waiting for exec-ready ($name)"
   if ! _acq_msb_wait_for_exec_ready "$name"; then
     echo "acq(msb): error: sandbox '$name' did not become exec-ready within" >&2
     echo "acq(msb):   ${ACQ_MSB_EXEC_READY_TIMEOUT}s. 'msb create' returns 0 even when the" >&2
@@ -854,24 +891,31 @@ EOF
     # Leave the sandbox in place for inspection; caller decides whether to rm.
     return 1
   fi
+  acq_debug "msb provision: exec-ready OK ($name)"
 
   # Verify the kits' runtime prerequisites are present in the base image
   # (node/git/curl/update-ca-certificates). We do NOT install them: the kit
   # net-rules lock egress to the kits' own hosts, so a package mirror is
   # unreachable during provision. Missing tools => a clear, actionable warning.
+  acq_debug "msb provision: checking prereqs ($name)"
   _acq_msb_check_prereqs "$name"
+  acq_debug "msb provision: prereqs checked ($name)"
 
   # Ensure the `agent` user (uid ACQ_MSB_AGENT_UID) with HOME=/home/agent exists.
   # The pinned kits stage files under /home/agent and run startup commands as
   # that user (the sbx agent template guarantees this user). A plain OCI base
   # (e.g. node:22-bookworm) has no `agent` user, so their `-u 1000` commands ran
   # as the wrong user against a non-existent home. Create it once, idempotently.
+  acq_debug "msb provision: ensuring agent user ($name)"
   _acq_msb_ensure_agent_user "$name"
+  acq_debug "msb provision: agent user ready ($name)"
 
   # Install the requested agent binary (sbx bakes it into the template image; on
   # a plain msb base acq must install it). Idempotent + marker-gated; a no-op for
   # `shell`, a clear warning for an agent with no known recipe.
+  acq_debug "msb provision: installing agent '$agent' ($name)"
   _acq_msb_install_agent "$name" "$agent"
+  acq_debug "msb provision: agent install step done ($name)"
 
   # Record which agent this sandbox runs, so acq_backend_attach (which only gets
   # the sandbox name) knows what to launch — the sbx equivalent is that
@@ -899,8 +943,11 @@ EOF
   # Apply each kit's files + commands.
   local kd
   for kd in "${kitdirs[@]}"; do
+    acq_debug "msb provision: applying kit dir $kd ($name)"
     _acq_msb_apply_kit_dir "$name" "$kd"
+    acq_debug "msb provision: applied kit dir $kd ($name)"
   done
+  acq_debug "msb provision: all kits applied; provision complete ($name)"
 }
 
 # ---------------------------------------------------------------------------

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -1029,6 +1029,19 @@ _acq_msb_agent_has_install_recipe() {
   esac
 }
 
+# _acq_msb_safe_agent_token AGENT -> 0 if AGENT is a safe agent token to
+# interpolate into a shell command. Agent tokens are short lowercase names
+# (opencode, claude, shell, …); restrict to [a-z-] so a value can never break
+# out of the `sh -c "command -v '$agent'"` single-quoting (defense against a
+# `acq create "x';…'"` arg or a tampered /var/lib/acq/agent marker). Callers
+# that build an `sh -c` string with $agent MUST gate on this first.
+_acq_msb_safe_agent_token() {
+  case "$1" in
+    ""|*[!a-z-]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 # ---------------------------------------------------------------------------
 # _acq_msb_install_agent NAME AGENT — install the agent binary into the guest
 # ---------------------------------------------------------------------------
@@ -1045,6 +1058,15 @@ _acq_msb_install_agent() {
   case "$agent" in
     shell|"") acq_debug "msb: agent '$agent' needs no binary install"; return 0 ;;
   esac
+
+  # Charset-guard the agent token before it enters any `sh -c "… '$agent' …"`.
+  # `acq create <agent> <path>` does not go through is_known_agent, so a hostile
+  # token (e.g. "x';touch /tmp/pwn;'") could otherwise break the single-quoting
+  # and run as root. Refuse anything outside [a-z-].
+  if ! _acq_msb_safe_agent_token "$agent"; then
+    echo "acq(msb): refusing agent name with unexpected characters: '$agent'" >&2
+    return 0
+  fi
 
   if ! _acq_msb_agent_has_install_recipe "$agent"; then
     # Maybe the base image already provides it — don't warn if so.
@@ -1296,10 +1318,16 @@ _acq_msb_attach() {
   fi
   [ -n "$ws" ] || ws="/home/agent"
 
-  # Read the agent recorded at provision. Default to `shell` if unset.
+  # Read the agent recorded at provision. Default to `shell` if unset. The value
+  # comes from a guest file (/var/lib/acq/agent); charset-guard it before it
+  # enters the `sh -c "command -v '$agent'"` below, since a tampered marker could
+  # otherwise break the single-quoting and run as the agent user. Fall back to a
+  # plain shell on anything unexpected.
   local agent
   agent=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/agent 2>/dev/null' </dev/null 2>/dev/null | tr -d '[:space:]')
-  [ -n "$agent" ] || agent="shell"
+  if [ -z "$agent" ] || ! _acq_msb_safe_agent_token "$agent"; then
+    agent="shell"
+  fi
 
   # Common flags for the interactive attach: PTY, agent user, workspace cwd, and
   # a sane $SHELL (msb's default interactive shell is the base image's Node REPL).
@@ -1448,15 +1476,23 @@ acq_backend_secret_set() {
   # not just usai. A named scope targets that sandbox; a global set sweeps all
   # running sandboxes. The real value is read from the acq store into a TRANSIENT
   # env var (never argv) that `msb modify` reads, then cleared.
+  #
+  # SECRET NEVER ON ARGV: the value is placed in the environment via a dynamic
+  # `export "$_env=$val"` (an env ENTRY, invisible to `ps`/`/proc/<pid>/cmdline`),
+  # NOT via `env NAME=VAL msb …` — there NAME=VAL is an OPERAND on env(1)'s argv
+  # and would leak the token to any `ps -ww` for the life of the child. The var
+  # is unset immediately after each call.
   local _env _host _binding val applied=0 sb
   _binding=$(_acq_msb_service_binding "$service")
   _env=$(printf '%s' "$_binding" | cut -f1)
   _host=$(printf '%s' "$_binding" | cut -f2)
   if [ -n "$_env" ] && [ -n "$_host" ]; then
     if val=$(acq_secret_resolve "$service" "$scope_name" 2>/dev/null) && [ -n "$val" ]; then
+      # shellcheck disable=SC2163  # dynamic export of the resolved binding env var
+      export "$_env=$val"
       if [ -n "$scope_name" ]; then
         if acq_backend_exists "$scope_name"; then
-          env "$_env=$val" msb modify "$scope_name" --secret "${_env}@${_host}" </dev/null >/dev/null 2>&1 \
+          msb modify "$scope_name" --secret "${_env}@${_host}" </dev/null >/dev/null 2>&1 \
             && applied=$((applied + 1))
         fi
       else
@@ -1465,12 +1501,13 @@ acq_backend_secret_set() {
         # stdin). Same trap guarded in acq_backend_secret_rm's sweep.
         while IFS= read -r sb; do
           [ -n "$sb" ] || continue
-          env "$_env=$val" msb modify "$sb" --secret "${_env}@${_host}" </dev/null >/dev/null 2>&1 \
+          msb modify "$sb" --secret "${_env}@${_host}" </dev/null >/dev/null 2>&1 \
             && applied=$((applied + 1))
         done <<EOF
 $(msb list -q 2>/dev/null)
 EOF
       fi
+      unset "$_env"
       val=""
       [ "$applied" -gt 0 ] && acq_debug "msb modify: re-fed $service (${_env}@${_host}) to $applied sandbox(es)"
     fi

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -704,25 +704,71 @@ acq_backend_provision() {
     esac
   fi
 
-  # Translate the caller's workspace path into a --volume mount. The agent token
-  # is the first positional; the workspace path follows. msb does NOT create the
-  # host mount path and it FAILS to mount when the guest path mirrors an absolute
-  # host path under /tmp (verified: identical host:guest under /tmp starts but
-  # the mount silently doesn't appear). So we mount the host workspace at a fixed
-  # conventional guest path under the agent home (ACQ_MSB_WORKSPACE), which works
-  # reliably. The chosen guest path is exported so the run/attach path can cd there.
-  local ws
-  ws=$(workspace_path "$@")
+  # Translate the caller's workspace path(s) into --volume mounts.
+  #
+  # CONTRACT (matches sbx semantics — see docs/QUICKSTART_SBX.md "Multiple
+  # Workspaces"): every workspace positional after the agent is mounted at its
+  # SAME absolute path inside the guest ("All workspaces appear inside the
+  # sandbox at their absolute host paths."). A trailing `:ro` marks that mount
+  # read-only. `acq run opencode ~/app ~/lib:ro` therefore mounts ~/app rw and
+  # ~/lib ro, each at its own host path.
+  #
+  # STARTING DIRECTORY (ACQ_MSB_GUEST_WORKSPACE, consumed by attach): the FIRST
+  # workspace positional is the "primary" — the agent starts there — regardless
+  # of how many mounts are given (docs/QUICKSTART_SBX.md: "Primary workspace —
+  # The first path; agent starts here."). ACQ_MSB_WORKSPACE overrides it.
+  #
+  # Why mount at the host path (not remapped under /home/agent): `msb create`
+  # performs the mount at create time, BEFORE acq can create the `agent` user and
+  # /home/agent (that happens post-create, once the guest is exec-ready). A plain
+  # base (node:22-bookworm) has no /home/agent, so mounting into it failed with
+  # "mount ...: Not a directory (os error 20)". Mounting at the host's own
+  # absolute path sidesteps the ordering problem and matches sbx. NOTE: msb also
+  # cannot mount a SYMLINKED host path (e.g. macOS $TMPDIR under /var ->
+  # /private/var); each path is canonicalized below before the mount.
+  local _ws_recs=() wline
+  while IFS= read -r wline; do
+    [ -n "$wline" ] && _ws_recs+=("$wline")
+  done <<EOF
+$(workspace_paths "$@")
+EOF
+
   ACQ_MSB_GUEST_WORKSPACE=""
-  if [ -n "$ws" ]; then
-    if [ ! -d "$ws" ]; then
-      echo "acq(msb): error: workspace path does not exist on the host: $ws" >&2
+  local _wi _wspec _wpath _wro _first_guest=""
+  for _wi in ${_ws_recs[@]+"${!_ws_recs[@]}"}; do
+    _wspec="${_ws_recs[$_wi]}"
+    # Split an optional trailing ":ro" (read-only) marker from the path.
+    _wro=""
+    case "$_wspec" in
+      *:ro) _wpath="${_wspec%:ro}"; _wro=":ro" ;;
+      *)    _wpath="$_wspec" ;;
+    esac
+    if [ ! -d "$_wpath" ]; then
+      echo "acq(msb): error: workspace path does not exist on the host: $_wpath" >&2
       echo "acq(msb):   msb cannot mount a nonexistent host path. Create it first." >&2
       return 1
     fi
-    ACQ_MSB_GUEST_WORKSPACE="${ACQ_MSB_WORKSPACE:-/home/agent/workspace}"
-    create_flags+=(--volume "${ws}:${ACQ_MSB_GUEST_WORKSPACE}")
-    acq_debug "msb volume: ${ws} -> ${ACQ_MSB_GUEST_WORKSPACE}"
+    # Canonicalize to the real, symlink-free path before mounting. msb cannot
+    # mount a symlinked host path (verified on 0.6.6: a macOS $TMPDIR path under
+    # the /var -> /private/var symlink fails to start with
+    # "mount ...: Not a directory (os error 20)", even mapped to a shallow guest
+    # target). Resolving to /private/var/... lets the mount succeed. Falls back
+    # to the original path if it cannot be resolved.
+    if command -v canonicalize_path >/dev/null 2>&1; then
+      _wpath=$(canonicalize_path "$_wpath")
+    fi
+    # Mount at the same absolute path in the guest (sbx-parity), preserving :ro.
+    create_flags+=(--volume "${_wpath}:${_wpath}${_wro}")
+    acq_debug "msb volume: ${_wpath} -> ${_wpath}${_wro}"
+    [ -z "$_first_guest" ] && _first_guest="$_wpath"
+  done
+
+  # Decide the agent's starting directory (recorded for attach). Explicit
+  # override wins; otherwise the FIRST (primary) workspace, matching sbx.
+  if [ -n "${ACQ_MSB_WORKSPACE:-}" ]; then
+    ACQ_MSB_GUEST_WORKSPACE="$ACQ_MSB_WORKSPACE"
+  elif [ -n "$_first_guest" ]; then
+    ACQ_MSB_GUEST_WORKSPACE="$_first_guest"
   fi
 
   # Credentials: read from the acq-owned secret store (keychain/file), scoped to
@@ -835,6 +881,20 @@ acq_backend_provision() {
     *[!a-z-]*) : ;;  # defensive: never write an odd token
     *) msb exec "$name" -u 0 -- sh -c "mkdir -p /var/lib/acq && printf '%s' '$agent' > /var/lib/acq/agent" >/dev/null 2>&1 || true ;;
   esac
+
+  # Record the guest workspace path too. attach only gets the sandbox NAME, so it
+  # cannot recompute the host→guest mapping (which now mirrors the host path);
+  # persist it so a name-only re-attach cds into the right place. The path was
+  # validated as an existing host dir above; guard the charset before it enters a
+  # root sh -c string.
+  if [ -n "$ACQ_MSB_GUEST_WORKSPACE" ]; then
+    case "$ACQ_MSB_GUEST_WORKSPACE" in
+      *[!A-Za-z0-9._/-]*)
+        acq_debug "msb: not recording unsafe guest workspace path: $ACQ_MSB_GUEST_WORKSPACE" ;;
+      *)
+        msb exec "$name" -u 0 -- sh -c "mkdir -p /var/lib/acq && printf '%s' '$ACQ_MSB_GUEST_WORKSPACE' > /var/lib/acq/workspace" >/dev/null 2>&1 || true ;;
+    esac
+  fi
 
   # Apply each kit's files + commands.
   local kd
@@ -1077,7 +1137,15 @@ _acq_msb_ssh_agent() {
   local name="$1"
   shift
 
-  local ws="${ACQ_MSB_WORKSPACE:-/home/agent/workspace}"
+  # Determine the workspace to cd into. Prefer an explicit ACQ_MSB_WORKSPACE
+  # override; otherwise read the guest path recorded at provision (which now
+  # mirrors the host mount path, so it can't be recomputed from NAME alone).
+  # Fall back to the agent home only if nothing was recorded (older sandbox).
+  local ws="${ACQ_MSB_WORKSPACE:-}"
+  if [ -z "$ws" ]; then
+    ws=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' 2>/dev/null | tr -d '\r\n')
+  fi
+  [ -n "$ws" ] || ws="/home/agent"
 
   # Read the agent recorded at provision. Default to `shell` if unset (older
   # sandbox, or a `shell` sandbox).

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -1142,6 +1142,19 @@ _acq_msb_ensure_agent_user() {
     su agent -s /bin/sh -c "test -w /home/agent" 2>/dev/null \
       || { echo "acq(msb): /home/agent is not writable by the agent user" >&2; exit 1; }
 
+    # Set SHELL=/bin/sh in the agent profile. The passwd shell is /bin/sh, but
+    # SHELL is not populated by `msb exec`/`su -c`, and msb interactive-exec
+    # ignores the passwd shell entirely (it drops to the base image default, a
+    # Node REPL on node:22-bookworm). acq always execs an explicit shell/agent, so
+    # this is cosmetic (tools that read SHELL) but correct and cheap. Idempotent.
+    # NOTE: this whole block is a single-quoted `sh -c` string — do NOT use single
+    # quotes here (they would close the outer quote). `echo` avoids both quotes
+    # and printf %-escaping.
+    if ! grep -qs "^export SHELL=" /home/agent/.profile 2>/dev/null; then
+      echo export SHELL=/bin/sh >> /home/agent/.profile
+      chown "agent:${_agrp}" /home/agent/.profile
+    fi
+
     # Passwordless sudo for agent (base-image requirement). Only if sudo exists;
     # a base without sudo still works for our purposes (kit/agent commands that
     # need root are run by acq as -u 0 directly), so a missing sudo is non-fatal.
@@ -1213,77 +1226,76 @@ acq_backend_run() {
 }
 
 # ---------------------------------------------------------------------------
-# acq_backend_attach — interactive attach (TTY) via SSH
+# acq_backend_attach — interactive attach (TTY) via `msb exec -t`
 # ---------------------------------------------------------------------------
 # sbx's `sbx run --name NAME` re-launches the agent baked into the sandbox at
-# create. msb's `msb ssh NAME` only opens a shell (as root, msb's default SSH
-# user), so acq must reproduce sbx's behavior itself: drop to the `agent` user,
-# cd into the workspace, and exec the recorded agent (opencode, …). A bare `acq
-# run <sandbox>` re-attach (no agent token) reads the agent recorded at provision
-# from /var/lib/acq/agent; `shell` (or a missing/failed agent) falls back to an
-# interactive shell as `agent` — never a root shell.
+# create. On msb we reproduce that with `msb exec`, which (unlike `msb ssh`)
+# gives us everything we need in one non-interactive-safe primitive:
+#   -t/--tty     allocate a PTY so a full-screen agent TUI (opencode) renders
+#                (msb ssh has NO tty flag and runs -- CMD without a PTY, which
+#                hung the TUI; a bare `msb ssh` tries to grab the CLIENT tty and
+#                fails on piped stdin);
+#   -u agent     run as the unprivileged agent user directly (no `su -` dance,
+#                no landing as root);
+#   -w WS        start in the workspace;
+#   -e SHELL     give the session a sane $SHELL (msb's interactive default is the
+#                base image's Node REPL, and the passwd shell isn't exported).
 #
-# Post-`--` args are forwarded to the agent (e.g. `-- --task "run tests"`).
+# A bare `acq run <sandbox>` re-attach (no agent token) reads the agent recorded
+# at provision from /var/lib/acq/agent; `shell` (or a missing/failed agent binary)
+# falls back to an interactive `/bin/sh -l` as `agent` — never a root shell, never
+# msb's Node-REPL default. Post-`--` args are forwarded to the agent.
 acq_backend_attach() {
   local name="$1"
   shift
 
   # Explicit `-- CMD…` after the sandbox name: run exactly that (advanced/escape
-  # hatch), still as the agent user in the workspace.
+  # hatch), still as the agent user in the workspace with a PTY.
   if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
     shift
-    _acq_msb_ssh_agent "$name" "$@"
+    _acq_msb_attach "$name" "$@"
     return $?
   fi
-  _acq_msb_ssh_agent "$name"
+  _acq_msb_attach "$name"
 }
 
-# _acq_msb_ssh_agent NAME [AGENT_ARGS...] — SSH in as `agent`, cd to the
+# _acq_msb_attach NAME [AGENT_ARGS...] — attach as `agent` with a PTY, cd to the
 # workspace, and launch the recorded agent (or a shell). AGENT_ARGS are appended
-# to the agent invocation. Uses a login shell so PATH picks up the globally
-# installed agent binary.
-_acq_msb_ssh_agent() {
+# to the agent invocation.
+_acq_msb_attach() {
   local name="$1"
   shift
 
-  # Determine the workspace to cd into. Prefer an explicit ACQ_MSB_WORKSPACE
-  # override; otherwise read the guest path recorded at provision (which now
-  # mirrors the host mount path, so it can't be recomputed from NAME alone).
-  # Fall back to the agent home only if nothing was recorded (older sandbox).
+  # Determine the workspace to cd into (-w). Prefer an explicit ACQ_MSB_WORKSPACE
+  # override; otherwise read the guest path recorded at provision (it mirrors the
+  # host mount path, so it can't be recomputed from NAME alone). Fall back to the
+  # agent home if nothing was recorded (older sandbox).
   local ws="${ACQ_MSB_WORKSPACE:-}"
   if [ -z "$ws" ]; then
-    ws=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' 2>/dev/null | tr -d '\r\n')
+    ws=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' </dev/null 2>/dev/null | tr -d '\r\n')
   fi
   [ -n "$ws" ] || ws="/home/agent"
 
-  # Read the agent recorded at provision. Default to `shell` if unset (older
-  # sandbox, or a `shell` sandbox).
+  # Read the agent recorded at provision. Default to `shell` if unset.
   local agent
-  agent=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/agent 2>/dev/null' 2>/dev/null | tr -d '\r\n[:space:]')
+  agent=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/agent 2>/dev/null' </dev/null 2>/dev/null | tr -d '\r\n[:space:]')
   [ -n "$agent" ] || agent="shell"
 
-  # Build the remote command run as the agent user. cd to the workspace if it
-  # exists; then exec the agent (or an interactive shell). If the agent binary is
-  # somehow absent, fall back to a shell rather than failing the attach — but say
-  # so, so the user isn't staring at a bare prompt wondering why.
-  local remote
+  # Common flags for the interactive attach: PTY, agent user, workspace cwd, and
+  # a sane $SHELL (msb's default interactive shell is the base image's Node REPL).
+  # exec so acq hands the terminal straight to msb (no wrapper between TTY & PTY).
   if [ "$agent" = "shell" ]; then
-    remote="cd '$ws' 2>/dev/null; exec \$SHELL -l"
-  else
-    # AGENT_ARGS (already shell-safe from the user's own invocation) are joined
-    # with single-quote escaping so they survive the remote sh -c.
-    local extra=""
-    local a
-    for a in "$@"; do
-      extra="$extra '$(printf '%s' "$a" | sed "s/'/'\\\\''/g")'"
-    done
-    remote="cd '$ws' 2>/dev/null; if command -v '$agent' >/dev/null 2>&1; then exec '$agent'$extra; else echo \"acq(msb): '$agent' not found in sandbox; opening a shell instead.\" >&2; exec \$SHELL -l; fi"
+    exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh "$name" -- /bin/sh -l
   fi
 
-  # `msb ssh NAME -- CMD` runs CMD (msb's default SSH user is root); we drop to
-  # the agent user via `su` so the agent runs unprivileged in its own HOME, the
-  # same posture as sbx. `su - agent` gives a login environment (PATH/HOME).
-  msb ssh "$name" -- su - agent -c "$remote"
+  # Pre-check the agent binary AS the agent user; fall back to a shell (with a
+  # notice) rather than launching into a broken/blank session if it's missing.
+  if ! msb exec -u agent "$name" -- sh -c "command -v '$agent'" </dev/null >/dev/null 2>&1; then
+    echo "acq(msb): '$agent' not found in sandbox '$name'; opening a shell instead." >&2
+    exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh "$name" -- /bin/sh -l
+  fi
+
+  exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh "$name" -- "$agent" "$@"
 }
 
 # ---------------------------------------------------------------------------

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -747,21 +747,177 @@ acq_backend_secret_set() {
 }
 
 # ---------------------------------------------------------------------------
+# acq_backend_secret_rm [-g | SANDBOX] SERVICE  (sbx backend)
+# ---------------------------------------------------------------------------
+# Remove a secret acq owns: delete it from the acq store AND clear sbx's proxy
+# entry, so no injected value lingers. Idempotent (absent secret is success).
+# Scope parsing mirrors acq_backend_secret_set: -g/--global, or a leading bare
+# sandbox name before the service. This is the counterpart to `acq secret set`;
+# for a raw sbx placeholder removal the user can still call `sbx secret rm`
+# directly (that path is passed through by the acq dispatcher).
+acq_backend_secret_rm() {
+  local service="${1:-}"
+  shift || true
+
+  local scope_flag="" scope_name=""
+  case "$service" in
+    -g|--global)
+      scope_flag="-g"; service="${1:-}"; shift || true ;;
+    -*)
+      ;;
+    *)
+      local _next="${1:-}"
+      case "$_next" in
+        ""|-*) ;;
+        *) scope_name="$service"; service="$_next"; shift || true ;;
+      esac
+      ;;
+  esac
+
+  if [ -z "$service" ]; then
+    echo "acq: secret rm: missing service name" >&2
+    echo "     usage: acq secret rm [-g | SANDBOX] <service>" >&2
+    return 1
+  fi
+  if [ -z "$scope_flag" ] && [ -z "$scope_name" ]; then
+    echo "acq: secret rm: scope required — use -g for global or provide a sandbox name" >&2
+    echo "     usage: acq secret rm [-g | SANDBOX] <service>" >&2
+    return 1
+  fi
+
+  local acq_sandbox=""
+  [ -n "$scope_name" ] && acq_sandbox="$scope_name"
+
+  # 1) Remove from the acq store (source of truth). Idempotent.
+  local removed_store=0
+  if command -v acq_secret_delete >/dev/null 2>&1; then
+    local key
+    key=$(_acq_secret_key "$service" "$acq_sandbox")
+    acq_secret_delete "$key" && removed_store=1
+  fi
+
+  # 2) Clear sbx's proxy entry so it stops injecting. Built-in services are
+  #    removed by service name; custom services (usai, ...) by their placeholder.
+  #    ALWAYS pass -f: `sbx secret rm` otherwise prompts "Remove? (y/N)" on a TTY
+  #    and BLOCKS waiting for input (observed hanging verify-backends). acq's rm
+  #    is non-interactive by contract. Also </dev/null as belt-and-suspenders so
+  #    no sbx prompt can ever consume our stdin. Best-effort — a missing sbx
+  #    entry is not an error.
+  local is_builtin=0
+  case "$_ACQ_SBX_BUILTIN_SERVICES" in
+    *" $service "*) is_builtin=1 ;;
+  esac
+  local scope_arg
+  if [ -n "$scope_flag" ]; then scope_arg="-g"; else scope_arg="$scope_name"; fi
+
+  if [ "$is_builtin" -eq 1 ]; then
+    sbx secret rm "$scope_arg" "$service" -f </dev/null >/dev/null 2>&1 || true
+  else
+    # Custom endpoint (usai, ...): sbx removes a custom secret by its PLACEHOLDER
+    # (there is no --host on `secret rm`). Look up the placeholder from the custom
+    # secrets table for this scope + env var, then remove it by --placeholder.
+    local env_var placeholder
+    env_var=$(_acq_service_hosts_env "$service" | cut -f2)
+    placeholder=$(_acq_sbx_custom_placeholder "$scope_flag" "$scope_name" "$env_var")
+    if [ -n "$placeholder" ]; then
+      sbx secret rm "$scope_arg" --placeholder "$placeholder" -f </dev/null >/dev/null 2>&1 || true
+    fi
+  fi
+
+  local where="global"
+  [ -n "$scope_name" ] && where="sandbox '$scope_name'"
+  if [ "$removed_store" -eq 1 ]; then
+    echo "acq: removed '$service' secret (${where}) from the acq store and sbx proxy." >&2
+  else
+    echo "acq: no '$service' secret found in the acq store (${where}); cleared sbx proxy anyway." >&2
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # _acq_sbx_secret_exists SCOPE_FLAG SCOPE_NAME SERVICE ENV_VAR -> 0 if present
 # ---------------------------------------------------------------------------
-# Best-effort existence check against `sbx secret ls`. Built-in services show
-# their service name; custom secrets show the env var name. Returns 0 (exists)
-# only on a confident match; on any listing failure, returns 1 (treat as absent)
-# so we don't block the user — sbx will still error clearly if it does exist.
+# Scope- AND section-AWARE existence check against `sbx secret ls`. The listing
+# has TWO tables:
+#
+#   SCOPE      TYPE     NAME    SECRET                 <- built-in services
+#   <scope>    service  github  (stored)
+#
+#   CUSTOM SECRETS
+#   SCOPE      TARGETS  ENV     PLACEHOLDER  SECRET    <- custom secrets
+#   <scope>    <host>   USAI_…  sbx-cs-…     ****
+#
+# A built-in service (github, ...) is identified by its NAME in the built-in
+# table; a custom service (usai, ...) by its ENV var in the CUSTOM table. We must
+# match in the CORRECT section, and only when the row's SCOPE column equals the
+# request scope — an earlier version blind-substring-matched the whole listing,
+# so github under ANY scope (or a stray token in either table) produced a false
+# positive that wrongly refused to seed the target scope.
+#
+# Args: SCOPE_FLAG (`-g` or empty), SCOPE_NAME (sandbox, or empty for global),
+#       SERVICE, ENV_VAR (empty for a built-in service).
+# Target scope string: `(global)` for -g, else the sandbox name.
+# Returns 0 only on a scoped, section-correct match; 1 otherwise / on ls failure.
 _acq_sbx_secret_exists() {
   local scope_flag="$1" scope_name="$2" service="$3" env_var="$4"
-  local listing needle
+  local listing want_scope
   listing=$(sbx secret ls 2>/dev/null) || return 1
-  if [ -n "$env_var" ]; then needle="$env_var"; else needle="$service"; fi
-  case "$listing" in
-    *"$needle"*) return 0 ;;
-    *) return 1 ;;
-  esac
+  if [ -n "$scope_flag" ]; then want_scope="(global)"; else want_scope="$scope_name"; fi
+
+  # want_section: "builtin" (match NAME) for a built-in service, else "custom"
+  # (match ENV). needle is the token to find in that section's row.
+  local want_section needle
+  if [ -n "$env_var" ]; then want_section="custom"; needle="$env_var"
+  else want_section="builtin"; needle="$service"; fi
+
+  printf '%s\n' "$listing" | awk \
+    -v scope="$want_scope" -v needle="$needle" -v want="$want_section" '
+    # Section tracking: everything before the "CUSTOM SECRETS" marker is the
+    # built-in table; everything after is the custom table.
+    /^CUSTOM SECRETS/ { section = "custom"; next }
+    NF == 0 { next }
+    # Skip each table header row (starts with the literal SCOPE column label).
+    $1 == "SCOPE" { next }
+    {
+      cur = (section == "custom") ? "custom" : "builtin"
+      if (cur == want && $1 == scope) {
+        # Built-in: NAME is field 3 (SCOPE TYPE NAME). Custom: ENV is field 3
+        # (SCOPE TARGETS ENV). Both live at $3 given single-token scope/target;
+        # also scan remaining fields defensively in case of extra spacing.
+        for (i = 2; i <= NF; i++) if ($i == needle) { found = 1; exit }
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  '
+}
+
+# ---------------------------------------------------------------------------
+# _acq_sbx_custom_placeholder SCOPE_FLAG SCOPE_NAME ENV_VAR -> placeholder|empty
+# ---------------------------------------------------------------------------
+# Look up the PLACEHOLDER of a CUSTOM secret (from the CUSTOM SECRETS table of
+# `sbx secret ls`) for a given scope + env var, so `sbx secret rm --placeholder`
+# can target it. Echoes the placeholder (e.g. sbx-cs-…) or nothing if absent.
+_acq_sbx_custom_placeholder() {
+  local scope_flag="$1" scope_name="$2" env_var="$3"
+  [ -n "$env_var" ] || return 0
+  local listing want_scope
+  listing=$(sbx secret ls 2>/dev/null) || return 0
+  if [ -n "$scope_flag" ]; then want_scope="(global)"; else want_scope="$scope_name"; fi
+
+  # CUSTOM table columns: SCOPE TARGETS ENV PLACEHOLDER SECRET. Find the row in
+  # the custom section whose SCOPE == want_scope and ENV == env_var, print its
+  # PLACEHOLDER. We locate ENV by value (not fixed index) and take the NEXT field
+  # as the placeholder, robust to a multi-token TARGETS cell.
+  printf '%s\n' "$listing" | awk \
+    -v scope="$want_scope" -v env="$env_var" '
+    /^CUSTOM SECRETS/ { in_custom = 1; next }
+    !in_custom { next }
+    NF == 0 { next }
+    $1 == "SCOPE" { next }
+    $1 == scope {
+      for (i = 2; i < NF; i++) if ($i == env) { print $(i+1); exit }
+    }
+  '
 }
 
 # ---------------------------------------------------------------------------

--- a/acq.backends/secret-store.sh
+++ b/acq.backends/secret-store.sh
@@ -190,6 +190,50 @@ _acq_secret_get_file() {
 }
 
 # ---------------------------------------------------------------------------
+# acq_secret_delete KEY  ->  0 if an entry was removed OR none existed
+# ---------------------------------------------------------------------------
+# Remove a secret from the active store backend. Idempotent: returns 0 whether
+# or not the entry existed (so `rm` of an absent secret is not an error), and
+# non-zero only on an actual backend failure. Removes from BOTH the keychain and
+# the file fallback where relevant, since a value may have been written to the
+# file backend on macOS (see the acq_secret_store note about avoiding argv).
+acq_secret_delete() {
+  local key="$1" backend rc=0
+  backend=$(_acq_secret_backend)
+  acq_debug "secret delete: key=$key backend=$backend"
+  case "$backend" in
+    keychain-macos)
+      # New writes go to the file fallback (argv-safe); older ALLOW_ARGV writes
+      # may be in the keychain. Clear both so no copy lingers.
+      security delete-generic-password -s "$ACQ_KEYCHAIN_LABEL" -a "$key" \
+        >/dev/null 2>&1 || true
+      _acq_secret_delete_file "$key" || rc=$?
+      ;;
+    keychain-linux)
+      # secret-tool clear removes all items matching the attribute; a no-match is
+      # not an error for our idempotent contract.
+      secret-tool clear acq_key "$key" >/dev/null 2>&1 || true
+      _acq_secret_delete_file "$key" || rc=$?
+      ;;
+    file)
+      _acq_secret_delete_file "$key" || rc=$?
+      ;;
+  esac
+  return "$rc"
+}
+
+# 0600 file removal. Idempotent (absent file is success); non-zero only if the
+# file exists but cannot be removed.
+_acq_secret_delete_file() {
+  local key="$1" f
+  f=$(_acq_secret_file_for "$key")
+  [ -e "$f" ] || return 0
+  rm -f "$f" 2>/dev/null || {
+    echo "acq: secret delete: file remove failed for '$key'." >&2; return 1; }
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # acq_secret_resolve SERVICE [SANDBOX]  ->  value on STDOUT
 # ---------------------------------------------------------------------------
 # Resolve a service's secret with sandbox-scope precedence: try

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -359,25 +359,29 @@ swap-on-access placeholders) remains a larger future effort tracked separately.
 
 ### Known limitations (msb)
 
-- **Private GitHub repos: the playbook kit clone is skipped on msb.** The
-  `agentic-coding-playbook` kit clones a private GitHub repo over HTTPS. msb
-  0.6.6 does not substitute the credential placeholder for git's HTTPS
-  smart-transport to `github.com` — the request is blocked/unsubstituted
-  regardless of request shape (verified extensively; msb's `Authorization:
-  Bearer` substitution works for the USAi header path but not for git). Binding
-  the same placeholder across multiple github hosts also trips microsandbox
-  [#1170](https://github.com/superradcompany/microsandbox/issues/1170). acq
-  therefore does **not** bind a GitHub secret on msb; the playbook kit is
-  non-fatal and warns, and the sandbox comes up fully usable otherwise. This is
-  tracked in
-  [quickstart#203](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/203)
-  for a fix once upstream git substitution works (see microsandbox
+- **Private GitHub repos: use the REST API, not `git clone`.** msb substitutes
+  an injected credential for the `Authorization: Bearer` header on the
+  **REST API** (`api.github.com`) — verified on msb 0.6.7 (an authenticated
+  request returns full rate-limit headers; a private-repo source-tarball fetch
+  succeeds). It does **not** substitute git's smart-HTTP transport to
+  `github.com` / `codeload.github.com`, so a `git clone` (or `gh repo clone`,
+  which shells out to git) of a private repo fails auth/TLS there. This was the
+  origin of
+  [quickstart#203](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/203).
+
+  **Resolution:** kits that need private GitHub content fetch it via the REST
+  API instead of git. The `agentic-coding-playbook` kit now fetches the repo
+  **source tarball** from `api.github.com/repos/<repo>/tarball/<ref>` (verifying
+  the extracted `AGENTS.md` against a pinned sha256), so it works on **both**
+  backends. acq binds `GITHUB_TOKEN@api.github.com` on msb (single host — a
+  multi-host binding trips microsandbox
+  [#1170](https://github.com/superradcompany/microsandbox/issues/1170)). Store a
+  token with `acq secret set -g github` (or `gh auth token | acq secret set -g
+  github`); absent a token the kit degrades gracefully (warns, no rules/skills).
+  Upstream git-transport substitution remains unfixed (microsandbox
   [#756](https://github.com/superradcompany/microsandbox/issues/756) /
-  [#768](https://github.com/superradcompany/microsandbox/pull/768) /
-  [#1170](https://github.com/superradcompany/microsandbox/issues/1170)). On the
-  **sbx** backend the playbook clone works (its proxy injects the token
-  transparently). Workarounds on msb: make the repo readable without auth, use a
-  base image with the playbook pre-cloned, or use the sbx backend.
+  [#768](https://github.com/superradcompany/microsandbox/pull/768)), but kits no
+  longer depend on it.
 
 ### Capability flags
 
@@ -386,7 +390,7 @@ swap-on-access placeholders) remains a larger future effort tracked separately.
 | `ACQ_BACKEND_SUPPORTS_PORT_FORWARD` | 0 | No post-hoc `acq ports`; publish at create/run via `-p HOST:GUEST` |
 | `ACQ_BACKEND_SUPPORTS_SNAPSHOTS` | 1 | `msb snapshot` save/restore |
 | `ACQ_BACKEND_CAN_RESUME` | 1 | `msb stop` / `msb start` preserve state |
-| `ACQ_BACKEND_SUPPORTS_CREDENTIAL_REWRITE` | 1 | `--secret ENV@HOST` + `--tls-intercept` (header substitution; git HTTPS not yet supported by msb) |
+| `ACQ_BACKEND_SUPPORTS_CREDENTIAL_REWRITE` | 1 | `--secret ENV@HOST` + `--tls-intercept` (header substitution on REST/API hosts; git smart-HTTP transport not substituted — use the REST API) |
 
 ### Differences from sbx
 
@@ -462,10 +466,10 @@ inspection):
 ./scripts/verify-backends -v
 ```
 
-A `WARN` line marks a known, tracked limitation (e.g. the msb private-repo
-playbook clone, [quickstart#203](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/203))
-— it is surfaced every run but does **not** count as a failure, so a clean msb
-run still exits 0.
+A `WARN` line marks a known, tracked limitation — it is surfaced every run but
+does **not** count as a failure, so a clean run still exits 0. (The former msb
+private-repo playbook `WARN` is gone: the playbook kit now fetches via the REST
+API and is a hard-required `pass` on both backends, given a stored github token.)
 
 ---
 
@@ -532,7 +536,6 @@ Manage kits with `acq kit list | validate PATH | apply NAME KITREF`.
 
 - Full Go/keychain swap-on-access secret component of design §7.5 (age fallback,
   `CredentialRewriteRule`); acq ships the bash keychain subset (see Secrets)
-- msb private-repo git auth ([quickstart#203](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/203))
 - `acq policy …` — network policy subcommands
 - `ppp` (Podman-Plus-Proxy) backend — Phase 3, in development at
   [GSA-TTS/ppp](https://github.com/GSA-TTS/ppp)

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -162,6 +162,8 @@ Tunables:
 | `ACQ_MSB_OPENCODE_PKG` | `opencode-ai` | npm package spec for the opencode install (pin e.g. `opencode-ai@1.2.3`) |
 | `ACQ_MSB_NPM_HOSTS` | `registry.npmjs.org` | npm registry host(s) to allow-list for the agent install (space-separated; set for an internal mirror) |
 | `ACQ_MSB_WORKSPACE` | `/home/agent/workspace` | Guest mount point for the host workspace |
+| `ACQ_MSB_MEMORY` | `4G` | Guest RAM at create (`-m`); `4G`/`4096`/`512M` (bare = MiB). Set empty to use msb's 512 MiB default |
+| `ACQ_MSB_CPUS` | `2` | Guest vCPU count at create (`-c`); set empty to use msb's 1-vCPU default |
 | `ACQ_MSB_DNS_NAMESERVER` | `1.1.1.1` | Guest DNS resolver (set empty to use msb's default) |
 | `ACQ_MSB_KIT_CACHE` | `$XDG_CACHE_HOME/acq/kits` | where fetched neutral kits are materialized |
 
@@ -176,6 +178,18 @@ request fails with `Could not resolve host`. The msb backend therefore passes
 microVM) to `msb create`. Override `ACQ_MSB_DNS_NAMESERVER` if `1.1.1.1` is
 blocked in your environment, or set it empty to fall back to msb's default (only
 if your host resolver is reachable from the guest).
+
+### Guest memory and vCPU
+
+msb defaults a sandbox to **512 MiB of RAM and 1 vCPU**, and the microVM has
+**no swap** — so a process that exceeds guest RAM is OOM-killed by the guest
+kernel and simply prints `Killed`. A Node.js agent TUI like `opencode` blows past
+512 MiB immediately, which looked like "opencode starts, then the terminal dies"
+(quickstart#228 follow-up). sbx sizes its agent templates generously; a plain msb
+base does not, so the msb backend passes `--memory 4G --cpus 2` at create by
+default. Tune with `ACQ_MSB_MEMORY` / `ACQ_MSB_CPUS` (set either empty to fall
+back to msb's own default). Memory takes a single-char unit suffix — `G`/`g` =
+GiB, `M`/`m` = MiB, bare number = MiB — so `4G`, `4096`, and `4g` are equivalent.
 
 ### Workspace mounting
 

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -158,7 +158,6 @@ Tunables:
 |---------|---------|---------|
 | `ACQ_MSB_IMAGE` | `docker.io/library/node:22-bookworm` | Base OCI image (must be pullable and ship node/git/curl/ca-certificates) |
 | `ACQ_MSB_SKIP_PREREQ_CHECK` | (unset) | Skip the base-image prerequisite presence check |
-| `ACQ_MSB_AGENT_UID` | `1000` | Preferred uid for the provisioned `agent` user |
 | `ACQ_MSB_OPENCODE_PKG` | `opencode-ai` | npm package spec for the opencode install (pin e.g. `opencode-ai@1.2.3`) |
 | `ACQ_MSB_NPM_HOSTS` | `registry.npmjs.org` | npm registry host(s) to allow-list for the agent install (space-separated; set for an internal mirror) |
 | `ACQ_MSB_WORKSPACE` | (host path) | Guest mount point for the host workspace (default: the same absolute path as on the host, matching sbx) |
@@ -278,15 +277,17 @@ sudoers rule) meets none of the first three. So at provision the msb adapter
 `HOME=/home/agent` (offline via `useradd`/`adduser`), chowns the staged
 `/home/agent` files to it, drops a passwordless-sudo rule in `/etc/sudoers.d`,
 and adds a sudoers `env_keep` for the proxy variables. It addresses the user by
-name (not the literal uid 1000), so it works even when 1000 is already taken. Set
-`ACQ_MSB_AGENT_UID` to prefer a specific uid.
+name (not the literal uid 1000), so it works even when 1000 is already taken by
+the base image (e.g. `node` on node:22-bookworm).
 
-**How attach launches the agent.** sbx's `sbx run --name` re-launches the baked-in
-agent; msb's `msb ssh NAME` only opens a shell (as root, msb's default SSH user).
-So on attach the msb adapter reproduces sbx's behavior itself: it `su - agent`s to
-the unprivileged `agent` user, `cd`s into the workspace, and execs the agent that
-was recorded at provision (falling back to an interactive shell as `agent` — never
-a root shell — for a `shell` sandbox or if the binary is somehow missing).
+**How attach launches the agent.** sbx's `sbx run --name` re-launches the
+baked-in agent. On msb the adapter reproduces that with `msb exec -t` — the one
+primitive that allocates a PTY (so a full-screen agent TUI renders), runs as the
+unprivileged `agent` user (`-u agent`), starts in the workspace (`-w`), and gives
+the session a sane `$SHELL`. It execs the agent recorded at provision, falling
+back to an interactive `/bin/sh -l` as `agent` — never a root shell, never msb's
+default interactive shell (the base image's Node REPL) — for a `shell` sandbox or
+if the agent binary is somehow missing.
 
 To use your own image, set `ACQ_MSB_IMAGE` to one that also provides node, git,
 curl, and ca-certificates:

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -160,7 +160,7 @@ Tunables:
 | `ACQ_MSB_SKIP_PREREQ_CHECK` | (unset) | Skip the base-image prerequisite presence check |
 | `ACQ_MSB_OPENCODE_PKG` | `opencode-ai` | npm package spec for the opencode install (pin e.g. `opencode-ai@1.2.3`) |
 | `ACQ_MSB_NPM_HOSTS` | `registry.npmjs.org` | npm registry host(s) to allow-list for the agent install (space-separated; set for an internal mirror) |
-| `ACQ_MSB_WORKSPACE` | (host path) | Guest mount point for the host workspace (default: the same absolute path as on the host, matching sbx) |
+| `ACQ_MSB_WORKSPACE` | (first workspace) | Agent's **starting directory** (`-w`) on attach. Does NOT change the mount, which is always host-path:host-path; overrides only where the agent starts. |
 | `ACQ_MSB_MEMORY` | `4G` | Guest RAM at create (`-m`); `4G`/`4096`/`512M` (bare = MiB). Set empty to use msb's 512 MiB default |
 | `ACQ_MSB_CPUS` | `2` | Guest vCPU count at create (`-c`); set empty to use msb's 1-vCPU default |
 | `ACQ_MSB_DNS_NAMESERVER` | `1.1.1.1` | Guest DNS resolver (set empty to use msb's default) |

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -3,7 +3,7 @@ title: "acq Backend Guide"
 description: "Per-backend strengths, tradeoffs, and configuration for acq"
 status: canonical
 tier: 2
-last_updated: "2026-07-15"
+last_updated: "2026-07-24"
 audience: "developers"
 keywords: ["acq", "backend", "sbx", "msb", "microsandbox", "tradeoffs"]
 related_files: ["docs/QUICKSTART.md", "docs/QUICKSTART_SBX.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
@@ -159,6 +159,8 @@ Tunables:
 | `ACQ_MSB_IMAGE` | `docker.io/library/node:22-bookworm` | Base OCI image (must be pullable and ship node/git/curl/ca-certificates) |
 | `ACQ_MSB_SKIP_PREREQ_CHECK` | (unset) | Skip the base-image prerequisite presence check |
 | `ACQ_MSB_AGENT_UID` | `1000` | Preferred uid for the provisioned `agent` user |
+| `ACQ_MSB_OPENCODE_PKG` | `opencode-ai` | npm package spec for the opencode install (pin e.g. `opencode-ai@1.2.3`) |
+| `ACQ_MSB_NPM_HOSTS` | `registry.npmjs.org` | npm registry host(s) to allow-list for the agent install (space-separated; set for an internal mirror) |
 | `ACQ_MSB_WORKSPACE` | `/home/agent/workspace` | Guest mount point for the host workspace |
 | `ACQ_MSB_DNS_NAMESERVER` | `1.1.1.1` | Guest DNS resolver (set empty to use msb's default) |
 | `ACQ_MSB_KIT_CACHE` | `$XDG_CACHE_HOME/acq/kits` | where fetched neutral kits are materialized |
@@ -206,15 +208,40 @@ ships all four tools and pulls from Docker Hub without auth. Before applying
 kits, the adapter **verifies** the tools are present and warns if any are
 missing (it does not try to install them).
 
-**The `agent` user contract.** The kits stage files under `/home/agent` and run
-their unprivileged commands as an `agent` user (uid 1000) — the contract sbx's
-agent template guarantees. A plain OCI base does not provide this (e.g.
-`node:22-bookworm` has a `node` user at uid 1000 and no `agent`). So at provision
-the msb adapter **creates an `agent` user with `HOME=/home/agent`** (idempotent,
-offline via `useradd`/`adduser`), chowns the staged `/home/agent` files to it,
-and runs the kits' uid-1000 commands as `agent` with `HOME=/home/agent` (it
-addresses the user by name, not by the literal uid 1000, so it works even when
-1000 is already taken). Set `ACQ_MSB_AGENT_UID` to prefer a specific uid.
+**The agent binary.** sbx's agent templates bake the requested agent (e.g.
+`opencode`) into the image; a plain msb base has no agent. So at provision the
+msb adapter **installs the agent it was asked to run**. For `opencode` this is
+`npm install -g opencode-ai` (node is a verified prerequisite), and the adapter
+allow-lists the npm registry host (`registry.npmjs.org`) at create so the
+default-deny guest egress permits the download. The install is idempotent: it is
+skipped when the binary is already present (e.g. a pre-baked `ACQ_MSB_IMAGE`) and
+marker-gated against re-apply. `shell` installs nothing; an agent with no known
+recipe that is also absent from the base image produces a clear warning (bake it
+into `ACQ_MSB_IMAGE`). Tunables: `ACQ_MSB_OPENCODE_PKG` (npm spec, e.g.
+`opencode-ai@1.2.3`), `ACQ_MSB_NPM_HOSTS` (registry host(s) to allow-list, for an
+internal mirror).
+
+**The base-image contract (Docker `shell-docker`).** sbx's templates are built on
+`docker/sandbox-templates:shell-docker`, whose
+[published base-image requirements](https://docs.docker.com/ai/sandboxes/customize/kit-reference/#base-image-requirements)
+are: a non-root `agent` user at UID 1000 **with passwordless sudo**, a
+`/home/agent` home owned by `agent`, **HTTP proxy env (`HTTP_PROXY`/`HTTPS_PROXY`/
+`NO_PROXY`) preserved across sudo**, and the agent binary present. A plain OCI
+base (e.g. `node:22-bookworm`, which has `node` at uid 1000 and no `agent`, no
+sudoers rule) meets none of the first three. So at provision the msb adapter
+**idempotently synthesizes** them: it creates the `agent` user with
+`HOME=/home/agent` (offline via `useradd`/`adduser`), chowns the staged
+`/home/agent` files to it, drops a passwordless-sudo rule in `/etc/sudoers.d`,
+and adds a sudoers `env_keep` for the proxy variables. It addresses the user by
+name (not the literal uid 1000), so it works even when 1000 is already taken. Set
+`ACQ_MSB_AGENT_UID` to prefer a specific uid.
+
+**How attach launches the agent.** sbx's `sbx run --name` re-launches the baked-in
+agent; msb's `msb ssh NAME` only opens a shell (as root, msb's default SSH user).
+So on attach the msb adapter reproduces sbx's behavior itself: it `su - agent`s to
+the unprivileged `agent` user, `cd`s into the workspace, and execs the agent that
+was recorded at provision (falling back to an interactive shell as `agent` — never
+a root shell — for a `shell` sandbox or if the binary is somehow missing).
 
 To use your own image, set `ACQ_MSB_IMAGE` to one that also provides node, git,
 curl, and ca-certificates:

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -161,7 +161,7 @@ Tunables:
 | `ACQ_MSB_AGENT_UID` | `1000` | Preferred uid for the provisioned `agent` user |
 | `ACQ_MSB_OPENCODE_PKG` | `opencode-ai` | npm package spec for the opencode install (pin e.g. `opencode-ai@1.2.3`) |
 | `ACQ_MSB_NPM_HOSTS` | `registry.npmjs.org` | npm registry host(s) to allow-list for the agent install (space-separated; set for an internal mirror) |
-| `ACQ_MSB_WORKSPACE` | `/home/agent/workspace` | Guest mount point for the host workspace |
+| `ACQ_MSB_WORKSPACE` | (host path) | Guest mount point for the host workspace (default: the same absolute path as on the host, matching sbx) |
 | `ACQ_MSB_MEMORY` | `4G` | Guest RAM at create (`-m`); `4G`/`4096`/`512M` (bare = MiB). Set empty to use msb's 512 MiB default |
 | `ACQ_MSB_CPUS` | `2` | Guest vCPU count at create (`-c`); set empty to use msb's 1-vCPU default |
 | `ACQ_MSB_DNS_NAMESERVER` | `1.1.1.1` | Guest DNS resolver (set empty to use msb's default) |
@@ -193,12 +193,43 @@ GiB, `M`/`m` = MiB, bare number = MiB — so `4G`, `4096`, and `4g` are equivale
 
 ### Workspace mounting
 
-msb does **not** create the host mount path and will not reliably mount a guest
-path that mirrors an absolute host path under `/tmp` (the mount silently does
-not appear). So the msb backend mounts your host workspace at a fixed guest path
-(`ACQ_MSB_WORKSPACE`, default `/home/agent/workspace`) rather than at its host
-path. The host path must already exist — `acq` errors clearly if it does not.
-This differs from sbx, which mounts the workspace at its original path.
+msb does **not** create the host mount path, so each host workspace path must
+already exist — `acq` errors clearly if one does not.
+
+The msb backend mounts every workspace at the **same absolute path inside the
+guest** (matching sbx's multi-workspace semantics — see
+`docs/QUICKSTART_SBX.md`): `acq run opencode /my/repo` makes the repo appear at
+`/my/repo` in the sandbox. Extra workspaces and a trailing `:ro` marker work the
+same as sbx:
+
+```bash
+acq --backend msb run opencode ~/projects/app ~/projects/lib:ro
+# mounts ~/projects/app (rw) and ~/projects/lib (ro), each at its host path
+```
+
+**Starting directory:** the agent starts in the **primary** (first) workspace,
+matching sbx (`docs/QUICKSTART_SBX.md`: "Primary workspace — the first path;
+agent starts here"). Override the start dir with `ACQ_MSB_WORKSPACE`.
+
+**Symlinked host paths are canonicalized.** msb cannot mount a symlinked host
+path — it fails to start with `mount ...: Not a directory (os error 20)`, even
+when mapped to a shallow guest target (verified on msb 0.6.6). The most common
+case is **macOS `$TMPDIR`**, a per-user `/var/folders/...` tree reached through
+the `/var` → `/private/var` symlink: any workspace under `$TMPDIR` / `/tmp`
+fails. `acq` therefore resolves each workspace to its real, symlink-free path
+(e.g. `/private/var/...`) before mounting. A directory under `$HOME` mounts
+fine; prefer one over a temp dir if you hit this.
+
+> **Why not remap under `/home/agent`?** An earlier version mounted the
+> workspace under the agent home (`/home/agent/workspace`). But `msb create`
+> performs the mount *before* `acq` can create the `agent` user and its
+> `/home/agent` directory (that happens post-create, once the guest is
+> exec-ready), so on a plain base image the mount failed with
+> `mount ...: Not a directory (os error 20)`. Mounting at the
+> host's own (canonicalized) absolute path avoids that ordering problem entirely
+> and matches what sbx does.
+
+Note the async-boot caveat:
 
 > **`msb create` starts asynchronously.** `msb create` returns success even if
 > the sandbox later fails to *start* (e.g. a bad mount). `acq` therefore treats

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -96,11 +96,16 @@ the neutral `hybrid/v1` kits, JSON schema, and registry) lands separately in
   with `--tls-intercept` (required for substitution), read from the acq secret
   store at provision into a transient env var (never argv, never the kit spec;
   the guest gets only a placeholder). `acq secret set` re-feeds running sandboxes
-  via `msb modify --secret`. The **GitHub token is deliberately NOT bound on
-  msb**: msb 0.6.6 does not substitute the placeholder for git's HTTPS clone to
-  github.com (verified; the header path for USAi works, git does not — see
-  microsandbox #756/#768/#1170), so the private playbook-clone kit is skipped on
-  msb (non-fatal, warns). Unlike sbx (whose
+  via `msb modify --secret`. The **GitHub token is bound to the REST API host
+  only** (`GITHUB_TOKEN@api.github.com`): msb substitutes the `Authorization:
+  Bearer` header on the wire to `api.github.com` (verified msb 0.6.7) but NOT
+  git's smart-HTTP transport to github.com/codeload (microsandbox
+  #756/#768/#1170). So kits authenticate to GitHub via the REST API, not `git
+  clone`: the playbook kit fetches a **source tarball** from
+  `api.github.com/repos/<repo>/tarball/<ref>` and now works on msb (this
+  supersedes the earlier decision to leave github unbound / skip the playbook
+  kit on msb; see quickstart#203). A single host is bound to avoid microsandbox
+  #1170 (multi-host binding). Unlike sbx (whose
   templates supply the image), msb runs a plain OCI image: the default is the
   public `node:22-bookworm` (built on buildpack-deps, so it already ships
   node/git/curl/ca-certificates — the four kits' prerequisites — and pulls
@@ -300,12 +305,16 @@ allow@HOST --trust-host-cas --tls-intercept --secret ENV@HOST --volume`,
   ports. This is a broader/less-transparent posture than sbx's proxy injection;
   it is the microsandbox model and the price of the microVM boundary. Disable
   with `ACQ_MSB_NO_TLS_INTERCEPT` (secrets then won't substitute).
-- **Known limitation (tracked):** on msb the private `agentic-coding-playbook`
-  clone is skipped — msb 0.6.6 does not substitute the credential placeholder
-  for git's HTTPS smart-transport to github.com (upstream microsandbox
-  #756/#768/#1170). The kit is non-fatal; the sandbox is otherwise fully usable
-  (USAi, git-ssh-sign, zscaler all work). The sbx backend is unaffected. Tracked
-  in quickstart#203 for when upstream git substitution lands.
+- **Private GitHub content via the REST API (quickstart#203, resolved):** msb
+  does NOT substitute the credential placeholder for git's HTTPS smart-transport
+  to github.com/codeload (upstream microsandbox #756/#768/#1170), so a private
+  `git clone` cannot authenticate on msb. It DOES substitute the `Authorization:
+  Bearer` header for the REST API (`api.github.com`, verified msb 0.6.7). So kits
+  fetch private GitHub content via the REST API: the `agentic-coding-playbook`
+  kit binds `GITHUB_TOKEN@api.github.com` and fetches a **source tarball**
+  (verified against a pinned AGENTS.md sha256) instead of cloning. It now works
+  on msb. (This supersedes the earlier "clone skipped on msb" limitation. The
+  underlying git-transport gap remains upstream, but no kit depends on it.)
 
 ### `environment` vocabulary (guest env vars)
 
@@ -335,23 +344,31 @@ reported by `acq kit validate`), because a name reaches the guest environment an
 possibly a shell. **Secrets do NOT go here** — they continue through the backend
 credential/secret path (sbx proxy, msb `--secret ENV@HOST`), never the kit spec.
 
-> **Cross-repo dependency (satisfied):** the authoritative `environment` schema
-> property + the field-level validator live in the **patterns** repo
+> **Cross-repo dependency:** the authoritative `environment` schema property +
+> the field-level validator live in the **patterns** repo
 > (`schemas/kit-hybrid-v1.schema.json`, `validate-kits.py`, PR #227 + the review
-> follow-up #228). Both merged and shipped in patterns **v1.7.0**, and
-> `PATTERNS_KIT_REF` (`acq.backends/common.sh`) is pinned to the v1.7.0 release
-> commit `9c277c09ed4ad45fd11709d6b048a58adc785443` (schema with `environment`
-> verified present). The pin was held at v1.6.0 until v1.7.0 existed, per the
-> fail-closed cross-repo gating.
+> follow-up #228), merged and shipped in patterns **v1.7.0**.
+>
+> **Pin status (TEMPORARY — see quickstart#203 / patterns#269):** `PATTERNS_KIT_REF`
+> (`acq.backends/common.sh`) is currently pinned to the **tip of patterns
+> `feat/fix-playbook-clones`** (`379756a…`), which carries the playbook kit's
+> REST-tarball fetch (the #203 fix) and is **not yet on patterns `main`**. This
+> is an explicit, in-code-documented temporary pin for validation. The release
+> gate is **not** satisfied until patterns#269 merges and this pin is finalized
+> to the merge commit / next release tag (and the two pin assertions in
+> `scripts/test-acq` are restored). Do not cut a release in the interim.
 
 ## Live verification (msb, on a KVM host)
 
-Confirmed working end-to-end on a sandbox-capable host during bring-up:
+Confirmed working end-to-end on a sandbox-capable host (msb 0.6.7) via
+`scripts/verify-backends` (15/15) and an interactive `acq run opencode`:
 `msb create` (with `--dns-nameserver`, `--tls-intercept`, `--trust-host-cas`,
-workspace mount at `/home/agent/workspace`, `agent` user creation), USAi key
-substitution (models API returns a real status over intercepted TLS),
-git-ssh-sign config, zscaler CA trust, and all kit files/commands applied. The
-one gap is the private playbook clone (above). Several msb behaviors were
+each workspace mounted at its **own absolute host path**, `agent` user created
+at a free uid with an agent-owned `/home/agent`), USAi key substitution (models
+API returns a real status over intercepted TLS), the playbook fetched via the
+REST tarball and linked, git-ssh-sign config, zscaler CA trust, and all kit
+files/commands applied. The agent is launched with `msb exec -t` (PTY) as the
+unprivileged `agent` user in the workspace. Several msb behaviors were
 discovered and worked around here (recorded so they aren't re-litigated):
 `msb create` returns 0 even on async start failure (→ exec-ready gate);
 identical host:guest `/tmp` mounts silently fail (→ fixed guest mount point);

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -213,6 +213,19 @@ for `docker/sandbox-templates:shell-docker`:
 Egress note: this adds one create-time allow-list host (the npm registry) only
 when an installable agent is requested; it does not widen egress for `shell`.
 
+### Guest sizing (follow-up to quickstart#228)
+
+Installing and launching the agent (above) exposed a further defect on the same
+report: `opencode` **started and was immediately `Killed`**. msb defaults a
+sandbox to **512 MiB of RAM and 1 vCPU** and the microVM has **no swap**, so a
+Node.js TUI that exceeds guest RAM is OOM-killed by the guest kernel (surfacing
+only as `Killed`). sbx's agent templates are sized generously; a plain msb base
+inherits the small default. The adapter therefore passes **`--memory 4G --cpus 2`**
+at create, tunable via `ACQ_MSB_MEMORY` / `ACQ_MSB_CPUS` (empty = fall back to
+msb's own default). Values are validated before reaching the create line (memory
+to msb's `[0-9GMgm.]` SIZE grammar, cpus to a positive integer) so a stray value
+cannot smuggle another flag onto `msb create`.
+
 ### msb CLI flag verification
 
 The msb flag/subcommand shapes used by the adapter were **verified against

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -344,19 +344,13 @@ reported by `acq kit validate`), because a name reaches the guest environment an
 possibly a shell. **Secrets do NOT go here** — they continue through the backend
 credential/secret path (sbx proxy, msb `--secret ENV@HOST`), never the kit spec.
 
-> **Cross-repo dependency:** the authoritative `environment` schema property +
-> the field-level validator live in the **patterns** repo
-> (`schemas/kit-hybrid-v1.schema.json`, `validate-kits.py`, PR #227 + the review
-> follow-up #228), merged and shipped in patterns **v1.7.0**.
->
-> **Pin status (TEMPORARY — see quickstart#203 / patterns#269):** `PATTERNS_KIT_REF`
-> (`acq.backends/common.sh`) is currently pinned to the **tip of patterns
-> `feat/fix-playbook-clones`** (`379756a…`), which carries the playbook kit's
-> REST-tarball fetch (the #203 fix) and is **not yet on patterns `main`**. This
-> is an explicit, in-code-documented temporary pin for validation. The release
-> gate is **not** satisfied until patterns#269 merges and this pin is finalized
-> to the merge commit / next release tag (and the two pin assertions in
-> `scripts/test-acq` are restored). Do not cut a release in the interim.
+> **Cross-repo dependency (satisfied):** the authoritative `environment` schema
+> property + the field-level validator live in the **patterns** repo
+> (`schemas/kit-hybrid-v1.schema.json`, `validate-kits.py`, PR #227), and the
+> playbook kit's REST-tarball fetch (the quickstart#203 fix) landed in
+> patterns#269. Both are merged to patterns `main`, and `PATTERNS_KIT_REF`
+> (`acq.backends/common.sh`) is pinned to `3fcde8e` (the #269 merge commit on
+> `main`, which includes #227). The release gate is satisfied.
 
 ## Live verification (msb, on a KVM host)
 

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -204,12 +204,15 @@ for `docker/sandbox-templates:shell-docker`:
   — the two remaining published requirements a plain base lacks. Idempotent +
   marker-gated; a base without `sudo` is non-fatal (acq runs root steps as
   `-u 0` directly).
-- **Launch the agent on attach** (`acq_backend_attach` → `_acq_msb_ssh_agent`).
-  Reproduces `sbx run --name`'s "re-launch the baked-in agent" behavior:
-  `msb ssh NAME -- su - agent -c "cd <workspace>; exec <agent>"`. The agent to
-  run is recorded at provision (`/var/lib/acq/agent`) so the name-only re-attach
-  path (`acq run <sandbox>`) still launches it. Falls back to a shell **as the
-  agent user** (never root) for `shell` sandboxes or a missing binary.
+- **Launch the agent on attach** (`acq_backend_attach` → `_acq_msb_attach`).
+  Reproduces `sbx run --name`'s "re-launch the baked-in agent" behavior with
+  `msb exec -t -u agent -w <workspace> -e SHELL=/bin/sh NAME -- <agent>` — the one
+  msb primitive that allocates a PTY (so a full-screen agent TUI renders; `msb
+  ssh` has no tty flag), runs as the unprivileged `agent` user, and starts in the
+  workspace. The agent to run is recorded at provision (`/var/lib/acq/agent`) so
+  the name-only re-attach path (`acq run <sandbox>`) still launches it. Falls back
+  to an interactive `/bin/sh -l` **as the agent user** (never root, never msb's
+  Node-REPL default) for `shell` sandboxes or a missing binary.
 
 Egress note: this adds one create-time allow-list host (the npm registry) only
 when an installable agent is requested; it does not widen egress for `shell`.

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -172,6 +172,47 @@ at create/run time via `-p HOST:GUEST`; the flag gates the sbx-style post-hoc
   state-preserving in-place add (msb has no `sbx kit add` equivalent); it never
   silently destroys state.
 
+### Agent install + base-image contract + attach (fix for quickstart#228)
+
+The initial 1.2.0 msb adapter provisioned a sandbox with the four kits but
+**never installed or launched the requested agent** (`opencode`): `msb create`
+booted a plain `node:22-bookworm`, no step installed opencode, and
+`acq_backend_attach` ran a bare `msb ssh NAME` — dropping the user into a **root
+shell with no agent** (reported in
+[quickstart#228](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/228)).
+Both defects stem from the adapter ignoring the AGENT token that
+`acq_backend_provision`/`attach` receive. On sbx this "just works" because the
+agent **template supplies the binary and its launch wiring**; msb runs a plain
+base and must reproduce that itself. The fix makes the msb adapter satisfy the
+same contract sbx's templates provide, keyed off the
+[Docker base-image requirements](https://docs.docker.com/ai/sandboxes/customize/kit-reference/#base-image-requirements)
+for `docker/sandbox-templates:shell-docker`:
+
+- **Install the agent** (`_acq_msb_install_agent`). The AGENT token is read from
+  the first positional at provision. `opencode` → `npm install -g opencode-ai`
+  (node is already a verified prerequisite), with the npm registry host
+  (`registry.npmjs.org`) allow-listed at create so the default-deny egress
+  permits the download. Idempotent: skipped if the binary is already present
+  (a pre-baked `ACQ_MSB_IMAGE`) and marker-gated. `shell` is a no-op; an unknown,
+  absent agent warns (bake it into `ACQ_MSB_IMAGE`). Tunables:
+  `ACQ_MSB_OPENCODE_PKG`, `ACQ_MSB_NPM_HOSTS`.
+- **Satisfy the base-image contract** (`_acq_msb_ensure_agent_user`, extended).
+  In addition to the `agent`/`/home/agent` user it already created, it now adds
+  **passwordless sudo** (`/etc/sudoers.d/90-acq-agent`) and preserves the
+  **HTTP proxy env across sudo** (`env_keep` in `/etc/sudoers.d/91-acq-proxy-env`)
+  — the two remaining published requirements a plain base lacks. Idempotent +
+  marker-gated; a base without `sudo` is non-fatal (acq runs root steps as
+  `-u 0` directly).
+- **Launch the agent on attach** (`acq_backend_attach` → `_acq_msb_ssh_agent`).
+  Reproduces `sbx run --name`'s "re-launch the baked-in agent" behavior:
+  `msb ssh NAME -- su - agent -c "cd <workspace>; exec <agent>"`. The agent to
+  run is recorded at provision (`/var/lib/acq/agent`) so the name-only re-attach
+  path (`acq run <sandbox>`) still launches it. Falls back to a shell **as the
+  agent user** (never root) for `shell` sandboxes or a missing binary.
+
+Egress note: this adds one create-time allow-list host (the npm registry) only
+when an installable agent is requested; it does not widen egress for `shell`.
+
 ### msb CLI flag verification
 
 The msb flag/subcommand shapes used by the adapter were **verified against
@@ -277,18 +318,23 @@ secret substitution requires `--tls-intercept` and only covers the
 ## Validation
 
 - `bash -n acq acq.backends/*.sh scripts/test-acq scripts/verify-backends` clean.
-- `./scripts/test-acq` passes (135 checks, incl. msb + kit + translation +
-  untrusted-input-hardening cases).
+- `./scripts/test-acq` passes (incl. msb + kit + translation +
+  untrusted-input-hardening cases, and the quickstart#228 regression cases:
+  agent install, base-image contract — passwordless sudo + proxy `env_keep` —
+  and attach-launches-agent-as-agent-user).
 - Neutral→sbx-v2 synthesis for all four kits parses as valid YAML (verified with
   a YAML parser during development).
 - `npm run lint` (markdownlint, shellcheck, gitleaks, YAML/JSON) — run in CI.
 - **Deferred, requires a sandbox-capable host (no nested sandboxes):**
-  the full `acq run … --backend msb` create→exec→attach loop and the
-  `scripts/verify-backends` msb row cannot run inside an sbx/msb sandbox and need
-  host virtualization (`/dev/kvm` on Linux). The msb CLI flag shapes were
+  the full `acq run … --backend msb` create→install→exec→attach loop and the
+  `scripts/verify-backends` msb rows (now including the `opencode`-installed
+  assertion added for quickstart#228) cannot run inside an sbx/msb sandbox and
+  need host virtualization (`/dev/kvm` on Linux). The msb CLI flag shapes were
   verified against `msb 0.6.6`; the live loop is deferred and mirrors how
   ADR-0009/ADR-0010 defer live verification. Run `./scripts/verify-backends`
-  on a sandbox-capable host and attach the transcript.
+  on a sandbox-capable host and attach the transcript. **The quickstart#228 fix
+  (agent install + attach launch) is verified offline via the stubbed harness;
+  its live create→install→attach path still needs a KVM host run.**
 
 ## Release gate (satisfied)
 

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -111,9 +111,10 @@ the neutral `hybrid/v1` kits, JSON schema, and registry) lands separately in
   user (HOME=/home/agent)** the kits assume (the sbx agent-template contract) —
   a plain base has no such user (node:22-bookworm has `node` at uid 1000) — and
   runs the kits' uid-1000 commands as `agent` (by name, with HOME set), chowning
-  staged `/home/agent` files to it. It **mounts the host workspace at a fixed
-  guest path** (`ACQ_MSB_WORKSPACE`, default `/home/agent/workspace`) because msb
-  won't create the host path and mishandles an identical host:guest `/tmp` mount.
+  staged `/home/agent` files to it. It **mounts each host workspace at the same
+  absolute path in the guest** (sbx-parity; see the workspace-mount note below) —
+  an earlier revision remapped to a fixed `/home/agent/workspace`, which failed
+  because `msb create` mounts before the `agent` user/home exist.
   It passes **`--dns-nameserver`** (default `1.1.1.1`) because msb hands the
   guest the host's resolvers, which for a corporate/VPN resolver are unreachable
   from the microVM (otherwise the guest can't resolve even allow-listed hosts).
@@ -225,6 +226,34 @@ at create, tunable via `ACQ_MSB_MEMORY` / `ACQ_MSB_CPUS` (empty = fall back to
 msb's own default). Values are validated before reaching the create line (memory
 to msb's `[0-9GMgm.]` SIZE grammar, cpus to a positive integer) so a stray value
 cannot smuggle another flag onto `msb create`.
+
+### Workspace mount at the host path (fix for PR #230)
+
+An earlier revision mounted the host workspace at a **fixed guest path**
+(`/home/agent/workspace`). That failed on a plain base image with
+`mount ...: Not a directory (os error 20)`: `msb create` performs the mount at
+**create time**, which is *before* the adapter can create the `agent` user and
+its `/home/agent` directory (that happens post-create, once the guest is
+exec-ready). Mounting into a not-yet-existent `/home/agent` therefore aborted
+the sandbox boot.
+
+The adapter now mounts **each workspace at its own absolute host path in the
+guest** (`--volume <host>:<host>[:ro]`), matching sbx's multi-workspace
+semantics (`docs/QUICKSTART_SBX.md`: "All workspaces appear inside the sandbox at
+their absolute host paths"). This sidesteps the create-time ordering problem and
+restores sbx parity. Multiple workspaces and a trailing `:ro` marker are
+supported (`workspace_paths` in `common.sh` enumerates them). The agent's
+starting directory is recorded at provision (`/var/lib/acq/workspace`) for the
+name-only re-attach path: it is the **primary (first) workspace**, matching sbx.
+`ACQ_MSB_WORKSPACE` overrides the start dir.
+
+A second, related failure: msb **cannot mount a symlinked host path**. It fails
+to start with the same `os error 20` even mapped to a shallow guest target
+(verified on msb 0.6.6). The common case is **macOS `$TMPDIR`**, a per-user
+`/var/folders/...` tree reached through the `/var` → `/private/var` symlink. The
+adapter therefore canonicalizes each workspace to its real, symlink-free path
+(`canonicalize_path` in `common.sh`) before mounting, and `scripts/verify-backends`
+no longer places its test workspace under `$TMPDIR`.
 
 ### msb CLI flag verification
 

--- a/docs/explorations/acq-design.md
+++ b/docs/explorations/acq-design.md
@@ -908,9 +908,9 @@ kit vocabulary** with a translation layer. Recorded in
    silently dropped every file/command after the first (this was the actual
    cause of the missing `merge-global-config.mjs`, not the earlier copy-race
    theory; `msb` exec/copy persistence itself was verified fine);
-   (ii) the host workspace is mounted at a fixed guest path
-   (`/home/agent/workspace`), because msb won't create the host path and
-   mishandles an identical host:guest `/tmp` mount;
+   (ii) each host workspace is mounted at its SAME absolute guest path
+   (sbx-parity), after an earlier fixed `/home/agent/workspace` remap failed
+   because `msb create` mounts before the agent user/home exist;
    (iii) `--dns-nameserver` (default `1.1.1.1`) is passed to `msb create`,
    because the host's corporate/VPN resolver is unreachable from the microVM
    (verified: with it, the models API resolves and returns 401/200 and github

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -776,8 +776,8 @@ out=$(ACQ_BACKEND=sbx "$ACQ" version 2>&1); rc=$?
 assert_eq "version exits 0" "0" "$rc"
 assert_contains "version: script path" "$out" "$REPO_ROOT/acq"
 # Assert `version` reports the CONFIGURED pin (read from common.sh), not a
-# hardcoded SHA — so this holds across pin bumps (incl. the temporary
-# patterns#269 pin and its eventual finalize). Tests the invariant, not a commit.
+# hardcoded SHA — so this holds across pin bumps. Tests the invariant, not a commit.
+# shellcheck disable=SC1090
 _want_ref=$(ACQ_SOURCE_ONLY=1 ACQ_SCRIPT_DIR="$REPO_ROOT" . "$ACQ" >/dev/null 2>&1; printf '%s' "$PATTERNS_KIT_REF")
 assert_contains "version: patterns kit ref" "$out" "$_want_ref"
 assert_contains "version: backend line" "$out" "backend:"
@@ -1695,6 +1695,7 @@ fi
 make_stubs
 out=$("$ACQ" kit list 2>&1)
 # Assert the CONFIGURED pin (not a hardcoded SHA) so this survives pin bumps.
+# shellcheck disable=SC1090
 _want_ref=$(ACQ_SOURCE_ONLY=1 ACQ_SCRIPT_DIR="$REPO_ROOT" . "$ACQ" >/dev/null 2>&1; printf '%s' "$PATTERNS_KIT_REF")
 assert_contains "kit: list shows patterns ref" "$out" "$_want_ref"
 assert_contains "kit: list shows acq-kits dir" "$out" "acq-kits"

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -131,6 +131,7 @@ case "$_msb_sub" in
       *"test -f "*) exit 1 ;;       # markers absent
       *"test -s "*) exit 0 ;;       # copied files present
       *"cat /var/lib/acq/agent"*) printf '%s' "${STUB_RECORDED_AGENT:-}" ;;
+      *"cat /var/lib/acq/workspace"*) printf '%s' "${STUB_RECORDED_WORKSPACE:-}" ;;
       *) : ;;
     esac ;;
   ssh)  : ;;
@@ -704,10 +705,71 @@ assert_contains "msb: provision enables --tls-intercept (needed for substitution
 assert_contains "msb: provision binds USAi via --secret" "$prov_log" "--secret USAI_API_KEY@api.gsa.usai.gov"
 assert_not_contains "msb: provision does NOT bind github (git substitution unsupported)" "$prov_log" "GITHUB_TOKEN@"
 assert_eq "msb: provision never leaks secret values to argv" "CLEAN" "$prov_leaks"
-# Workspace is mounted at the fixed guest path (NOT host:host), and the host
-# path (/tmp) exists so no error.
-assert_contains "msb: workspace mounted at guest path" "$prov_log" "--volume /tmp:/home/agent/workspace"
-assert_not_contains "msb: workspace NOT mounted host:host" "$prov_log" "--volume /tmp:/tmp"
+# Workspace is mounted at the SAME absolute path in the guest (sbx-parity), not
+# remapped under /home/agent (which fails to mount pre-user-create).
+assert_contains "msb: workspace mounted at same guest path (sbx-parity)" "$prov_log" "--volume /tmp:/tmp"
+assert_not_contains "msb: workspace NOT remapped under /home/agent" "$prov_log" "--volume /tmp:/home/agent/workspace"
+cleanup_stubs
+
+# 8m1b. Multi-workspace: every workspace positional after the agent is mounted at
+#       its own absolute host path (sbx-parity), a trailing :ro is preserved, and
+#       the recorded start dir is the FIRST (primary) workspace regardless of how
+#       many mounts are given (docs/QUICKSTART_SBX.md: "Primary workspace — the
+#       first path; agent starts here").
+make_stubs; load_acq
+# Two real host dirs to mount (a nonexistent path would hard-fail provision).
+mkdir -p "$STUBDIR/ws-app" "$STUBDIR/ws-lib"
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/mw-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision mwbox opencode "$STUBDIR/ws-app" "$STUBDIR/ws-lib:ro" >/dev/null 2>&1
+)
+mw_log=$(cat "$CALLS")
+assert_contains "msb: multi-ws mounts primary at its host path" "$mw_log" "--volume ${STUBDIR}/ws-app:${STUBDIR}/ws-app"
+assert_contains "msb: multi-ws mounts extra ro at its host path" "$mw_log" "--volume ${STUBDIR}/ws-lib:${STUBDIR}/ws-lib:ro"
+assert_contains "msb: multi-ws start dir is the FIRST (primary) workspace" "$mw_log" "'${STUBDIR}/ws-app' > /var/lib/acq/workspace"
+assert_not_contains "msb: multi-ws does NOT fall back to /home/agent/workspace" "$mw_log" "'/home/agent/workspace' > /var/lib/acq/workspace"
+
+# Single workspace records that mount as the start dir.
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/sw-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  acq_backend_provision swbox opencode "$STUBDIR/ws-app" >/dev/null 2>&1
+)
+sw_log=$(cat "$CALLS")
+assert_contains "msb: single-ws records that mount as start dir" "$sw_log" "'${STUBDIR}/ws-app' > /var/lib/acq/workspace"
+cleanup_stubs
+
+# 8m1c. Symlinked host workspace is canonicalized before mounting. msb cannot
+#       mount a symlinked host path (macOS $TMPDIR is /var -> /private/var), so
+#       acq resolves it to its real path first. Simulate with a symlink dir ->
+#       real dir and assert the --volume uses the REAL target, not the link.
+make_stubs; load_acq
+mkdir -p "$STUBDIR/real-ws"
+ln -sf "$STUBDIR/real-ws" "$STUBDIR/link-ws"
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/sym-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision symbox opencode "$STUBDIR/link-ws" >/dev/null 2>&1
+)
+sym_log=$(cat "$CALLS")
+# realpath of the symlink is the real dir; assert the mount uses it.
+_real_ws=$(realpath "$STUBDIR/real-ws" 2>/dev/null || printf '%s' "$STUBDIR/real-ws")
+assert_contains "msb: symlinked workspace canonicalized to real path" "$sym_log" "--volume ${_real_ws}:${_real_ws}"
+assert_not_contains "msb: symlinked workspace NOT mounted via the link" "$sym_log" "--volume ${STUBDIR}/link-ws:"
 cleanup_stubs
 
 # 8m2. msb provision aborts (hard fail) when the sandbox never becomes
@@ -884,6 +946,7 @@ make_stubs; load_acq
 : > "$CALLS"
 (
   export STUB_RECORDED_AGENT="opencode"
+  export STUB_RECORDED_WORKSPACE="/tmp/myrepo"
   . "${REPO_ROOT}/acq.backends/msb.sh"
   acq_backend_attach attachbox >/dev/null 2>&1
 )
@@ -891,7 +954,7 @@ attach_log=$(cat "$CALLS")
 assert_contains "msb: attach uses msb ssh" "$attach_log" "msb ssh attachbox"
 assert_contains "msb: attach drops to the agent user (su - agent)" "$attach_log" "su - agent"
 assert_contains "msb: attach execs the recorded agent" "$attach_log" "exec 'opencode'"
-assert_contains "msb: attach cds into the workspace" "$attach_log" "cd '/home/agent/workspace'"
+assert_contains "msb: attach cds into the recorded workspace" "$attach_log" "cd '/tmp/myrepo'"
 assert_not_contains "msb: attach is NOT a bare root ssh" "$attach_log" "msb ssh attachbox
 "
 cleanup_stubs

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -857,9 +857,15 @@ SPEC
 agent_log=$(cat "$CALLS")
 assert_contains "msb: provision creates agent user" "$agent_log" "agent"
 # The uid-1000 startup command must run as `agent` with HOME=/home/agent,
-# never as `-u 1000` (which would be the base image's `node` user).
-assert_contains "msb: uid-1000 kit cmd runs as agent" "$agent_log" "msb exec agentbox -u agent -e HOME=/home/agent -- node"
+# never as `-u 1000` (which would be the base image's `node` user). acq also
+# injects non-interactive git guards (GIT_TERMINAL_PROMPT=0 etc.) between the
+# HOME env and the argv, so assert the stable prefix rather than the full line.
+assert_contains "msb: uid-1000 kit cmd runs as agent" "$agent_log" "msb exec agentbox -u agent -e HOME=/home/agent"
 assert_not_contains "msb: uid-1000 kit cmd not run as -u 1000" "$agent_log" "msb exec agentbox -u 1000 -- node"
+# Non-interactive enforcement: kit execs get stdin-free git prompt guards so a
+# kit that would prompt (e.g. private `git clone`) fails fast instead of hanging
+# provision. Assert the guard env is threaded onto the startup command.
+assert_contains "msb: kit cmd gets GIT_TERMINAL_PROMPT=0 guard" "$agent_log" "-e GIT_TERMINAL_PROMPT=0"
 assert_contains "msb: chowns staged /home/agent file to agent" "$agent_log" "chown agent /home/agent/usai-config/merge-global-config.mjs"
 cleanup_stubs
 

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -119,9 +119,18 @@ case "$_msb_sub" in
     case "$snippet" in
       *"echo ok"*) printf 'ok\n' ;;
       *'%{http_code}'*) printf '%s' "${STUB_KEY_STATUS:-200}" ;;
+      # `command -v <agent>` (agent-presence probe): controllable so the install
+      # path can be exercised. By default the agent is ABSENT (exit 1) so install
+      # runs; STUB_AGENT_PRESENT=1 makes it "present" (skips install). The prereq
+      # `command -v node/git/curl/...` checks stay "present" (exit 0).
+      *"command -v 'opencode'"*|*"command -v 'claude'"*|*"command -v 'shell'"*)
+        [ "${STUB_AGENT_PRESENT:-0}" = "1" ] && exit 0 || exit 1 ;;
       *"command -v"*) : ;;          # prereqs "present" (empty missing set)
+      *"npm install"*)
+        [ "${STUB_NPM_FAIL:-0}" = "1" ] && exit 1 || exit 0 ;;
       *"test -f "*) exit 1 ;;       # markers absent
       *"test -s "*) exit 0 ;;       # copied files present
+      *"cat /var/lib/acq/agent"*) printf '%s' "${STUB_RECORDED_AGENT:-}" ;;
       *) : ;;
     esac ;;
   ssh)  : ;;
@@ -790,6 +799,115 @@ assert_contains "msb: provision creates agent user" "$agent_log" "agent"
 assert_contains "msb: uid-1000 kit cmd runs as agent" "$agent_log" "msb exec agentbox -u agent -e HOME=/home/agent -- node"
 assert_not_contains "msb: uid-1000 kit cmd not run as -u 1000" "$agent_log" "msb exec agentbox -u 1000 -- node"
 assert_contains "msb: chowns staged /home/agent file to agent" "$agent_log" "chown agent /home/agent/usai-config/merge-global-config.mjs"
+cleanup_stubs
+
+# 8n1. msb provision satisfies the Docker base-image contract for the agent user:
+#      passwordless sudo (sudoers.d drop-in) AND HTTP proxy env preserved across
+#      sudo (env_keep). See docs.docker.com kit-reference "Base image requirements".
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/basereq-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision basereqbox shell /tmp >/dev/null 2>&1
+)
+basereq_log=$(cat "$CALLS")
+assert_contains "msb: agent gets passwordless sudo (sudoers.d)" "$basereq_log" "sudoers.d/90-acq-agent"
+assert_contains "msb: NOPASSWD rule for agent" "$basereq_log" "NOPASSWD:ALL"
+assert_contains "msb: proxy env preserved across sudo (env_keep)" "$basereq_log" "env_keep"
+assert_contains "msb: proxy env_keep names HTTPS_PROXY" "$basereq_log" "HTTPS_PROXY"
+cleanup_stubs
+
+# 8n2. msb provision INSTALLS the requested agent (opencode) when it is not
+#      already present — the reported bug was that opencode was never installed.
+#      Install is `npm install -g opencode-ai` as root, and the create call
+#      allow-lists the npm registry host so the (default-deny) egress permits it.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/inst-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  # Default stub: agent ABSENT -> install runs; npm succeeds.
+  acq_backend_provision instbox opencode /tmp >/dev/null 2>&1
+)
+inst_log=$(cat "$CALLS")
+assert_contains "msb: installs opencode via npm -g" "$inst_log" "npm install -g --no-fund --no-audit opencode-ai"
+assert_contains "msb: allow-lists npm registry host at create" "$inst_log" "--net-rule allow@registry.npmjs.org"
+assert_contains "msb: records the agent for attach" "$inst_log" "/var/lib/acq/agent"
+cleanup_stubs
+
+# 8n3. Idempotent install: if the agent binary is already present (e.g. baked
+#      into ACQ_MSB_IMAGE), provision does NOT run npm install again.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/inst2-secrets" STUB_AGENT_PRESENT=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision inst2box opencode /tmp >/dev/null 2>&1
+)
+assert_not_contains "msb: skips npm install when agent already present" "$(cat "$CALLS")" "npm install"
+cleanup_stubs
+
+# 8n4. `shell` sandbox: no agent binary install, no npm registry allow-list.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/shell-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision shellbox shell /tmp >/dev/null 2>&1
+)
+shell_log=$(cat "$CALLS")
+assert_not_contains "msb: shell agent does not npm install" "$shell_log" "npm install"
+assert_not_contains "msb: shell agent adds no npm net-rule" "$shell_log" "allow@registry.npmjs.org"
+cleanup_stubs
+
+# 8n5. Attach LAUNCHES the recorded agent as the `agent` user in the workspace —
+#      NOT a bare root shell (the reported bug). `msb ssh NAME` alone drops you in
+#      as root; acq must `su - agent` + exec the recorded agent.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export STUB_RECORDED_AGENT="opencode"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  acq_backend_attach attachbox >/dev/null 2>&1
+)
+attach_log=$(cat "$CALLS")
+assert_contains "msb: attach uses msb ssh" "$attach_log" "msb ssh attachbox"
+assert_contains "msb: attach drops to the agent user (su - agent)" "$attach_log" "su - agent"
+assert_contains "msb: attach execs the recorded agent" "$attach_log" "exec 'opencode'"
+assert_contains "msb: attach cds into the workspace" "$attach_log" "cd '/home/agent/workspace'"
+assert_not_contains "msb: attach is NOT a bare root ssh" "$attach_log" "msb ssh attachbox
+"
+cleanup_stubs
+
+# 8n6. Attach on a `shell` sandbox (or an unrecorded agent) opens a shell as the
+#      agent user — still never a root shell.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export STUB_RECORDED_AGENT="shell"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  acq_backend_attach shellattach >/dev/null 2>&1
+)
+shellattach_log=$(cat "$CALLS")
+assert_contains "msb: shell attach drops to agent user" "$shellattach_log" "su - agent"
+assert_not_contains "msb: shell attach does not exec a named agent" "$shellattach_log" "exec 'shell'"
 cleanup_stubs
 
 # 8o. Regression: msb applies ALL kit files and ALL kit commands, not just the

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -722,6 +722,10 @@ if grep -q 'ghp_SECRETVALUE' "$CALLS"; then
 else
   pass "secret set: value never leaks to msb argv (passed via env)"
 fi
+# The value must reach the child as an env ENTRY (export), NOT as an `env
+# NAME=VAL msb …` argv operand (which `ps`/cmdline would expose). Assert the
+# rotate path does not shell out through `env` with the token on argv.
+assert_not_contains "secret set: no 'env NAME=VAL' argv leak (uses export)" "$set_log" "env GITHUB_TOKEN="
 cleanup_stubs
 
 # 5h2d. Global `acq secret set -g usai` (msb) sweeps ALL running sandboxes
@@ -1298,6 +1302,39 @@ assert_contains "msb: shell attach uses msb exec -t as agent" "$shellattach_log"
 assert_contains "msb: shell attach execs an explicit /bin/sh -l" "$shellattach_log" "shellattach -- /bin/sh -l"
 assert_not_contains "msb: shell attach does not exec a named agent" "$shellattach_log" "shellattach -- shell"
 assert_not_contains "msb: shell attach does NOT use msb ssh" "$shellattach_log" "msb ssh"
+cleanup_stubs
+
+# 8n7. SECURITY: a hostile agent token must never break out of the
+#      `sh -c "command -v '$agent'"` single-quoting. (1) install path with a
+#      metachar-laden `acq create` agent arg, and (2) attach reading a tampered
+#      /var/lib/acq/agent marker — both must refuse/fall back, never emit an
+#      `sh -c` string containing the injection.
+make_stubs; load_acq
+: > "$CALLS"
+inj_out=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/inj-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_install_agent injbox "x';touch /tmp/acq_pwn;'" 2>&1
+)
+inj_log=$(cat "$CALLS")
+assert_contains "msb: install refuses metachar agent token" "$inj_out" "refusing agent name"
+assert_not_contains "msb: install never emits the injected sh -c" "$inj_log" "touch /tmp/acq_pwn"
+cleanup_stubs
+
+# Attach with a tampered marker (returned by the stub) falls back to a shell and
+# never interpolates the injection into an sh -c command-v probe.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export STUB_RECORDED_AGENT="x';touch /tmp/acq_pwn;'"
+  export STUB_RECORDED_WORKSPACE="/tmp/wsp"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  acq_backend_attach injattach >/dev/null 2>&1
+)
+injattach_log=$(cat "$CALLS")
+assert_not_contains "msb: attach never runs the injected marker in sh -c" "$injattach_log" "touch /tmp/acq_pwn"
+assert_contains "msb: attach falls back to /bin/sh on tampered marker" "$injattach_log" "injattach -- /bin/sh -l"
 cleanup_stubs
 
 # 8o. Regression: msb applies ALL kit files and ALL kit commands, not just the

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -764,6 +764,29 @@ assert_eq "help: bare acq exits 2" "2" "$bare_rc"
 assert_contains "help: bare acq shows usage" "$bare_out" "acq — agentic coding quickstart wrapper"
 # --backend msb surfaces the msb backend's own help under the separator.
 assert_contains "help: --backend msb appends msb help" "$(ACQ_BACKEND=sbx "$ACQ" --backend msb help 2>&1)" "msb"
+# A `--help`/`-h` AFTER `--` must NOT be hijacked into acq's help — it belongs to
+# the agent/inner command and must pass through verbatim.
+: > "$CALLS"
+ACQ_BACKEND=sbx "$ACQ" exec mybox -- mycmd --help >/dev/null 2>&1 || true
+afterdd_log=$(cat "$CALLS")
+assert_contains "help: --help after -- passes through to backend exec" "$afterdd_log" "mycmd --help"
+assert_not_contains "help: --help after -- did NOT print acq help" "$afterdd_log" "agentic coding quickstart wrapper"
+cleanup_stubs
+
+# 7c. `acq secret ls|import|set-custom` pass through to the backend WITHOUT
+#     doubling the subcommand token (regression: `sbx secret ls ls`). The set/rm
+#     branches shift; this branch must too.
+make_stubs
+: > "$CALLS"
+ACQ_BACKEND=sbx "$ACQ" secret ls -q >/dev/null 2>&1 || true
+ls_log=$(cat "$CALLS")
+assert_contains "secret ls: forwards a single ls token" "$ls_log" "sbx secret ls -q"
+assert_not_contains "secret ls: does NOT double the token" "$ls_log" "secret ls ls"
+: > "$CALLS"
+ACQ_BACKEND=sbx "$ACQ" secret set-custom -g --host h --env E >/dev/null 2>&1 || true
+sc_log=$(cat "$CALLS")
+assert_contains "secret set-custom: single token" "$sc_log" "sbx secret set-custom -g --host h --env E"
+assert_not_contains "secret set-custom: not doubled" "$sc_log" "set-custom set-custom"
 cleanup_stubs
 
 # ===========================================================================

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1152,38 +1152,60 @@ assert_not_contains "msb: shell agent does not npm install" "$shell_log" "npm in
 assert_not_contains "msb: shell agent adds no npm net-rule" "$shell_log" "allow@registry.npmjs.org"
 cleanup_stubs
 
-# 8n5. Attach LAUNCHES the recorded agent as the `agent` user in the workspace —
-#      NOT a bare root shell (the reported bug). `msb ssh NAME` alone drops you in
-#      as root; acq must `su - agent` + exec the recorded agent.
+# 8n5. Attach LAUNCHES the recorded agent as the `agent` user in the workspace,
+#      with a PTY — NOT a bare root shell (the reported bug) and NOT msb's Node
+#      REPL default. Uses `msb exec -t -u agent -w <ws>` (not `msb ssh`, which has
+#      no tty flag and hung the TUI).
 make_stubs; load_acq
 : > "$CALLS"
 (
   export STUB_RECORDED_AGENT="opencode"
   export STUB_RECORDED_WORKSPACE="/tmp/myrepo"
+  export STUB_AGENT_PRESENT=1     # opencode binary present -> attach execs it
   . "${REPO_ROOT}/acq.backends/msb.sh"
   acq_backend_attach attachbox >/dev/null 2>&1
 )
 attach_log=$(cat "$CALLS")
-assert_contains "msb: attach uses msb ssh" "$attach_log" "msb ssh attachbox"
-assert_contains "msb: attach drops to the agent user (su - agent)" "$attach_log" "su - agent"
-assert_contains "msb: attach execs the recorded agent" "$attach_log" "exec 'opencode'"
-assert_contains "msb: attach cds into the recorded workspace" "$attach_log" "cd '/tmp/myrepo'"
-assert_not_contains "msb: attach is NOT a bare root ssh" "$attach_log" "msb ssh attachbox
-"
+assert_contains "msb: attach allocates a PTY (msb exec -t)" "$attach_log" "msb exec -t -u agent"
+assert_contains "msb: attach runs as the agent user" "$attach_log" "-u agent -w /tmp/myrepo"
+assert_contains "msb: attach sets a sane SHELL" "$attach_log" "-e SHELL=/bin/sh"
+assert_contains "msb: attach execs the recorded agent in the workspace" "$attach_log" "attachbox -- opencode"
+assert_not_contains "msb: attach does NOT use msb ssh (no PTY / TUI hang)" "$attach_log" "msb ssh"
+assert_not_contains "msb: attach does NOT su - agent (msb exec -u handles it)" "$attach_log" "su - agent"
 cleanup_stubs
 
-# 8n6. Attach on a `shell` sandbox (or an unrecorded agent) opens a shell as the
-#      agent user — still never a root shell.
+# 8n5b. Attach FALLS BACK to a shell (with notice) when the recorded agent binary
+#       is missing — never leaves the user in a broken/blank session.
+make_stubs; load_acq
+: > "$CALLS"
+missing_out=$(
+  export STUB_RECORDED_AGENT="opencode"
+  export STUB_RECORDED_WORKSPACE="/tmp/myrepo"
+  export STUB_AGENT_PRESENT=0     # opencode absent -> fall back to /bin/sh -l
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  acq_backend_attach attachbox 2>&1
+)
+missing_log=$(cat "$CALLS")
+assert_contains "msb: attach falls back to shell when agent binary missing" "$missing_log" "attachbox -- /bin/sh -l"
+assert_contains "msb: attach warns when agent binary missing" "$missing_out" "not found in sandbox"
+cleanup_stubs
+
+# 8n6. Attach on a `shell` sandbox (or an unrecorded agent) opens a login shell
+#      as the agent user with a PTY — never a root shell, never msb's Node REPL
+#      (so it must pass an explicit `/bin/sh -l`, not omit the command).
 make_stubs; load_acq
 : > "$CALLS"
 (
   export STUB_RECORDED_AGENT="shell"
+  export STUB_RECORDED_WORKSPACE="/tmp/wsp"
   . "${REPO_ROOT}/acq.backends/msb.sh"
   acq_backend_attach shellattach >/dev/null 2>&1
 )
 shellattach_log=$(cat "$CALLS")
-assert_contains "msb: shell attach drops to agent user" "$shellattach_log" "su - agent"
-assert_not_contains "msb: shell attach does not exec a named agent" "$shellattach_log" "exec 'shell'"
+assert_contains "msb: shell attach uses msb exec -t as agent" "$shellattach_log" "msb exec -t -u agent -w /tmp/wsp"
+assert_contains "msb: shell attach execs an explicit /bin/sh -l" "$shellattach_log" "shellattach -- /bin/sh -l"
+assert_not_contains "msb: shell attach does not exec a named agent" "$shellattach_log" "shellattach -- shell"
+assert_not_contains "msb: shell attach does NOT use msb ssh" "$shellattach_log" "msb ssh"
 cleanup_stubs
 
 # 8o. Regression: msb applies ALL kit files and ALL kit commands, not just the

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1168,6 +1168,78 @@ make_stubs; load_acq
 assert_not_contains "msb: empty DNS nameserver omits the flag" "$(cat "$CALLS")" "--dns-nameserver"
 cleanup_stubs
 
+# 8q2. msb provision sizes the guest generously by default (memory + cpus).
+#      msb's 512 MiB / 1 vCPU default OOM-kills a Node.js agent TUI (opencode
+#      prints "Killed" on launch), so acq passes a generous default at create.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/mem-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision membox shell /tmp >/dev/null 2>&1
+)
+mem_log=$(cat "$CALLS")
+assert_contains "msb: provision sets a generous default --memory" "$mem_log" "--memory 4G"
+assert_contains "msb: provision sets default --cpus" "$mem_log" "--cpus 2"
+cleanup_stubs
+
+# 8q3. ACQ_MSB_MEMORY / ACQ_MSB_CPUS overrides are honored.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/mem2-secrets" ACQ_MSB_MEMORY="8G" ACQ_MSB_CPUS="4"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision mem2box shell /tmp >/dev/null 2>&1
+)
+mem2_log=$(cat "$CALLS")
+assert_contains "msb: ACQ_MSB_MEMORY override honored" "$mem2_log" "--memory 8G"
+assert_contains "msb: ACQ_MSB_CPUS override honored" "$mem2_log" "--cpus 4"
+cleanup_stubs
+
+# 8q4. Empty ACQ_MSB_MEMORY / ACQ_MSB_CPUS omit the flags (fall back to msb's
+#      own default), and an invalid value is rejected with a warning (not passed
+#      through, so it can't smuggle another flag onto the create line).
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/mem3-secrets" ACQ_MSB_MEMORY="" ACQ_MSB_CPUS=""
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision mem3box shell /tmp >/dev/null 2>&1
+)
+mem3_log=$(cat "$CALLS")
+assert_not_contains "msb: empty ACQ_MSB_MEMORY omits the flag" "$mem3_log" "--memory"
+assert_not_contains "msb: empty ACQ_MSB_CPUS omits the flag" "$mem3_log" "--cpus"
+cleanup_stubs
+
+make_stubs; load_acq
+: > "$CALLS"
+mem_bad_out=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/mem4-secrets" ACQ_MSB_MEMORY="4G; rm -rf /" ACQ_MSB_CPUS="two"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision mem4box shell /tmp 2>&1 >/dev/null
+)
+mem4_log=$(cat "$CALLS")
+assert_contains "msb: invalid ACQ_MSB_MEMORY warns" "$mem_bad_out" "ignoring invalid ACQ_MSB_MEMORY"
+assert_contains "msb: invalid ACQ_MSB_CPUS warns" "$mem_bad_out" "ignoring invalid ACQ_MSB_CPUS"
+assert_not_contains "msb: invalid memory value not passed to create" "$mem4_log" "rm -rf"
+cleanup_stubs
+
 # ===========================================================================
 # 8r. acq usai-rotate-api-key — backend-neutral dispatch (ADR-0012)
 # ===========================================================================

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -119,6 +119,13 @@ case "$_msb_sub" in
     case "$snippet" in
       *"echo ok"*) printf 'ok\n' ;;
       *'%{http_code}'*) printf '%s' "${STUB_KEY_STATUS:-200}" ;;
+      # The ensure-agent-user block is one big `sh -c` (useradd/mkdir/chown + a
+      # `su agent … test -w /home/agent` writability check). Match it FIRST (it
+      # also contains `command -v useradd`, which the generic command-v case
+      # below would otherwise swallow). STUB_HOME_NOT_WRITABLE=1 models an
+      # unwritable home so the block exits 1 and provision must abort.
+      *"test -w /home/agent"*)
+        [ "${STUB_HOME_NOT_WRITABLE:-0}" = "1" ] && exit 1 || exit 0 ;;
       # `command -v <agent>` (agent-presence probe): controllable so the install
       # path can be exercised. By default the agent is ABSENT (exit 1) so install
       # runs; STUB_AGENT_PRESENT=1 makes it "present" (skips install). The prereq
@@ -138,6 +145,7 @@ case "$_msb_sub" in
   stop) : ;;
   remove|rm) : ;;
   copy|cp) : ;;
+  modify) : ;;
   *) : ;;
 esac
 # Drain any piped stdin exactly like a real remote exec would, so the test
@@ -464,16 +472,66 @@ else
 fi
 cleanup_stubs
 
-# 5d. `-g github` when it ALREADY exists -> stop with rm hint, no set call.
+# 5d. `-g github` when it ALREADY exists (in the GLOBAL scope) -> stop with rm
+#     hint, no set call. The fixture mirrors `sbx secret ls` layout (leading
+#     SCOPE column) so the scope-aware existence check matches the global row.
 make_stubs
-# Make the sbx stub's `secret ls` report github present.
-printf 'github\n' > "$STUBDIR/sbx_ls"
+printf 'SCOPE      TYPE      NAME     SECRET\n(global)   service   github   (stored)\n' > "$STUBDIR/sbx_ls"
 export SBX_LS_FIXTURE="$STUBDIR/sbx_ls"
 out=$(printf 'ghp_x\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g github 2>&1 || true)
 unset SBX_LS_FIXTURE
 log=$(cat "$CALLS")
 assert_contains "secret: existing github -> rm hint" "$out" "sbx secret rm -g github"
 assert_not_contains "secret: existing github -> no set call" "$log" "sbx secret set -g github"
+cleanup_stubs
+
+# 5d1. Scope-awareness regression: github existing under a DIFFERENT scope must
+#      NOT block seeding the target scope. Previously a blind substring match
+#      over the whole `sbx secret ls` produced a false "already exists" whenever
+#      any other sandbox had github (the verify-backends sbx seed skip). The
+#      fixture has github under `otherbox` only; setting `-g github` (global
+#      scope) must PROCEED to the feed call.
+make_stubs
+printf 'SCOPE      TYPE      NAME     SECRET\notherbox   service   github   (stored)\n' > "$STUBDIR/sbx_ls"
+export SBX_LS_FIXTURE="$STUBDIR/sbx_ls"
+out=$(printf 'ghp_x\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g github 2>&1 || true)
+unset SBX_LS_FIXTURE
+log=$(cat "$CALLS")
+assert_contains "secret: github under other scope does NOT block -g (feeds sbx)" "$log" "sbx secret set -g github"
+assert_not_contains "secret: github under other scope -> no false rm hint" "$out" "sbx secret rm -g github"
+cleanup_stubs
+
+# 5d2. Same, sandbox-scoped: setting `mybox github` when github exists only under
+#      `otherbox` must proceed (this is exactly the verify-backends seed case).
+make_stubs
+printf 'SCOPE      TYPE      NAME     SECRET\notherbox   service   github   (stored)\n' > "$STUBDIR/sbx_ls"
+export SBX_LS_FIXTURE="$STUBDIR/sbx_ls"
+out=$(printf 'ghp_x\n' | ACQ_BACKEND=sbx "$ACQ" secret set mybox github 2>&1 || true)
+unset SBX_LS_FIXTURE
+log=$(cat "$CALLS")
+assert_contains "secret: sandbox github not blocked by other scope (feeds sbx)" "$log" "sbx secret set mybox github"
+cleanup_stubs
+
+# 5d3. Section-awareness: a BUILT-IN service (github) must be matched in the
+#      built-in table only, and a CUSTOM service (usai) in the CUSTOM SECRETS
+#      table only — never cross-section. Fixture has BOTH tables populated.
+make_stubs
+cat > "$STUBDIR/sbx_ls" <<'LS'
+SCOPE      TYPE      NAME     SECRET
+(global)   service   github   (stored)
+
+CUSTOM SECRETS
+SCOPE      TARGETS            ENV            PLACEHOLDER               SECRET
+(global)   api.gsa.usai.gov   USAI_API_KEY   sbx-cs-0lrfssn3YnvE8P2j   api-ke***tJ63
+LS
+export SBX_LS_FIXTURE="$STUBDIR/sbx_ls"
+# github IS present in the built-in table at (global) -> should block with rm hint.
+gh_out=$(printf 'ghp_x\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g github 2>&1 || true)
+# usai IS present in the CUSTOM table at (global) -> should block with rm hint.
+usai_out=$(printf 'x\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai 2>&1 || true)
+unset SBX_LS_FIXTURE
+assert_contains "secret: github found in built-in section (blocks)" "$gh_out" "sbx secret rm -g github"
+assert_contains "secret: usai found in custom section (blocks)" "$usai_out" "already has"
 cleanup_stubs
 
 # 5e. `-g usai` (custom, non-interactive/piped) -> stored + prints sbx command,
@@ -537,6 +595,122 @@ perms=$(stat -c '%a' "$STUBDIR/unit-secrets/acq.usai" 2>/dev/null || stat -f '%L
 assert_eq "store: file entry is 0600" "600" "$perms"
 cleanup_stubs
 
+# 5h1. acq_secret_delete: removes an entry, is idempotent, and scoped.
+make_stubs
+del_out=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/del-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'GV\n' | acq_secret_store "$(_acq_secret_key github)"
+  printf 'SV\n' | acq_secret_store "$(_acq_secret_key github mybox)"
+  # Delete the sandbox-scoped one; global must remain. Check the KEY directly
+  # (acq_secret_get on the scoped key) rather than acq_secret_has, which would
+  # fall back to the global entry by design.
+  acq_secret_delete "$(_acq_secret_key github mybox)" && printf 'del-scoped-rc=0\n'
+  acq_secret_get "$(_acq_secret_key github mybox)" >/dev/null 2>&1 && printf 'scoped-still=yes\n' || printf 'scoped-still=no\n'
+  acq_secret_get "$(_acq_secret_key github)" >/dev/null 2>&1 && printf 'global-still=yes\n' || printf 'global-still=no\n'
+  # Deleting an absent key is success (idempotent).
+  acq_secret_delete "$(_acq_secret_key github mybox)" && printf 'del-absent-rc=0\n'
+  # Delete global too.
+  acq_secret_delete "$(_acq_secret_key github)" && printf 'del-global-rc=0\n'
+  acq_secret_get "$(_acq_secret_key github)" >/dev/null 2>&1 && printf 'global-after=yes\n' || printf 'global-after=no\n'
+)
+assert_contains "delete: removes scoped entry (rc 0)" "$del_out" "del-scoped-rc=0"
+assert_contains "delete: scoped gone after delete" "$del_out" "scoped-still=no"
+assert_contains "delete: global untouched by scoped delete" "$del_out" "global-still=yes"
+assert_contains "delete: absent key is idempotent success" "$del_out" "del-absent-rc=0"
+assert_contains "delete: global removed" "$del_out" "del-global-rc=0"
+assert_contains "delete: global gone after delete" "$del_out" "global-after=no"
+cleanup_stubs
+
+# 5h2. `acq secret rm SANDBOX github` (msb) removes the acq-store entry via the
+#      backend rm path, AND live-unbinds it from the running sandbox with
+#      `msb modify --secret-rm GITHUB_TOKEN`. Uses the real dispatch + stubbed msb.
+make_stubs; load_acq
+# Report the sandbox as "running" so the live-unbind path targets it.
+printf 'rmbox\n' > "$STUBDIR/.msb_sandbox_list"
+: > "$CALLS"
+rm_out=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/rm-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'TOK\n' | acq_secret_store "$(_acq_secret_key github rmbox)"
+  acq_secret_has github rmbox && printf 'before=yes\n' || printf 'before=no\n'
+  ACQ_BACKEND=msb "$ACQ" secret rm rmbox github >/dev/null 2>&1
+  acq_secret_has github rmbox && printf 'after=yes\n' || printf 'after=no\n'
+)
+rm_log=$(cat "$CALLS")
+assert_contains "secret rm: present before" "$rm_out" "before=yes"
+assert_contains "secret rm: removed after (msb backend rm)" "$rm_out" "after=no"
+assert_contains "secret rm: live-unbinds via msb modify --secret-rm" "$rm_log" "msb modify rmbox --secret-rm GITHUB_TOKEN"
+cleanup_stubs
+
+# 5h2b. Global `acq secret rm -g usai` (msb) sweeps ALL running sandboxes with
+#       msb modify --secret-rm USAI_API_KEY.
+make_stubs; load_acq
+printf 'boxA\nboxB\n' > "$STUBDIR/.msb_sandbox_list"
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/rmg-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'K\n' | acq_secret_store "$(_acq_secret_key usai)"
+  ACQ_BACKEND=msb "$ACQ" secret rm -g usai >/dev/null 2>&1
+)
+rmg_log=$(cat "$CALLS")
+assert_contains "secret rm -g: unbinds boxA" "$rmg_log" "msb modify boxA --secret-rm USAI_API_KEY"
+assert_contains "secret rm -g: unbinds boxB" "$rmg_log" "msb modify boxB --secret-rm USAI_API_KEY"
+cleanup_stubs
+
+# 5h2c. `acq secret set` (msb) live add/rotates into running sandboxes for EVERY
+#       bound service, not just usai. github into a named running sandbox must
+#       re-feed via `msb modify <box> --secret GITHUB_TOKEN@api.github.com`, and
+#       the real value must NOT leak into argv.
+make_stubs; load_acq
+printf 'setbox\n' > "$STUBDIR/.msb_sandbox_list"
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/set-secrets"
+  export ACQ_SECRET_TEST_VALUE="ghp_SECRETVALUE"   # non-TTY store input
+  ACQ_BACKEND=msb "$ACQ" secret set setbox github >/dev/null 2>&1
+)
+set_log=$(cat "$CALLS")
+assert_contains "secret set: github live-rotates into running sandbox" "$set_log" "msb modify setbox --secret GITHUB_TOKEN@api.github.com"
+if grep -q 'ghp_SECRETVALUE' "$CALLS"; then
+  fail "secret set: value must NOT appear in msb argv" "leaked into $CALLS"
+else
+  pass "secret set: value never leaks to msb argv (passed via env)"
+fi
+cleanup_stubs
+
+# 5h2d. Global `acq secret set -g usai` (msb) sweeps ALL running sandboxes
+#       (regression guard for the stdin-consumption loop bug: both boxes fed).
+make_stubs; load_acq
+printf 'sboxA\nsboxB\n' > "$STUBDIR/.msb_sandbox_list"
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/setg-secrets"
+  export ACQ_SECRET_TEST_VALUE="usai-key-value"
+  ACQ_BACKEND=msb "$ACQ" secret set -g usai >/dev/null 2>&1
+)
+setg_log=$(cat "$CALLS")
+assert_contains "secret set -g: rotates sboxA" "$setg_log" "msb modify sboxA --secret USAI_API_KEY@api.gsa.usai.gov"
+assert_contains "secret set -g: rotates sboxB" "$setg_log" "msb modify sboxB --secret USAI_API_KEY@api.gsa.usai.gov"
+cleanup_stubs
+
+# 5h3. `acq secret rm` requires a scope; a lone token is passed through (not
+#      treated as a managed removal) — assert the managed-service classifier.
+make_stubs
+classify_out=$(
+  . "${REPO_ROOT}/acq.backends/common.sh"
+  _acq_is_managed_secret_rm -g github     && printf 'g-github=managed\n'  || printf 'g-github=passthru\n'
+  _acq_is_managed_secret_rm mybox usai    && printf 'box-usai=managed\n'  || printf 'box-usai=passthru\n'
+  _acq_is_managed_secret_rm somePlaceholder && printf 'lone=managed\n'    || printf 'lone=passthru\n'
+  _acq_is_managed_secret_rm -g unknownsvc && printf 'g-unknown=managed\n' || printf 'g-unknown=passthru\n'
+)
+assert_contains "classify: -g github is managed" "$classify_out" "g-github=managed"
+assert_contains "classify: SANDBOX usai is managed" "$classify_out" "box-usai=managed"
+assert_contains "classify: lone placeholder is passthrough" "$classify_out" "lone=passthru"
+assert_contains "classify: unknown service is passthrough" "$classify_out" "g-unknown=passthru"
+cleanup_stubs
+
 # ===========================================================================
 # 6. Kit list completeness (same four kits as qsbx)
 # ===========================================================================
@@ -557,7 +731,11 @@ make_stubs
 out=$(ACQ_BACKEND=sbx "$ACQ" version 2>&1); rc=$?
 assert_eq "version exits 0" "0" "$rc"
 assert_contains "version: script path" "$out" "$REPO_ROOT/acq"
-assert_contains "version: patterns kit ref" "$out" "9c277c09"
+# Assert `version` reports the CONFIGURED pin (read from common.sh), not a
+# hardcoded SHA — so this holds across pin bumps (incl. the temporary
+# patterns#269 pin and its eventual finalize). Tests the invariant, not a commit.
+_want_ref=$(ACQ_SOURCE_ONLY=1 ACQ_SCRIPT_DIR="$REPO_ROOT" . "$ACQ" >/dev/null 2>&1; printf '%s' "$PATTERNS_KIT_REF")
+assert_contains "version: patterns kit ref" "$out" "$_want_ref"
 assert_contains "version: backend line" "$out" "backend:"
 cleanup_stubs
 
@@ -673,7 +851,7 @@ cleanup_stubs
 #     msb (git substitution unsupported), pointing at the known limitation.
 make_stubs
 out=$(ACQ_SECRET_TEST_VALUE="ghp_x" ACQ_BACKEND=msb "$ACQ" secret set -g github 2>&1 || true)
-assert_contains "msb: secret set github notes msb does not bind it" "$out" "does NOT bind GitHub"
+assert_contains "msb: secret set github notes REST-API binding" "$out" "GITHUB_TOKEN@api.github.com"
 if [ -f "$STUBDIR/secrets/acq.github" ]; then
   pass "msb: secret set github stored in acq store"
 else
@@ -703,7 +881,12 @@ prov_leaks=$(
 prov_log=$(cat "$CALLS")
 assert_contains "msb: provision enables --tls-intercept (needed for substitution)" "$prov_log" "--tls-intercept"
 assert_contains "msb: provision binds USAi via --secret" "$prov_log" "--secret USAI_API_KEY@api.gsa.usai.gov"
-assert_not_contains "msb: provision does NOT bind github (git substitution unsupported)" "$prov_log" "GITHUB_TOKEN@"
+# GitHub IS now bound — to the REST API host ONLY (api.github.com), the path msb
+# substitutes. The playbook kit fetches a tarball there instead of git-cloning
+# github.com/codeload (which msb does not substitute — quickstart#203).
+assert_contains "msb: provision binds github to api.github.com (REST path msb substitutes)" "$prov_log" "--secret GITHUB_TOKEN@api.github.com"
+assert_not_contains "msb: provision does NOT bind github to github.com (git transport unsubstituted)" "$prov_log" "GITHUB_TOKEN@github.com"
+assert_not_contains "msb: provision does NOT bind github to codeload" "$prov_log" "GITHUB_TOKEN@codeload"
 assert_eq "msb: provision never leaks secret values to argv" "CLEAN" "$prov_leaks"
 # Workspace is mounted at the SAME absolute path in the guest (sbx-parity), not
 # remapped under /home/agent (which fails to mount pre-user-create).
@@ -867,6 +1050,30 @@ assert_not_contains "msb: uid-1000 kit cmd not run as -u 1000" "$agent_log" "msb
 # provision. Assert the guard env is threaded onto the startup command.
 assert_contains "msb: kit cmd gets GIT_TERMINAL_PROMPT=0 guard" "$agent_log" "-e GIT_TERMINAL_PROMPT=0"
 assert_contains "msb: chowns staged /home/agent file to agent" "$agent_log" "chown agent /home/agent/usai-config/merge-global-config.mjs"
+# Agent-user setup must create the user WITHOUT pinning uid 1000 (which collides
+# with the base image's pre-existing uid-1000 user, e.g. node) and must chown the
+# home to agent so it is writable — otherwise every agent-user kit fails with
+# Permission denied (the playbook silent-fetch-failure regression).
+assert_not_contains "msb: agent user NOT created with a fixed -u 1000" "$agent_log" "useradd -m -d /home/agent -s /bin/sh -u 1000"
+assert_contains "msb: chowns /home/agent to the agent user" "$agent_log" 'chown "agent:'
+assert_contains "msb: verifies /home/agent is writable by agent" "$agent_log" "test -w /home/agent"
+cleanup_stubs
+
+# 8n0. Agent-user setup is FATAL when /home/agent is not writable by agent (a
+#      root-owned home silently broke every agent-user kit). Model the su-test
+#      probe FAILING and assert provision aborts (rc != 0) rather than degrading.
+make_stubs; load_acq
+homefail_out=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/homefail-secrets"
+  export STUB_HOME_NOT_WRITABLE=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision homefailbox shell /tmp >/dev/null 2>&1; printf 'RC=%s\n' "$?"
+)
+assert_contains "msb: unwritable agent home aborts provision (rc!=0)" "$homefail_out" "RC=1"
 cleanup_stubs
 
 # 8n1. msb provision satisfies the Docker base-image contract for the agent user:
@@ -1373,7 +1580,9 @@ fi
 # 9a. `acq kit list` shows the pinned neutral kits.
 make_stubs
 out=$("$ACQ" kit list 2>&1)
-assert_contains "kit: list shows patterns ref" "$out" "9c277c09"
+# Assert the CONFIGURED pin (not a hardcoded SHA) so this survives pin bumps.
+_want_ref=$(ACQ_SOURCE_ONLY=1 ACQ_SCRIPT_DIR="$REPO_ROOT" . "$ACQ" >/dev/null 2>&1; printf '%s' "$PATTERNS_KIT_REF")
+assert_contains "kit: list shows patterns ref" "$out" "$_want_ref"
 assert_contains "kit: list shows acq-kits dir" "$out" "acq-kits"
 assert_contains "kit: list shows usai-provider" "$out" "usai-provider"
 assert_contains "kit: list shows git-ssh-sign" "$out" "git-ssh-sign"

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -66,6 +66,7 @@ make_stubs() {
 { printf 'sbx'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >>"$CALLS"
 case "${1:-}" in
   version) printf 'sbx version: v0.35.1 abc123\n' ;;
+  --help|-h) printf 'SBX-TOPLEVEL-HELP\n' ;;
   ls)
     [ -f "$STUBDIR/.sandbox_list" ] && cat "$STUBDIR/.sandbox_list"
     exit 0 ;;
@@ -78,7 +79,7 @@ case "${1:-}" in
       *'%{http_code}'*) printf '%s' "${STUB_KEY_STATUS:-200}" ;;
       *) exit 0 ;;
     esac ;;
-  run)  exit 0 ;;
+  run)  [ "${2:-}" = "--help" ] && printf 'SBX-RUN-HELP\n'; exit 0 ;;
   stop) exit 0 ;;
   rm)   exit 0 ;;
   cp)   exit 0 ;;
@@ -109,6 +110,7 @@ STUB
 _msb_sub="${1:-}"
 case "$_msb_sub" in
   --version|-V) printf 'msb 0.6.6\n' ;;
+  --help|-h) printf 'MSB-TOPLEVEL-HELP for msb\n' ;;
   doctor) exit 0 ;;
   create) : >"$STUBDIR/.msb_created" ;;
   list|ls)
@@ -737,6 +739,31 @@ assert_contains "version: script path" "$out" "$REPO_ROOT/acq"
 _want_ref=$(ACQ_SOURCE_ONLY=1 ACQ_SCRIPT_DIR="$REPO_ROOT" . "$ACQ" >/dev/null 2>&1; printf '%s' "$PATTERNS_KIT_REF")
 assert_contains "version: patterns kit ref" "$out" "$_want_ref"
 assert_contains "version: backend line" "$out" "backend:"
+cleanup_stubs
+
+# ===========================================================================
+# 7b. acq help — acq's own usage + backend passthrough, and --backend {sbx,msb}
+# ===========================================================================
+make_stubs
+# `acq help` prints acq usage, lists --backend sbx|msb, then the backend's help.
+help_out=$(ACQ_BACKEND=sbx "$ACQ" help 2>&1); help_rc=$?
+assert_eq "help: exits 0" "0" "$help_rc"
+assert_contains "help: shows acq banner" "$help_out" "acq — agentic coding quickstart wrapper"
+assert_contains "help: documents --backend sbx|msb" "$help_out" "--backend sbx|msb"
+assert_contains "help: mentions msb backend" "$help_out" "microsandbox (msb)"
+assert_contains "help: appends backend help" "$help_out" "SBX-TOPLEVEL-HELP"
+# `acq --help` and `acq -h` behave the same.
+assert_contains "help: --help form" "$(ACQ_BACKEND=sbx "$ACQ" --help 2>&1)" "acq — agentic coding quickstart wrapper"
+assert_contains "help: -h form" "$(ACQ_BACKEND=sbx "$ACQ" -h 2>&1)" "acq — agentic coding quickstart wrapper"
+# `acq help run` and `acq run --help` delegate to the backend's per-subcommand help.
+assert_contains "help: 'help run' -> backend run --help" "$(ACQ_BACKEND=sbx "$ACQ" help run 2>&1)" "SBX-RUN-HELP"
+assert_contains "help: 'run --help' -> backend run --help" "$(ACQ_BACKEND=sbx "$ACQ" run --help 2>&1)" "SBX-RUN-HELP"
+# A bare `acq` (no subcommand) prints help but is a usage error (exit 2).
+bare_out=$(ACQ_BACKEND=sbx "$ACQ" 2>&1); bare_rc=$?
+assert_eq "help: bare acq exits 2" "2" "$bare_rc"
+assert_contains "help: bare acq shows usage" "$bare_out" "acq — agentic coding quickstart wrapper"
+# --backend msb surfaces the msb backend's own help under the separator.
+assert_contains "help: --backend msb appends msb help" "$(ACQ_BACKEND=sbx "$ACQ" --backend msb help 2>&1)" "msb"
 cleanup_stubs
 
 # ===========================================================================

--- a/scripts/verify-backends
+++ b/scripts/verify-backends
@@ -48,11 +48,17 @@ ACQ="$REPO_ROOT/acq"
 
 VERBOSE="${VERIFY_VERBOSE:-}"
 KEEP="${VERIFY_KEEP:-}"
+# Live, timestamped step tracing. VERIFY_TRACE=1 (or -x/--trace) turns on a
+# heartbeat before/after each acq step AND forces acq's own ACQ_DEBUG trace to
+# stream live, so a step that hangs is visible (which internal call stalled)
+# instead of silently buffering inside a command substitution. See trace().
+TRACE="${VERIFY_TRACE:-}"
 POSITIONAL=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -v|--verbose) VERBOSE=1 ;;
     -k|--keep)    KEEP=1 ;;
+    -x|--trace)   TRACE=1 ;;
     -h|--help)
       sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
       exit 0 ;;
@@ -61,6 +67,24 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 set -- ${POSITIONAL[@]+"${POSITIONAL[@]}"}
+
+# When tracing, acq's internal debug trace is streamed live so we can see which
+# msb/sbx sub-call is executing when a step hangs. Enabling TRACE implies live
+# streaming of the create step (see run_acq).
+if [ -n "$TRACE" ]; then
+  export ACQ_DEBUG="${ACQ_DEBUG:-1}"
+  VERBOSE=1
+fi
+
+# Monotonic-ish timestamp (HH:MM:SS) for trace lines.
+_ts() { date +%H:%M:%S 2>/dev/null || printf '??:??:??'; }
+
+# trace MSG — emit a timestamped heartbeat line to stderr when tracing is on.
+# Used to bracket long/blocking steps so a hang shows the LAST line reached.
+trace() {
+  [ -n "$TRACE" ] || return 0
+  printf '        [trace %s] %s\n' "$(_ts)" "$*" >&2
+}
 
 # Refuse to run inside a sandbox (no nested sandboxes).
 if [ -f /.dockerenv ] || [ -n "${SBX_SANDBOX:-}" ] || [ -n "${MSB_SANDBOX:-}" ]; then
@@ -94,13 +118,24 @@ dump() {
 # Run an acq command, capturing combined stdout+stderr into LAST_OUT and
 # returning its exit status. The first arg is a short label for the step; in
 # verbose mode it and the exact command line are streamed live.
+#
+# When TRACE is on, a timestamped heartbeat brackets the step (START ... DONE
+# rc=N) so a step that hangs shows its START line with no matching DONE — that
+# names the exact acq step that stalled. Live streaming (VERBOSE) is forced in
+# trace mode so acq's own ACQ_DEBUG output appears in real time rather than
+# being buffered inside the command substitution until the step returns.
 run_acq() {
   local desc="$1"; shift
+  trace "START ${desc}: acq $*"
+  local _rc
   if [ -n "$VERBOSE" ]; then
     printf '        $ acq %s   # %s\n' "$*" "$desc" >&2
-    LAST_OUT=$("$ACQ" "$@" 2>&1 | tee /dev/stderr); return "${PIPESTATUS[0]}"
+    LAST_OUT=$("$ACQ" "$@" 2>&1 | tee /dev/stderr); _rc="${PIPESTATUS[0]}"
+  else
+    LAST_OUT=$("$ACQ" "$@" 2>&1); _rc=$?
   fi
-  LAST_OUT=$("$ACQ" "$@" 2>&1); return $?
+  trace "DONE  ${desc}: rc=${_rc}"
+  return "$_rc"
 }
 
 # Workspace to mount.

--- a/scripts/verify-backends
+++ b/scripts/verify-backends
@@ -271,12 +271,53 @@ verify_backend() {
   fi
 }
 
+# verify_agent_install BACKEND — provision an `opencode` sandbox (not `shell`)
+# and assert the agent binary is actually installed and launchable. This catches
+# the class of bug where a sandbox comes up but the agent was never installed
+# (quickstart#228): on sbx the template bakes it in; on msb acq installs it.
+verify_agent_install() {
+  local backend="$1"
+  echo ""
+  echo "== backend: ${backend} (agent install) =="
+
+  local aname
+  aname=$(
+    # shellcheck disable=SC1090
+    ACQ_SOURCE_ONLY=1 ACQ_SCRIPT_DIR="$REPO_ROOT" . "$ACQ" >/dev/null 2>&1
+    derive_name opencode "$WORKDIR" 2>/dev/null
+  )
+  [ -n "$aname" ] || aname="opencode-$(basename "$WORKDIR" | tr '[:upper:]' '[:lower:]')"
+  printf '        sandbox name: %s\n' "$aname"
+
+  if ! run_acq "create-opencode" --backend "$backend" create opencode "$WORKDIR"; then
+    fail "${backend}: provision (acq create opencode) failed"
+    dump "acq create output" "$LAST_OUT"
+    run_acq "rm" --backend "$backend" rm "$aname" >/dev/null 2>&1 || true
+    return
+  fi
+
+  # The agent binary must be on PATH inside the sandbox (the bug: it wasn't).
+  if run_acq "exec opencode-present" --backend "$backend" exec "$aname" -- sh -c "command -v opencode >/dev/null 2>&1"; then
+    pass "${backend}: opencode binary installed and on PATH"
+  else
+    fail "${backend}: opencode binary NOT found in sandbox (agent install failed)"
+    dump "exec output" "$LAST_OUT"
+  fi
+
+  if [ -n "$KEEP" ] && [ "$FAIL" -gt 0 ]; then
+    printf '        (keeping sandbox %s; --keep set)\n' "$aname"
+  else
+    run_acq "rm" --backend "$backend" rm "$aname" >/dev/null 2>&1 || true
+  fi
+}
+
 echo "verify-backends"
 echo "  workspace: $WORKDIR"
 
 # sbx
 if command -v sbx >/dev/null 2>&1; then
   verify_backend sbx
+  verify_agent_install sbx
 else
   echo ""; echo "== backend: sbx =="; skip "sbx: not installed"
 fi
@@ -284,6 +325,7 @@ fi
 # msb
 if command -v msb >/dev/null 2>&1; then
   verify_backend msb
+  verify_agent_install msb
 else
   echo ""; echo "== backend: msb =="; skip "msb: not installed"
 fi

--- a/scripts/verify-backends
+++ b/scripts/verify-backends
@@ -304,6 +304,20 @@ verify_agent_install() {
     dump "exec output" "$LAST_OUT"
   fi
 
+  # The guest must have enough RAM to actually RUN a Node.js agent TUI. msb's
+  # 512 MiB default OOM-kills opencode on launch (quickstart#228 follow-up: it
+  # started, then the terminal died with "Killed"). Assert a generous ceiling
+  # (>= ~2 GiB) so a regression that drops the sizing flags is caught live, not
+  # just at exec-present. MemTotal is in kB; 2 GiB ~= 2000000 kB.
+  local memkb
+  run_acq "exec memtotal" --backend "$backend" exec "$aname" -- sh -c "awk '/MemTotal/{print \$2}' /proc/meminfo" >/dev/null 2>&1 || true
+  memkb=$(printf '%s' "$LAST_OUT" | tr -dc '0-9')
+  if [ -n "$memkb" ] && [ "$memkb" -ge 2000000 ] 2>/dev/null; then
+    pass "${backend}: guest has RAM headroom for the agent (${memkb} kB)"
+  else
+    fail "${backend}: guest RAM too small for a Node.js agent (MemTotal='${memkb}' kB); opencode will be OOM-killed"
+  fi
+
   if [ -n "$KEEP" ] && [ "$FAIL" -gt 0 ]; then
     printf '        (keeping sandbox %s; --keep set)\n' "$aname"
   else

--- a/scripts/verify-backends
+++ b/scripts/verify-backends
@@ -37,8 +37,8 @@
 #
 # Exit 0 = every installed backend passed (skipped backends don't fail the run).
 # Non-zero = at least one installed backend failed a check.
-# WARN lines are known, tracked limitations (e.g. the msb private-repo playbook
-# clone, quickstart#203) — surfaced every run but NOT counted as failures.
+# WARN lines are known, tracked limitations — surfaced every run but NOT counted
+# as failures.
 
 set -uo pipefail
 
@@ -102,8 +102,7 @@ pass() { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
 fail() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
 skip() { SKIP=$((SKIP + 1)); printf '  skip  %s\n' "$1"; }
 # warn(): a known, tracked limitation — surfaced loudly every run but NOT counted
-# as a failure (the run still exits 0). Use for deferred gaps like the msb
-# private-repo playbook clone (quickstart#203).
+# as a failure (the run still exits 0). Use for deferred gaps.
 warn() { WARN=$((WARN + 1)); printf '  WARN  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
 
 # Print a captured block indented under a heading (only when non-empty).
@@ -167,6 +166,68 @@ USAI_MODELS_URL="https://api.gsa.usai.gov/api/v1/models"
 USAI_KIT_CONFIG_PATH="/home/agent/usai-config/opencode.jsonc"
 
 # ---------------------------------------------------------------------------
+# GitHub token seeding for the private-repo playbook kit.
+# ---------------------------------------------------------------------------
+# The playbook kit fetches a PRIVATE repo tarball from api.github.com, which
+# needs a github token. We DISCOURAGE storing a global github token, and the
+# user is normally already authenticated via `gh`. So for the throwaway verify
+# sandboxes we seed a SANDBOX-SCOPED github secret from `gh auth token` just for
+# that sandbox, via `acq secret set <sandbox> github` — which both records it in
+# the acq store (msb reads it at create) AND feeds the sbx proxy. We clean it up
+# afterward. If `gh` is absent / logged out, the playbook check SKIPs (not fails)
+# so a token-less run still passes.
+#
+# GH_SEEDED_FOR is set to the sandbox name once a seed succeeds, so the playbook
+# check knows whether to assert (seeded) or skip (not seeded), and cleanup knows
+# what to remove. It is reset per sandbox.
+GH_SEEDED_FOR=""
+
+# _gh_token — echo a github token for seeding, or empty if none is available.
+# Prefer an already-exported GH_TOKEN / GITHUB_TOKEN (how many users, incl. CI,
+# authenticate) — note that when GH_TOKEN is set in the env, `gh auth token`
+# prints NOTHING (gh treats the env var as authoritative and won't echo it), so
+# we must read the env var directly. Fall back to `gh auth token` (keyring) when
+# no env token is set and gh is installed + logged in.
+_gh_token() {
+  if [ -n "${GH_TOKEN:-}" ]; then printf '%s' "$GH_TOKEN"; return 0; fi
+  if [ -n "${GITHUB_TOKEN:-}" ]; then printf '%s' "$GITHUB_TOKEN"; return 0; fi
+  command -v gh >/dev/null 2>&1 || return 0
+  gh auth token 2>/dev/null || true
+}
+
+# seed_github_secret BACKEND SANDBOX — seed a sandbox-scoped github secret from
+# `gh` for this sandbox, BEFORE provision. Sets GH_SEEDED_FOR on success. No-op
+# (leaves GH_SEEDED_FOR empty) when no gh token is available.
+seed_github_secret() {
+  local backend="$1" sandbox="$2" tok
+  GH_SEEDED_FOR=""
+  tok=$(_gh_token)
+  if [ -z "$tok" ]; then
+    return 0
+  fi
+  # `acq secret set <sandbox> github` reads the value on stdin (never argv). On
+  # sbx this also runs `sbx secret set <sandbox> github` so the proxy has it; on
+  # msb it lands in the acq store, which provision binds at create.
+  if printf '%s\n' "$tok" | run_acq "seed-github" --backend "$backend" secret set "$sandbox" github >/dev/null 2>&1; then
+    GH_SEEDED_FOR="$sandbox"
+    trace "seeded sandbox-scoped github secret for $sandbox ($backend)"
+  else
+    trace "could not seed github secret for $sandbox ($backend); playbook check will skip"
+  fi
+  tok=""
+}
+
+# unseed_github_secret BACKEND SANDBOX — remove the sandbox-scoped github secret
+# we seeded, via `acq secret rm` (removes it from the acq store and clears the
+# backend injector). Best-effort; never fails the run.
+unseed_github_secret() {
+  local backend="$1" sandbox="$2"
+  [ -n "$GH_SEEDED_FOR" ] || return 0
+  run_acq "unseed-github" --backend "$backend" secret rm "$sandbox" github >/dev/null 2>&1 || true
+  GH_SEEDED_FOR=""
+}
+
+# ---------------------------------------------------------------------------
 # Per-backend verification. $1 = backend name. Assumes it is installed.
 # ---------------------------------------------------------------------------
 verify_backend() {
@@ -210,11 +271,16 @@ verify_backend() {
   [ -n "$name" ] || name="shell-$(basename "$WORKDIR" | tr '[:upper:]' '[:lower:]')"
   printf '        sandbox name: %s\n' "$name"
 
+  # Seed a sandbox-scoped github token (from `gh`) BEFORE create so the private
+  # playbook tarball fetch can authenticate. No-op if gh is unavailable.
+  seed_github_secret "$backend" "$name"
+
   # Create a sandbox with the four kits applied via acq's normal provision path.
   if ! run_acq "create" --backend "$backend" create shell "$WORKDIR"; then
     fail "${backend}: provision (acq create shell) failed" \
          "command: acq --backend ${backend} create shell ${WORKDIR}"
     dump "acq create output" "$LAST_OUT"
+    unseed_github_secret "$backend" "$name"
     if [ -n "$KEEP" ]; then
       printf '        (keeping sandbox %s for inspection; --keep set)\n' "$name"
     else
@@ -299,21 +365,47 @@ verify_backend() {
     dump "exec output" "$LAST_OUT"
   fi
 
-  # 4) playbook clone symlink appears (AGENTS.md linked into OpenCode config).
-  #    On msb the private-repo clone is a KNOWN, TRACKED gap (quickstart#203):
-  #    msb 0.6.6 doesn't substitute the git credential for github.com HTTPS. So
-  #    on msb a missing clone is a WARN (surfaced, but the run still passes);
-  #    on sbx it remains a hard requirement.
-  if run_acq "exec playbook" --backend "$backend" exec "$name" -- sh -c \
-      'test -e "$HOME/.agentic-coding-playbook/.git" || test -L "$HOME/.config/opencode/AGENTS.md"'; then
-    pass "${backend}: playbook kit applied (clone or AGENTS.md link present)"
-  elif [ "$backend" = "msb" ]; then
-    warn "${backend}: playbook clone absent — known msb private-repo git-auth gap" \
-         "tracked in quickstart#203 (msb git-over-HTTPS secret substitution); non-fatal"
+  # 3b) Agent home is owned by the agent user. A root-owned /home/agent silently
+  #     breaks every agent-user kit (the playbook regression: fetch ran, mkdir
+  #     denied, degraded silently). msb creates the agent user at provision (uid
+  #     may differ from 1000 — it collides with the base image's user); sbx bakes
+  #     it into the template. Assert ownership on both so the bug can't silently
+  #     return. Checked as the DEFAULT exec user (root on msb, agent on sbx): we
+  #     compare the owner of $HOME's /home/agent to the agent user by name.
+  if run_acq "exec home-owner" --backend "$backend" exec "$name" -- sh -c \
+      'test "$(stat -c %U /home/agent 2>/dev/null || stat -f %Su /home/agent 2>/dev/null)" = agent'; then
+    pass "${backend}: /home/agent owned by the agent user"
   else
-    fail "${backend}: playbook clone/symlink not found"
+    fail "${backend}: /home/agent not owned by agent (agent-user setup regressed)"
     dump "exec output" "$LAST_OUT"
   fi
+
+  # 4) playbook fetch appears (AGENTS.md present in the tree AND linked into the
+  #    OpenCode config). The kit fetches the repo SOURCE TARBALL via the REST API
+  #    (api.github.com), which BOTH backends substitute the github token for
+  #    (msb 0.6.7 verified) — so given a token this is a hard requirement on both
+  #    (quickstart#203 is resolved by the tarball approach). We seed a
+  #    sandbox-scoped token from `gh` before create; if `gh` was unavailable
+  #    (GH_SEEDED_FOR empty) there is no token and we SKIP rather than fail — a
+  #    token-less run still passes.
+  #
+  #    NOTE: the kit runs as the `agent` user and links into /home/agent. Do NOT
+  #    rely on $HOME here — a plain `msb exec` runs as ROOT ($HOME=/root), so an
+  #    unqualified "$HOME/.agentic-coding-playbook" checks the wrong path and
+  #    always fails even when the kit succeeded. Check the literal /home/agent
+  #    paths instead (the agent's home, on both backends).
+  if [ -z "$GH_SEEDED_FOR" ]; then
+    skip "${backend}: playbook fetch (no github token; gh not available/logged in)"
+  elif run_acq "exec playbook" --backend "$backend" exec "$name" -- sh -c \
+      'test -f /home/agent/.agentic-coding-playbook/AGENTS.md && test -L /home/agent/.config/opencode/AGENTS.md'; then
+    pass "${backend}: playbook kit applied (AGENTS.md fetched + linked)"
+  else
+    fail "${backend}: playbook AGENTS.md not fetched/linked (token was seeded from gh)"
+    dump "exec output" "$LAST_OUT"
+  fi
+
+  # Remove the sandbox-scoped github secret we seeded (best-effort).
+  unseed_github_secret "$backend" "$name"
 
   # Clean up the throwaway sandbox.
   if [ -n "$KEEP" ] && [ "$FAIL" -gt 0 ]; then

--- a/scripts/verify-backends
+++ b/scripts/verify-backends
@@ -104,11 +104,28 @@ run_acq() {
 }
 
 # Workspace to mount.
+#
+# NOTE: do NOT default to $TMPDIR / /tmp. On macOS, msb cannot mount a host path
+# under $TMPDIR (a per-user /var/folders/... tree, itself reached via the /var ->
+# /private/var symlink): `msb create` fails to start with
+# "mount ...: Not a directory (os error 20)" for ANY such path, even mapped to a
+# shallow guest target (verified on msb 0.6.6). A real directory under $HOME
+# mounts fine. So the verify workspace lives under a stable cache dir, and we
+# resolve it to its canonical (symlink-free) path before mounting.
 WORKDIR="${1:-}"
 if [ -z "$WORKDIR" ]; then
-  WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/acq-verify-ws.XXXXXX")
+  _verify_base="${XDG_CACHE_HOME:-$HOME/.cache}/acq/verify"
+  mkdir -p "$_verify_base"
+  WORKDIR=$(mktemp -d "${_verify_base}/ws.XXXXXX")
   ( cd "$WORKDIR" && git init -q && git config user.email test@example.com \
       && git config user.name "acq verify" && echo hi > README.md ) || true
+fi
+
+# Canonicalize (resolve symlinks) so the mounted host path is the real one. acq
+# does this too, but resolving here keeps the derived sandbox name and any direct
+# msb/sbx checks below consistent with what acq actually mounts.
+if command -v realpath >/dev/null 2>&1; then
+  WORKDIR=$(realpath "$WORKDIR" 2>/dev/null || printf '%s' "$WORKDIR")
 fi
 
 USAI_MODELS_URL="https://api.gsa.usai.gov/api/v1/models"


### PR DESCRIPTION
## Context

Fixes #228 — on the **msb** backend, `acq run opencode <path>` did not deliver a working agent: it dropped into a root shell with opencode not installed, and later hung. Bringing the msb backend to parity with sbx surfaced a chain of msb-specific defects (provisioning, credentials, agent launch), all fixed here. This PR also **resolves #203** (private-repo playbook fetch on msb).

> **Depends on [agentic-coding-patterns#269](https://github.com/GSA-TTS/agentic-coding-patterns/pull/269).** The playbook kit is fetched from the patterns repo; the fix for #203 lives there. `PATTERNS_KIT_REF` is temporarily pinned to that PR's branch tip for validation — **do not merge until #269 lands and the pin is finalized to the merge commit.**

## What changed (msb backend)

1. **Install + launch the agent as the `agent` user** (original #228): install opencode via npm (npm-registry host allow-listed at create); satisfy the Docker base-image contract (agent user, passwordless sudo, proxy env_keep); launch on attach.
2. **Guest sizing** — `--memory 4G --cpus 2` (opencode was OOM-killed on msb's 512 MiB default). Tunable via `ACQ_MSB_MEMORY`/`ACQ_MSB_CPUS`.
3. **Workspace mounting** — mount each workspace at its **same absolute host path** (sbx-parity), not a fixed `/home/agent/workspace` (which failed to mount pre-user-create). Canonicalize symlinked host paths (macOS `$TMPDIR` → `/private/var/...`). Multi-workspace + `:ro` supported; agent starts in the primary (first) workspace.
4. **Non-interactive kit execs** — stdin `</dev/null` + `GIT_TERMINAL_PROMPT=0`/`GIT_ASKPASS`/`SSH_ASKPASS` so a kit that would prompt (private `git clone`) fails fast instead of hanging provision.
5. **Agent-home ownership (fixes the silent playbook failure)** — `_acq_msb_ensure_agent_user` no longer pins uid 1000 (it collides with the base image's `node` user, leaving `/home/agent` root-owned so every agent-user kit failed with Permission denied). Create `agent` at any uid, unconditionally chown `/home/agent`, verify writability; a non-writable home is now **fatal** (was silently ignored).
6. **GitHub credential → REST API (fixes #203)** — bind `GITHUB_TOKEN@api.github.com` (the host msb substitutes on the wire; git smart-HTTP to github.com/codeload is **not** substituted). The playbook kit now fetches a **REST source tarball** (verified against a pinned `AGENTS.md` sha256) instead of `git clone`, so it authenticates on **both** backends. (patterns#269.)
7. **Attach via `msb exec -t`** — gives the agent TUI a **PTY** (`msb ssh` has no tty flag and hung the TUI), runs as `-u agent` in `-w <workspace>` with a sane `$SHELL` (msb's interactive default is the base image's Node REPL). Missing agent binary falls back to a shell; `shell` sandbox gets an explicit `/bin/sh -l` — never a root shell.
8. **`acq help`** — `acq help` / `acq --help` / `acq -h` (and a bare `acq`) now print acq's own usage — explicitly documenting `--backend sbx|msb` — then delegate to the resolved backend's help for the same subcommand (`acq help run` / `acq run --help` → backend `run --help`). Usage moved out of top-of-script comments.

## Secret management (both backends)

- **`acq secret rm [-g|SANDBOX] SERVICE`** — deletes from the acq store; sbx clears its proxy entry (`-f`, non-interactive — no confirm-prompt hang); msb live-unbinds running sandboxes via `msb modify --secret-rm`.
- **Live add/rotate generalized** — `acq secret set` re-feeds running sandboxes for every bound service (usai + github), not just usai.
- **sbx existence pre-check is now scope- and section-aware** (parses the `CUSTOM SECRETS` table), fixing a false "already exists" when the same service existed under another scope.

## Verification

- **`scripts/verify-backends`: 15/15** on sbx + msb 0.6.7 — kits applied, USAi round-trips, `/home/agent` agent-owned, **playbook AGENTS.md fetched + linked on both backends**, opencode installed with RAM headroom.
- Live `acq --backend msb run opencode <path>` renders the opencode **TUI** (no hang); `run shell` gives an interactive `/bin/sh`.
- Offline: `scripts/test-acq` **264/0**, `scripts/test-migrate-or-halt` **57/0**, markdownlint clean. verify-backends gained `-x`/`--trace` for live diagnosis and a new "/home/agent owned by agent" regression check on both backends; seeds a sandbox-scoped github token from `gh` (no global token required) and skips (not fails) when none is available.

## Rollback

Revert the commits on this branch; each is scoped and self-contained. No data migration or state change.

## Security impact

- msb binds `GITHUB_TOKEN` to `api.github.com` **only** (single host; substituted on the wire, never in the guest env or argv). npm-registry egress added only when installing an agent.
- Passwordless sudo + proxy `env_keep` for the `agent` user match the sbx template's posture; scoped to the sandbox.
- Secret values never touch argv (store on stdin; `msb modify`/`curl -K -` read from env).

## Relationship to #226 (msb custom-endpoint secrets)

This PR **advances but does not close** #226 (bind generic custom-endpoint
secrets on msb, "gap C"):

- ✅ The msb re-feed/rotate machinery is now **generic** — `acq secret set`
  re-feeds running sandboxes via `msb modify --secret` for *every* bound service
  (driven off `_acq_msb_service_binding`), not just usai. `acq secret rm`
  live-unbinds the same way.
- ✅ **github** is now bound on msb — via the **REST API** (`GITHUB_TOKEN@api.github.com`)
  and a tarball-fetching kit. This actually **overtakes #226's stated exclusion**
  (which assumed github was upstream-blocked by the git-over-HTTPS gap); the REST
  path sidesteps that entirely and also resolves #203.
- ⚠️ **Still open:** the service→ENV/HOST table (`_acq_msb_service_binding`) is a
  fixed `usai`+`github` list, not generic. An arbitrary stored custom endpoint
  (`acq secret set SANDBOX --host api.example.com --env API_KEY`) is still
  stored-but-not-bound on msb. Closing that needs the acq secret store to persist
  the per-service host/env pair (msb's `acq_backend_secret_set` does not yet
  accept/store `--host/--env`) and the binding function to read it back — a
  separate chunk of work. **#226 stays open**; noted inline in `_acq_msb_service_binding`.

## Out of scope / follow-up

- **Finalize `PATTERNS_KIT_REF`** to patterns#269's merge commit once it lands (blocker on merging this PR; noted inline in `common.sh`).

Co-authored-by: OpenCode Agent <bret.mogilefsky@gsa.gov>

