### PR TITLE
feat(acq): detect stale sandboxes + acq kit check|update (#236)

### DIFF
--- a/acq
+++ b/acq
@@ -457,7 +457,9 @@ case "$subcommand" in
       fi
       case "$_a" in
         --) _acq_seen_sep=1; _acq_run_args+=("$_a") ;;
-        --no-update-check) ACQ_UPDATE_CHECK=0 ;;
+        # export: consumed by maybe_offer_bundle_refresh in the sourced
+        # acq.backends/common.sh (cross-file; shellcheck can't see the reader).
+        --no-update-check) export ACQ_UPDATE_CHECK=0 ;;
         *) _acq_run_args+=("$_a") ;;
       esac
     done

--- a/acq
+++ b/acq
@@ -442,7 +442,7 @@ case "$subcommand" in
   run|create)
     _sub="$subcommand"
     shift                       # drop the subcommand token; $@ is now its args
-    # Strip acq-owned `--no-update-check` (quickstart#236) BEFORE kit extraction
+    # Strip acq-owned `--no-update-check` BEFORE kit extraction
     # and dispatch so it never reaches the backend CLI. It disables the automatic
     # stale-sandbox check for this one invocation (same effect as
     # ACQ_UPDATE_CHECK=0). Only honored BEFORE the `--` separator, so an
@@ -546,7 +546,7 @@ case "$subcommand" in
       if acq_backend_exists "$local_name"; then
         # Capture staleness BEFORE the heal — ensure_kits_applied rewrites the
         # provenance record to "current", so reading status after it would never
-        # see stale/unknown and the offer below would be dead (quickstart#236).
+        # see stale/unknown and the offer below would be dead.
         _pre_heal_status=$(acq_provenance_status "${ACQ_RESOLVED_BACKEND}" "$local_name")
         acq_backend_ensure_kits_applied "$local_name" || true
         # Existing sandbox: offer a refresh if it predates the pinned bundle.
@@ -581,7 +581,7 @@ case "$subcommand" in
       # attaching by name is a re-attach to a running session where the key
       # was already validated on the original acq run. Matches qsbx behavior.
       # Capture staleness BEFORE the heal (the heal rewrites provenance to
-      # "current"), then heal, then offer a refresh (quickstart#236). Never
+      # "current"), then heal, then offer a refresh. Never
       # blocks; skipped under --no-update-check / ACQ_UPDATE_CHECK=0.
       _pre_heal_status=$(acq_provenance_status "${ACQ_RESOLVED_BACKEND}" "$first")
       acq_backend_ensure_kits_applied "$first" || true

--- a/acq
+++ b/acq
@@ -78,6 +78,8 @@ Subcommands:
   run AGENT PATH [...] [-- AGENT_ARGS...]  Create+attach a sandbox, or re-attach
                                            an existing one, and launch AGENT
                                            (e.g. opencode) or a shell.
+                                           (--no-update-check skips the stale-
+                                           bundle check for this run.)
   create AGENT PATH [...]                  Create a sandbox (detached).
   ls                                       List sandboxes.
   stop NAME                                Stop a sandbox (without removing).
@@ -98,6 +100,10 @@ Subcommands:
   kit list                                 Show the pinned kits (+ extras).
   kit validate PATH                        Validate a neutral hybrid/v1 kit.
   kit apply NAME KITREF                    Apply a kit to an existing sandbox.
+  kit check SANDBOX                        Report if a sandbox is on the pinned
+                                           built-in kit bundle.
+  kit update SANDBOX [--yes]               Refresh the built-in kit bundle in a
+                                           sandbox, in place (state preserved).
   help                                     Show this help.
 
 Any other subcommand is passed through to the active backend's CLI.
@@ -293,6 +299,89 @@ case "$subcommand" in
         acq_backend_apply_kit "$local_name" "$local_kitref"
         exit $?
         ;;
+      check)
+        # Report whether a sandbox is on the locally pinned built-in bundle.
+        # Read-only: never mutates the sandbox or its provenance record.
+        shift
+        local_name="${1:-}"
+        if [ -z "$local_name" ]; then
+          echo "acq: kit check: usage: acq kit check SANDBOX" >&2
+          exit 1
+        fi
+        acq_resolve_backend "${explicit_backend}"
+        if ! acq_backend_exists "$local_name"; then
+          echo "acq: kit check: no such sandbox '$local_name'." >&2
+          exit 1
+        fi
+        local_status=$(acq_provenance_status "${ACQ_RESOLVED_BACKEND}" "$local_name")
+        local_applied=$(acq_provenance_field "${ACQ_RESOLVED_BACKEND}" "$local_name" applied_ref)
+        printf 'sandbox:       %s (backend: %s)\n' "$local_name" "${ACQ_RESOLVED_BACKEND}"
+        printf 'local pinned:  %s\n' "$PATTERNS_KIT_REF"
+        printf 'applied ref:   %s\n' "${local_applied:-<none recorded>}"
+        case "$local_status" in
+          current)
+            printf 'status:        current (on the pinned bundle)\n'
+            exit 0
+            ;;
+          stale)
+            printf 'status:        stale (does not match the pinned bundle)\n'
+            printf '\nRefresh in place with: acq kit update %s\n' "$local_name"
+            exit 0
+            ;;
+          *)
+            printf 'status:        unknown (no provenance record; may predate tracking)\n'
+            printf '\nRefresh in place with: acq kit update %s\n' "$local_name"
+            exit 0
+            ;;
+        esac
+        ;;
+      update)
+        # Reapply the built-in bundle in place to the locally pinned ref.
+        # `--yes` skips the confirmation (only honored on this explicit command;
+        # the automatic `acq run` check never auto-updates).
+        shift
+        local_name=""
+        local_assume_yes=0
+        for _karg in "$@"; do
+          case "$_karg" in
+            --yes|-y) local_assume_yes=1 ;;
+            -*) echo "acq: kit update: unknown option '$_karg'" >&2; exit 1 ;;
+            *) [ -z "$local_name" ] && local_name="$_karg" ;;
+          esac
+        done
+        if [ -z "$local_name" ]; then
+          echo "acq: kit update: usage: acq kit update SANDBOX [--yes]" >&2
+          exit 1
+        fi
+        acq_resolve_backend "${explicit_backend}"
+        if ! acq_backend_exists "$local_name"; then
+          echo "acq: kit update: no such sandbox '$local_name'." >&2
+          exit 1
+        fi
+        local_status=$(acq_provenance_status "${ACQ_RESOLVED_BACKEND}" "$local_name")
+        if [ "$local_status" = "current" ]; then
+          echo "acq: '$local_name' is already on the pinned bundle (${PATTERNS_KIT_REF}); nothing to do." >&2
+          exit 0
+        fi
+        if [ "$local_assume_yes" -ne 1 ]; then
+          if [ ! -t 0 ]; then
+            echo "acq: kit update: refusing to update non-interactively without --yes." >&2
+            echo "     Re-run: acq kit update $local_name --yes" >&2
+            exit 1
+          fi
+          _kans=""
+          printf 'acq: refresh the kit bundle in %s to %s? [y/N] ' "$local_name" "$PATTERNS_KIT_REF" >&2
+          read -r _kans 2>/dev/null || _kans=""
+          case "$_kans" in
+            y|Y|yes|YES) ;;
+            *) echo "acq: kit update: cancelled." >&2; exit 0 ;;
+          esac
+        fi
+        if acq_bundle_reapply "${ACQ_RESOLVED_BACKEND}" "$local_name"; then
+          exit 0
+        fi
+        exit 1
+        ;;
       --help|-h|"")
         cat >&2 <<'KITUSAGE'
 acq kit — manage neutral hybrid/v1 kits
@@ -301,13 +390,15 @@ Usage:
   acq kit list                 Show the pinned built-in kits (+ extras)
   acq kit validate PATH        Validate a neutral kit (dir or spec.yaml)
   acq kit apply NAME KITREF    Apply a kit to an existing sandbox (mid-life)
+  acq kit check SANDBOX        Report if a sandbox is on the pinned bundle
+  acq kit update SANDBOX [--yes]  Refresh the built-in bundle in place
 
 See docs/BACKEND_GUIDE.md and docs/adr/0011-msb-backend-and-neutral-kits.md.
 KITUSAGE
         exit 1
         ;;
       *)
-        echo "acq: unknown kit subcommand '${sub2}'. Try: acq kit list | validate PATH | apply NAME KITREF" >&2
+        echo "acq: unknown kit subcommand '${sub2}'. Try: acq kit list | validate PATH | apply NAME KITREF | check SANDBOX | update SANDBOX [--yes]" >&2
         exit 1
         ;;
     esac
@@ -351,6 +442,26 @@ case "$subcommand" in
   run|create)
     _sub="$subcommand"
     shift                       # drop the subcommand token; $@ is now its args
+    # Strip acq-owned `--no-update-check` (quickstart#236) BEFORE kit extraction
+    # and dispatch so it never reaches the backend CLI. It disables the automatic
+    # stale-sandbox check for this one invocation (same effect as
+    # ACQ_UPDATE_CHECK=0). Only honored BEFORE the `--` separator, so an
+    # identically-named flag meant for the inner agent (after `--`) passes
+    # through verbatim. Equivalent for the whole session: export ACQ_UPDATE_CHECK=0.
+    _acq_run_args=()
+    _acq_seen_sep=0
+    for _a in "$@"; do
+      if [ "$_acq_seen_sep" -eq 1 ]; then
+        _acq_run_args+=("$_a")
+        continue
+      fi
+      case "$_a" in
+        --) _acq_seen_sep=1; _acq_run_args+=("$_a") ;;
+        --no-update-check) ACQ_UPDATE_CHECK=0 ;;
+        *) _acq_run_args+=("$_a") ;;
+      esac
+    done
+    set -- ${_acq_run_args[@]+"${_acq_run_args[@]}"}
     extract_kit_flags "$@"
     [ "${#ACQ_CLI_KITS[@]}" -gt 0 ] && _build_kit_list   # re-fold with CLI kits
     # Rebuild positional args as: <subcommand> <remaining args w/o --kit>.
@@ -431,7 +542,16 @@ case "$subcommand" in
       fi
 
       if acq_backend_exists "$local_name"; then
-        acq_backend_ensure_kits_applied "$local_name"
+        # Capture staleness BEFORE the heal — ensure_kits_applied rewrites the
+        # provenance record to "current", so reading status after it would never
+        # see stale/unknown and the offer below would be dead (quickstart#236).
+        _pre_heal_status=$(acq_provenance_status "${ACQ_RESOLVED_BACKEND}" "$local_name")
+        acq_backend_ensure_kits_applied "$local_name" || true
+        # Existing sandbox: offer a refresh if it predates the pinned bundle.
+        # Never blocks; skipped under --no-update-check / ACQ_UPDATE_CHECK=0. A
+        # just-provisioned sandbox (else branch) is current by construction, so
+        # the offer is intentionally only on this path.
+        maybe_offer_bundle_refresh "${ACQ_RESOLVED_BACKEND}" "$local_name" "$_pre_heal_status"
       else
         acq_backend_provision "$local_name" "${create_args[@]}"
       fi
@@ -458,7 +578,12 @@ case "$subcommand" in
       # create args needed to provision a fresh validation sandbox, and
       # attaching by name is a re-attach to a running session where the key
       # was already validated on the original acq run. Matches qsbx behavior.
-      acq_backend_ensure_kits_applied "$first"
+      # Capture staleness BEFORE the heal (the heal rewrites provenance to
+      # "current"), then heal, then offer a refresh (quickstart#236). Never
+      # blocks; skipped under --no-update-check / ACQ_UPDATE_CHECK=0.
+      _pre_heal_status=$(acq_provenance_status "${ACQ_RESOLVED_BACKEND}" "$first")
+      acq_backend_ensure_kits_applied "$first" || true
+      maybe_offer_bundle_refresh "${ACQ_RESOLVED_BACKEND}" "$first" "$_pre_heal_status"
       warn_if_no_ssh_signing_key
 
       # Rebuild arg list without the sandbox name (first occurrence only).

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -21,21 +21,17 @@
 # acq.backends/kit-translate.sh, which fetches a kit's neutral spec.yaml and
 # emits the active backend's native operations.
 #
-# PATTERNS_KIT_REF is pinned to an agentic-coding-patterns commit on `main`.
-# It provides the neutral acq-kits + the hybrid/v1 schema with the `environment`
-# vocabulary (patterns #227, consumed by kit-translate.sh's kit_spec_env) and the
-# playbook kit's REST-tarball fetch (patterns #269, fixes quickstart#203 — private
-# playbook auth on msb via the GitHub REST API instead of git clone).
+# PATTERNS_KIT_REF is pinned to an agentic-coding-patterns commit that provides
+# the neutral acq-kits, the hybrid/v1 schema (including the kit-bundle
+# `provenance` block that the currency check below reads), and the playbook
+# kit's REST-tarball fetch.
 # ============================================================================
 PATTERNS_KIT_REPO="git+https://github.com/GSA-TTS/agentic-coding-patterns.git"
-# patterns main @ 5c55bcf — bundle provenance schema + usai-provider provenance
-# block (patterns#273, quickstart#235), on top of the playbook REST-tarball fetch
-# (#269, quickstart#203), the environment vocabulary (#227) and neutral acq-kits
-# (#221/#224). Full 40-char SHA (not an abbreviation): this ref drives a
-# credential-bearing cross-repo kit fetch, so pin it unambiguously for
-# reproducibility. It is ALSO the bundle-version anchor recorded in a sandbox's
-# host-side provenance record (see ACQ_BUILTIN_BUNDLE below + the provenance
-# helpers) so acq can tell a stale sandbox from a current one.
+# Full 40-char SHA (not an abbreviation): this ref drives a credential-bearing
+# cross-repo kit fetch, so pin it unambiguously for reproducibility. It is also
+# the bundle-version anchor recorded in a sandbox's host-side provenance record
+# (see ACQ_BUILTIN_BUNDLE below + the provenance helpers) so acq can tell a
+# stale sandbox from a current one.
 PATTERNS_KIT_REF="5c55bcf9fc77947b145a828f75877797ebd6d178"
 PATTERNS_KIT_DIR="integrations/isolation/acq-kits"
 
@@ -50,9 +46,8 @@ GITSSHSIGN_KIT="${PATTERNS_KIT_REPO}#ref=${PATTERNS_KIT_REF}&dir=${PATTERNS_KIT_
 # shellcheck disable=SC2034  # consumed by `acq kit list` in the acq entry point
 ACQ_KIT_NAMES=(usai-provider agentic-coding-playbook zscaler-ca-certificate git-ssh-sign)
 
-# Built-in bundle identity (quickstart#235 / patterns#273). This mirrors the
-# `provenance` block the usai-provider kit declares in the patterns repo at the
-# pinned PATTERNS_KIT_REF. acq records these in a sandbox's host-side provenance
+# Built-in bundle identity. This mirrors the `provenance` block the usai-provider
+# kit declares at the pinned PATTERNS_KIT_REF. acq records these in a sandbox's
 # record so a later `acq run` / `acq kit check` can tell whether an existing
 # sandbox was built from the CURRENTLY pinned bundle. The bundle name + repo are
 # stable identity; the applied SHA (PATTERNS_KIT_REF) is the currency signal.
@@ -66,7 +61,7 @@ ACQ_BUILTIN_BUNDLE_REPO="GSA-TTS/agentic-coding-patterns"
 ACQ_EXTRA_KITS="${ACQ_EXTRA_KITS:-}"
 ACQ_EXTRA_KIT_SOURCES="${ACQ_EXTRA_KIT_SOURCES:-}"
 
-# Update-check opt-out (quickstart#236). When ACQ_UPDATE_CHECK=0, `acq run` never
+# Update-check opt-out. When ACQ_UPDATE_CHECK=0, `acq run` never
 # runs the stale-sandbox check (no provenance comparison, no prompt). The
 # explicit `acq kit check` / `acq kit update` commands still work — the opt-out
 # only silences the automatic per-run check. `acq run --no-update-check` sets
@@ -465,7 +460,7 @@ acq_resolve_backend() {
 }
 
 # ============================================================================
-# Kit-bundle provenance + staleness (quickstart#235 / #236)
+# Kit-bundle provenance + staleness
 # ============================================================================
 # When acq applies the built-in kit bundle to a sandbox it records, HOST-SIDE, a
 # small provenance record naming the bundle and the exact PATTERNS_KIT_REF that
@@ -474,7 +469,7 @@ acq_resolve_backend() {
 # record exists), the sandbox is "stale/legacy" and acq offers a safe in-place
 # refresh.
 #
-# Design (per quickstart#235 consensus + #236 decisions):
+# Design:
 #   - Host-side only. The record lives under XDG_STATE_HOME on the machine
 #     running acq, keyed by backend + sandbox name. No guest exec is needed to
 #     read it, so the check is fast and works even for a stopped sandbox. If the
@@ -630,8 +625,7 @@ acq_bundle_reapply() {
 
 # Automatic stale-sandbox advisory for `acq run` on an EXISTING sandbox. Compares
 # the sandbox's recorded bundle ref against the local pinned PATTERNS_KIT_REF and,
-# when they differ (or no record exists), OFFERS an in-place refresh. Contract
-# (quickstart#236):
+# when they differ (or no record exists), OFFERS an in-place refresh. Contract:
 #   - Opt-out: ACQ_UPDATE_CHECK=0 (or `acq run --no-update-check`) skips entirely.
 #   - Interactive only. Non-interactive (no TTY on stdin) NEVER blocks: it prints
 #     one concise advisory and returns 0 so the run continues.

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -28,11 +28,15 @@
 # playbook auth on msb via the GitHub REST API instead of git clone).
 # ============================================================================
 PATTERNS_KIT_REPO="git+https://github.com/GSA-TTS/agentic-coding-patterns.git"
-# patterns main @ 3fcde8e — playbook REST-tarball fetch (#269, quickstart#203),
-# on top of the environment vocabulary (#227) and neutral acq-kits (#221/#224).
-# Full 40-char SHA (not an abbreviation): this ref drives a credential-bearing
-# cross-repo kit fetch, so pin it unambiguously for reproducibility.
-PATTERNS_KIT_REF="3fcde8ee396bf9841de47f6f7886db088164243d"
+# patterns main @ 5c55bcf — bundle provenance schema + usai-provider provenance
+# block (patterns#273, quickstart#235), on top of the playbook REST-tarball fetch
+# (#269, quickstart#203), the environment vocabulary (#227) and neutral acq-kits
+# (#221/#224). Full 40-char SHA (not an abbreviation): this ref drives a
+# credential-bearing cross-repo kit fetch, so pin it unambiguously for
+# reproducibility. It is ALSO the bundle-version anchor recorded in a sandbox's
+# host-side provenance record (see ACQ_BUILTIN_BUNDLE below + the provenance
+# helpers) so acq can tell a stale sandbox from a current one.
+PATTERNS_KIT_REF="5c55bcf9fc77947b145a828f75877797ebd6d178"
 PATTERNS_KIT_DIR="integrations/isolation/acq-kits"
 
 USAI_KIT="${PATTERNS_KIT_REPO}#ref=${PATTERNS_KIT_REF}&dir=${PATTERNS_KIT_DIR}/usai-provider"
@@ -46,10 +50,28 @@ GITSSHSIGN_KIT="${PATTERNS_KIT_REPO}#ref=${PATTERNS_KIT_REF}&dir=${PATTERNS_KIT_
 # shellcheck disable=SC2034  # consumed by `acq kit list` in the acq entry point
 ACQ_KIT_NAMES=(usai-provider agentic-coding-playbook zscaler-ca-certificate git-ssh-sign)
 
+# Built-in bundle identity (quickstart#235 / patterns#273). This mirrors the
+# `provenance` block the usai-provider kit declares in the patterns repo at the
+# pinned PATTERNS_KIT_REF. acq records these in a sandbox's host-side provenance
+# record so a later `acq run` / `acq kit check` can tell whether an existing
+# sandbox was built from the CURRENTLY pinned bundle. The bundle name + repo are
+# stable identity; the applied SHA (PATTERNS_KIT_REF) is the currency signal.
+# shellcheck disable=SC2034  # consumed by the provenance helpers below
+ACQ_BUILTIN_BUNDLE="acq-builtin"
+# shellcheck disable=SC2034
+ACQ_BUILTIN_BUNDLE_REPO="GSA-TTS/agentic-coding-patterns"
+
 # Additional user-supplied kits. Set ACQ_EXTRA_KITS to a whitespace-separated
 # list of kit references. Set ACQ_EXTRA_KIT_SOURCES for their allowlist prefixes.
 ACQ_EXTRA_KITS="${ACQ_EXTRA_KITS:-}"
 ACQ_EXTRA_KIT_SOURCES="${ACQ_EXTRA_KIT_SOURCES:-}"
+
+# Update-check opt-out (quickstart#236). When ACQ_UPDATE_CHECK=0, `acq run` never
+# runs the stale-sandbox check (no provenance comparison, no prompt). The
+# explicit `acq kit check` / `acq kit update` commands still work — the opt-out
+# only silences the automatic per-run check. `acq run --no-update-check` sets
+# this for a single invocation (parsed in the acq entry point).
+ACQ_UPDATE_CHECK="${ACQ_UPDATE_CHECK:-1}"
 
 # Kits supplied on the command line via `--kit <ref>` (repeatable) on
 # run/create. These are extracted from the arg list by extract_kit_flags (below)
@@ -440,6 +462,233 @@ acq_resolve_backend() {
 
   _load_backend_adapter "$name"
   _build_kit_list
+}
+
+# ============================================================================
+# Kit-bundle provenance + staleness (quickstart#235 / #236)
+# ============================================================================
+# When acq applies the built-in kit bundle to a sandbox it records, HOST-SIDE, a
+# small provenance record naming the bundle and the exact PATTERNS_KIT_REF that
+# was applied. A later `acq run` / `acq kit check` compares that recorded ref
+# against the local checkout's CURRENT PATTERNS_KIT_REF: if they differ (or no
+# record exists), the sandbox is "stale/legacy" and acq offers a safe in-place
+# refresh.
+#
+# Design (per quickstart#235 consensus + #236 decisions):
+#   - Host-side only. The record lives under XDG_STATE_HOME on the machine
+#     running acq, keyed by backend + sandbox name. No guest exec is needed to
+#     read it, so the check is fast and works even for a stopped sandbox. If the
+#     host state is lost, the sandbox reads as "unknown" and acq simply re-offers
+#     a refresh — never a destructive default.
+#   - The LOCAL checkout's PATTERNS_KIT_REF is the source of truth (never the
+#     mutable patterns `main`).
+#   - Staleness = exact-ref mismatch (or missing record). No git ancestry / no
+#     network call: deterministic and offline-safe. A newer-but-different local
+#     pin correctly offers a refresh.
+#   - Written ONLY after a successful apply (the caller gates the write on the
+#     apply's exit status); a partial/failed apply must not claim currency.
+#   - Fail-open: any read/parse/detect error is treated as "cannot determine" and
+#     never blocks a run.
+#
+# Record format: a tiny, dependency-free `key=value` file (one pair per line).
+# We deliberately avoid a JSON/YAML dependency in the shell path — the fields are
+# flat scalars and this matches the awk-parsed acq config convention.
+
+# Provenance state directory (host-side). Overridable via ACQ_PROVENANCE_DIR for
+# tests and for users who relocate XDG state. Mirrors _acq_config_file's style.
+_acq_provenance_dir() {
+  if [ -n "${ACQ_PROVENANCE_DIR:-}" ]; then
+    printf '%s\n' "$ACQ_PROVENANCE_DIR"
+    return 0
+  fi
+  printf '%s\n' "${XDG_STATE_HOME:-$HOME/.local/state}/acq/provenance"
+}
+
+# Path to one sandbox's provenance record. Keyed by backend + sandbox name so the
+# same name under two backends never collides. The sandbox name is sanitized to a
+# safe filename charset (defense-in-depth: a name reaches a filesystem path here).
+# A short checksum of the RAW name is appended so two distinct names that sanitize
+# to the same string (e.g. "a/b" and "a_b") do not alias onto one record.
+_acq_provenance_file() {
+  local backend="${1:-}" name="${2:-}"
+  [ -n "$backend" ] && [ -n "$name" ] || return 1
+  local safe_backend safe_name name_sum
+  safe_backend=$(printf '%s' "$backend" | tr -c 'A-Za-z0-9._-' '_')
+  safe_name=$(printf '%s' "$name" | tr -c 'A-Za-z0-9._-' '_')
+  # cksum of the raw name disambiguates sanitizer collisions (fail-open: if cksum
+  # is somehow unavailable the name still resolves, just without the suffix).
+  name_sum=$(printf '%s' "$name" | cksum 2>/dev/null | cut -d' ' -f1 2>/dev/null || echo 0)
+  printf '%s/%s/%s.%s.env\n' "$(_acq_provenance_dir)" "$safe_backend" "$safe_name" "$name_sum"
+}
+
+# Write (or overwrite) a sandbox's provenance record. Call ONLY after a
+# successful bundle apply. Records the bundle identity + the exact applied ref +
+# an ISO-8601 UTC timestamp + the backend. Best-effort: a write failure warns
+# (debug) and returns non-zero but never aborts the caller (fail-open).
+# Usage: acq_provenance_write BACKEND SANDBOX_NAME
+acq_provenance_write() {
+  local backend="${1:-}" name="${2:-}"
+  [ -n "$backend" ] && [ -n "$name" ] || return 1
+  local file dir ts
+  file=$(_acq_provenance_file "$backend" "$name") || return 1
+  dir=$(dirname "$file")
+  if ! mkdir -p "$dir" 2>/dev/null; then
+    acq_debug "provenance: could not create state dir: $dir"
+    return 1
+  fi
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+  # Write atomically via a temp file + mv so a crash mid-write can't leave a
+  # half-written record that later parses as a bogus "current" ref.
+  local tmp="${file}.tmp.$$"
+  {
+    printf 'schema=1\n'
+    printf 'bundle=%s\n' "$ACQ_BUILTIN_BUNDLE"
+    printf 'repo=%s\n' "$ACQ_BUILTIN_BUNDLE_REPO"
+    printf 'applied_ref=%s\n' "$PATTERNS_KIT_REF"
+    printf 'backend=%s\n' "$backend"
+    printf 'applied_at=%s\n' "$ts"
+  } > "$tmp" 2>/dev/null || { acq_debug "provenance: write failed: $tmp"; rm -f "$tmp" 2>/dev/null; return 1; }
+  mv -f "$tmp" "$file" 2>/dev/null || { acq_debug "provenance: mv failed: $file"; rm -f "$tmp" 2>/dev/null; return 1; }
+  acq_debug "provenance: recorded $backend/$name applied_ref=$PATTERNS_KIT_REF"
+  return 0
+}
+
+# Read one field from a sandbox's provenance record. Echoes the value (empty if
+# absent/unreadable). Defensive flat key=value parse (no YAML/JSON dep), matching
+# the acq config awk convention. Only the first match wins.
+# Usage: acq_provenance_field BACKEND SANDBOX_NAME FIELD
+acq_provenance_field() {
+  local backend="${1:-}" name="${2:-}" field="${3:-}"
+  [ -n "$backend" ] && [ -n "$name" ] && [ -n "$field" ] || return 0
+  local file
+  file=$(_acq_provenance_file "$backend" "$name") || return 0
+  [ -f "$file" ] || return 0
+  awk -F= -v k="$field" '
+    $1 == k { sub(/^[^=]*=/, ""); print; exit }
+  ' "$file" 2>/dev/null || true
+}
+
+# Classify a sandbox's currency against the LOCAL pinned PATTERNS_KIT_REF.
+# Echoes exactly one of: current | stale | unknown.
+#   current — record exists and applied_ref == local PATTERNS_KIT_REF.
+#   stale   — record exists and applied_ref != local PATTERNS_KIT_REF.
+#   unknown — no record (legacy sandbox, or host state lost) or unreadable.
+# Fail-open: on any doubt it returns "unknown", which callers treat as "offer a
+# refresh" — never as "force" and never as a launch blocker.
+# Usage: acq_provenance_status BACKEND SANDBOX_NAME
+acq_provenance_status() {
+  local backend="${1:-}" name="${2:-}"
+  [ -n "$backend" ] && [ -n "$name" ] || { printf 'unknown\n'; return 0; }
+  local applied
+  applied=$(acq_provenance_field "$backend" "$name" applied_ref)
+  if [ -z "$applied" ]; then
+    printf 'unknown\n'
+    return 0
+  fi
+  if [ "$applied" = "$PATTERNS_KIT_REF" ]; then
+    printf 'current\n'
+  else
+    printf 'stale\n'
+  fi
+  return 0
+}
+
+# Reapply the built-in bundle to an existing sandbox and, on success, refresh its
+# host-side provenance record. Uses the backend's heal path
+# (acq_backend_ensure_kits_applied) with ACQ_FORCE_KIT_REAPPLY=1 so a
+# present-but-stale kit is actually re-applied (the sbx feature-probe would
+# otherwise skip a kit that is present but built from an older ref). msb already
+# re-applies all kits idempotently; the force flag is a no-op there. After a usai
+# refresh the kit's own startup global-merge re-runs on next attach, so the
+# refreshed model catalog reaches the config. State (sessions, secrets, unrelated
+# config, project overrides) is preserved: this is an in-place kit reapply, never
+# a sandbox delete/recreate.
+# Returns 0 on success (bundle applied + provenance updated by the heal path),
+# non-zero on apply failure (record left untouched, so the sandbox correctly
+# stays "stale/unknown").
+# Usage: acq_bundle_reapply BACKEND SANDBOX_NAME
+acq_bundle_reapply() {
+  local backend="${1:-}" name="${2:-}"
+  [ -n "$backend" ] && [ -n "$name" ] || return 1
+  if ! command -v acq_backend_ensure_kits_applied >/dev/null 2>&1; then
+    echo "acq: error: backend '$backend' cannot reapply kits (no ensure_kits_applied)." >&2
+    return 1
+  fi
+  echo "acq: refreshing the built-in kit bundle in '$name' (in place; state preserved)..." >&2
+  # ensure_kits_applied writes provenance itself on full success and returns
+  # non-zero on any built-in-kit failure, so we do not double-write here.
+  if ACQ_FORCE_KIT_REAPPLY=1 acq_backend_ensure_kits_applied "$name"; then
+    echo "acq: '$name' refreshed to patterns ref ${PATTERNS_KIT_REF}." >&2
+    echo "      Restart the agent (or re-run 'acq run') to pick up refreshed config." >&2
+    return 0
+  fi
+  echo "acq: warning: kit refresh for '$name' did not complete cleanly; leaving it as-is." >&2
+  echo "      The sandbox and its state are untouched. Re-run 'acq kit update $name' to retry," >&2
+  echo "      or 'acq rm $name && acq run ...' for a clean rebuild." >&2
+  return 1
+}
+
+# Automatic stale-sandbox advisory for `acq run` on an EXISTING sandbox. Compares
+# the sandbox's recorded bundle ref against the local pinned PATTERNS_KIT_REF and,
+# when they differ (or no record exists), OFFERS an in-place refresh. Contract
+# (quickstart#236):
+#   - Opt-out: ACQ_UPDATE_CHECK=0 (or `acq run --no-update-check`) skips entirely.
+#   - Interactive only. Non-interactive (no TTY on stdin) NEVER blocks: it prints
+#     one concise advisory and returns 0 so the run continues.
+#   - Default is No. A bare Enter, EOF (Ctrl-D / closed stdin), or anything other
+#     than an explicit yes declines — and a decline never prevents launch.
+#   - Fail-open: "unknown" status (legacy/lost record) is advisory, not forced.
+# The caller MUST pass the status captured BEFORE the pre-attach heal, because the
+# heal rewrites provenance to "current" — reading status here would then always
+# see "current" and never offer. $3 is that pre-heal status (current|stale|
+# unknown); when omitted we read it live (used by unit tests that seed a record).
+# This function always returns 0 (it must never abort a run); the refresh itself
+# is best-effort.
+# Usage: maybe_offer_bundle_refresh BACKEND SANDBOX_NAME [PRE_HEAL_STATUS]
+maybe_offer_bundle_refresh() {
+  local backend="${1:-}" name="${2:-}" status="${3:-}"
+  [ -n "$backend" ] && [ -n "$name" ] || return 0
+
+  # Opt-out short-circuits the entire check.
+  [ "${ACQ_UPDATE_CHECK:-1}" = "0" ] && return 0
+
+  [ -n "$status" ] || status=$(acq_provenance_status "$backend" "$name")
+  # Nothing to do when the sandbox is already on the pinned bundle.
+  [ "$status" = "current" ] && return 0
+
+  case "$status" in
+    stale)
+      echo "acq: note — '$name' was built from an older kit bundle than your pinned" >&2
+      echo "      version (local patterns ref ${PATTERNS_KIT_REF})." >&2
+      ;;
+    *)
+      # unknown: legacy sandbox (pre-provenance) or lost host record.
+      echo "acq: note — acq cannot confirm '$name' is on your pinned kit bundle" >&2
+      echo "      (no provenance record; it may predate provenance tracking)." >&2
+      ;;
+  esac
+  echo "      A refresh updates the built-in kits (USAi config, playbook, Zscaler CA," >&2
+  echo "      git-ssh-sign) in place. Your sessions, secrets, and project files are kept." >&2
+
+  # Non-interactive: advise how to do it explicitly, then continue. Never block.
+  if [ ! -t 0 ]; then
+    echo "      To refresh later: acq kit update $name" >&2
+    echo "      To silence this check: ACQ_UPDATE_CHECK=0 (or acq run --no-update-check)." >&2
+    return 0
+  fi
+
+  local ans=""
+  printf 'acq: refresh the kit bundle in %s now? [y/N] ' "$name" >&2
+  read -r ans 2>/dev/null || ans=""
+  case "$ans" in
+    y|Y|yes|YES)
+      acq_bundle_reapply "$backend" "$name" || true
+      ;;
+    *)
+      echo "acq: continuing without refreshing (run 'acq kit update $name' anytime)." >&2
+      ;;
+  esac
+  return 0
 }
 
 # ============================================================================

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -1014,8 +1014,8 @@ EOF
     fi
   done
   acq_debug "msb provision: all kits applied; provision complete ($name)"
-  # Record host-side bundle provenance now the built-in bundle is applied
-  # (quickstart#236). Best-effort: a provenance write failure never affects the
+  # Record host-side bundle provenance now the built-in bundle is applied.
+  # Best-effort: a provenance write failure never affects the
   # sandbox. Reached only when provision did not abort earlier under set -e.
   acq_provenance_write msb "$name" || true
 }
@@ -1431,8 +1431,8 @@ acq_backend_ensure_kits_applied() {
     fi
     i=$((i + 1))
   done
-  # Record host-side bundle provenance ONLY when every built-in kit applied
-  # (quickstart#236). msb re-applies all built-in kits idempotently, so on full
+  # Record host-side bundle provenance ONLY when every built-in kit applied.
+  # msb re-applies all built-in kits idempotently, so on full
   # success the sandbox carries the currently pinned bundle. Best-effort write.
   if [ "$ok" -eq 1 ]; then
     acq_provenance_write msb "$name" || true

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -1014,6 +1014,10 @@ EOF
     fi
   done
   acq_debug "msb provision: all kits applied; provision complete ($name)"
+  # Record host-side bundle provenance now the built-in bundle is applied
+  # (quickstart#236). Best-effort: a provenance write failure never affects the
+  # sandbox. Reached only when provision did not abort earlier under set -e.
+  acq_provenance_write msb "$name" || true
 }
 
 # ---------------------------------------------------------------------------
@@ -1406,19 +1410,35 @@ acq_backend_apply_kit() {
 acq_backend_ensure_kits_applied() {
   local name="$1"
   local kits=("$USAI_KIT" "$PLAYBOOK_KIT" "$ZSCALER_KIT" "$GITSSHSIGN_KIT")
+  local builtin_count="${#kits[@]}"
   if [ -n "${ACQ_EXTRA_KITS:-}" ]; then
     local _extras=()
     split_noglob _extras "$ACQ_EXTRA_KITS"
     kits+=("${_extras[@]}")
   fi
-  local kitref kitdir
+  local kitref kitdir i=0 ok=1
   for kitref in "${kits[@]}"; do
     kitdir=$(_acq_msb_fetch_kit "$kitref") || {
       echo "acq(msb): warning: could not fetch kit for healing: $kitref" >&2
+      # A built-in kit that can't even be fetched means we cannot claim the
+      # bundle is current. Extra-kit fetch failures don't affect the verdict.
+      [ "$i" -lt "$builtin_count" ] && ok=0
+      i=$((i + 1))
       continue
     }
-    _acq_msb_apply_kit_dir "$name" "$kitdir" || true
+    if ! _acq_msb_apply_kit_dir "$name" "$kitdir"; then
+      [ "$i" -lt "$builtin_count" ] && ok=0
+    fi
+    i=$((i + 1))
   done
+  # Record host-side bundle provenance ONLY when every built-in kit applied
+  # (quickstart#236). msb re-applies all built-in kits idempotently, so on full
+  # success the sandbox carries the currently pinned bundle. Best-effort write.
+  if [ "$ok" -eq 1 ]; then
+    acq_provenance_write msb "$name" || true
+    return 0
+  fi
+  return 1
 }
 
 # ---------------------------------------------------------------------------

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -343,7 +343,7 @@ acq_backend_provision() {
   fi
   local _rc=$?
   # Record host-side bundle provenance ONLY after a successful create — a failed
-  # create must not leave a record claiming the sandbox is current (#236).
+  # create must not leave a record claiming the sandbox is current.
   if [ "$_rc" -eq 0 ]; then
     acq_provenance_write sbx "$name" || true
   fi
@@ -417,7 +417,7 @@ acq_backend_apply_kit() {
 # (carries ensure_kit_applied logic from qsbx)
 # ---------------------------------------------------------------------------
 # Injects any ABSENT built-in kit. When ACQ_FORCE_KIT_REAPPLY=1 (set by
-# acq_bundle_reapply for a stale-bundle refresh, quickstart#236) it re-adds ALL
+# acq_bundle_reapply for a stale-bundle refresh) it re-adds ALL
 # built-in kits even when present, so a kit built from an older ref is actually
 # refreshed — the feature-probe alone would skip a present-but-stale kit.
 # Returns 0 only if every built-in kit is present-or-successfully-applied, so a
@@ -477,7 +477,7 @@ acq_backend_ensure_kits_applied() {
   fi
 
   # 3b) git-ssh-sign kit. The original heal loop omitted this built-in kit; a
-  # forced reapply (stale-bundle refresh, #236) MUST cover the whole bundle, so
+  # forced reapply (stale-bundle refresh) MUST cover the whole bundle, so
   # re-add it when forcing. On a normal heal we leave the historical behavior
   # (the kit self-heals via the playbook clone) unchanged.
   if [ "$force" = "1" ]; then
@@ -513,8 +513,8 @@ acq_backend_ensure_kits_applied() {
     fi
   done
 
-  # Record host-side provenance ONLY if every built-in kit is present-or-applied
-  # (quickstart#236). A failed apply must not write a record claiming the sandbox
+  # Record host-side provenance ONLY if every built-in kit is present-or-applied.
+  # A failed apply must not write a record claiming the sandbox
   # is current. Best-effort write: a provenance write failure never fails the run.
   if [ "$ok" -eq 1 ]; then
     acq_provenance_write sbx "$name" || true

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -341,6 +341,13 @@ acq_backend_provision() {
   else
     sbx create --name "$name" "${kf[@]}"
   fi
+  local _rc=$?
+  # Record host-side bundle provenance ONLY after a successful create — a failed
+  # create must not leave a record claiming the sandbox is current (#236).
+  if [ "$_rc" -eq 0 ]; then
+    acq_provenance_write sbx "$name" || true
+  fi
+  return "$_rc"
 }
 
 # ---------------------------------------------------------------------------
@@ -409,9 +416,18 @@ acq_backend_apply_kit() {
 # acq_backend_ensure_kits_applied — heal a pre-kit sandbox in place
 # (carries ensure_kit_applied logic from qsbx)
 # ---------------------------------------------------------------------------
+# Injects any ABSENT built-in kit. When ACQ_FORCE_KIT_REAPPLY=1 (set by
+# acq_bundle_reapply for a stale-bundle refresh, quickstart#236) it re-adds ALL
+# built-in kits even when present, so a kit built from an older ref is actually
+# refreshed — the feature-probe alone would skip a present-but-stale kit.
+# Returns 0 only if every built-in kit is present-or-successfully-applied, so a
+# caller can gate a provenance write on real success (never claim currency after
+# a failed apply).
 
 acq_backend_ensure_kits_applied() {
   local name="$1"
+  local force="${ACQ_FORCE_KIT_REAPPLY:-0}"
+  local ok=1
 
   _acq_sbx_ensure_kit_sources_allowed
 
@@ -422,7 +438,7 @@ acq_backend_ensure_kits_applied() {
   zscaler_local=$(_acq_sbx_translate_kit "$ZSCALER_KIT")
 
   # 1) USAi provider kit
-  if _acq_sbx_kit_feature_absent "$name" "test -f '$USAI_KIT_CONFIG_PATH' && echo present"; then
+  if [ "$force" = "1" ] || _acq_sbx_kit_feature_absent "$name" "test -f '$USAI_KIT_CONFIG_PATH' && echo present"; then
     echo "acq: '$name' is missing the USAi kit; injecting with 'sbx kit add'..." >&2
     if sbx kit add "$name" "$usai_local" </dev/null >/dev/null 2>&1; then
       sbx exec "$name" -- sh -c \
@@ -432,34 +448,53 @@ acq_backend_ensure_kits_applied() {
     else
       echo "acq: warning: 'sbx kit add' (USAi kit) failed for '$name'." >&2
       echo "      Recover with: sbx kit add '$name' '$usai_local'" >&2
+      ok=0
     fi
   fi
 
   # 2) Playbook kit
-  if _acq_sbx_kit_feature_absent "$name" 'test -e "$HOME/.agentic-coding-playbook/.git" && echo present'; then
+  if [ "$force" = "1" ] || _acq_sbx_kit_feature_absent "$name" 'test -e "$HOME/.agentic-coding-playbook/.git" && echo present'; then
     echo "acq: '$name' is missing the playbook kit; injecting with 'sbx kit add'..." >&2
     if sbx kit add "$name" "$playbook_local" </dev/null >/dev/null 2>&1; then
       echo "acq: playbook kit injected into '$name'. Restart the agent to pick it up." >&2
     else
       echo "acq: warning: 'sbx kit add' (playbook kit) failed for '$name'." >&2
       echo "      Recover with: sbx kit add '$name' '$playbook_local'" >&2
+      ok=0
     fi
   fi
 
   # 3) Zscaler CA kit
-  if _acq_sbx_kit_feature_absent "$name" 'test -e /usr/local/share/ca-certificates/zscaler-ca.crt && echo present'; then
+  if [ "$force" = "1" ] || _acq_sbx_kit_feature_absent "$name" 'test -e /usr/local/share/ca-certificates/zscaler-ca.crt && echo present'; then
     echo "acq: '$name' is missing the Zscaler CA kit; injecting with 'sbx kit add'..." >&2
     if sbx kit add "$name" "$zscaler_local" </dev/null >/dev/null 2>&1; then
       echo "acq: Zscaler CA kit injected into '$name'." >&2
     else
       echo "acq: warning: 'sbx kit add' (Zscaler CA kit) failed for '$name'." >&2
       echo "      Recover with: sbx kit add '$name' '$zscaler_local'" >&2
+      ok=0
+    fi
+  fi
+
+  # 3b) git-ssh-sign kit. The original heal loop omitted this built-in kit; a
+  # forced reapply (stale-bundle refresh, #236) MUST cover the whole bundle, so
+  # re-add it when forcing. On a normal heal we leave the historical behavior
+  # (the kit self-heals via the playbook clone) unchanged.
+  if [ "$force" = "1" ]; then
+    local gitsshsign_local
+    gitsshsign_local=$(_acq_sbx_translate_kit "$GITSSHSIGN_KIT")
+    if sbx kit add "$name" "$gitsshsign_local" </dev/null >/dev/null 2>&1; then
+      echo "acq: git-ssh-sign kit refreshed in '$name'." >&2
+    else
+      echo "acq: warning: 'sbx kit add' (git-ssh-sign kit) failed for '$name'." >&2
+      ok=0
     fi
   fi
 
   # 4) Extra kits (tracked by marker file). Extra kits may be neutral or already
   #    sbx-v2; _acq_sbx_translate_kit handles both. The marker uses the original
-  #    ref (stable across runs), not the translated local dir.
+  #    ref (stable across runs), not the translated local dir. Extra-kit failures
+  #    do not affect the built-in bundle's provenance verdict.
   local applied k local_extra
   applied=$(sbx exec "$name" -- sh -c 'cat "$HOME/.acq-extra-kits" 2>/dev/null' </dev/null 2>/dev/null || true)
   local _extras=()
@@ -477,6 +512,15 @@ acq_backend_ensure_kits_applied() {
       echo "      Recover with: sbx kit add '$name' '$local_extra'" >&2
     fi
   done
+
+  # Record host-side provenance ONLY if every built-in kit is present-or-applied
+  # (quickstart#236). A failed apply must not write a record claiming the sandbox
+  # is current. Best-effort write: a provenance write failure never fails the run.
+  if [ "$ok" -eq 1 ]; then
+    acq_provenance_write sbx "$name" || true
+    return 0
+  fi
+  return 1
 }
 
 # ---------------------------------------------------------------------------

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -558,7 +558,7 @@ See [ADR-0016](adr/0016-kit-bundle-provenance-and-stale-refresh.md).
 ## Shipped later
 
 - `acq kit check|update` + host-side kit-bundle provenance and stale-sandbox
-  refresh (quickstart#236, ADR-0016)
+  refresh (see ADR-0016)
 
 ## Still deferred
 
@@ -568,4 +568,4 @@ See [ADR-0016](adr/0016-kit-bundle-provenance-and-stale-refresh.md).
 - `ppp` (Podman-Plus-Proxy) backend — Phase 3, in development at
   [GSA-TTS/ppp](https://github.com/GSA-TTS/ppp)
 - Removal of `qsbx` (Phase 4 / 2.0.0)
-- Advisory "your Quickstart checkout is behind origin" check (quickstart#237)
+- Advisory "your Quickstart checkout is behind origin" check

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -525,6 +525,28 @@ the kit spec never carries a secret value.
 
 Manage kits with `acq kit list | validate PATH | apply NAME KITREF`.
 
+### Kit-bundle provenance and stale-sandbox refresh
+
+`acq` records, host-side, which built-in bundle ref each sandbox was built from
+(under `${XDG_STATE_HOME:-$HOME/.local/state}/acq/provenance/<backend>/<name>.env`;
+override with `ACQ_PROVENANCE_DIR`). It compares that against the **local**
+`PATTERNS_KIT_REF` to detect drift:
+
+- `acq kit check SANDBOX` — report `current` / `stale` / `unknown` (read-only).
+- `acq kit update SANDBOX [--yes]` — reapply the bundle in place to the pinned
+  ref, preserving sandbox state. `--yes` is honored **only** on this explicit
+  command.
+- `acq run` on an existing sandbox that is behind the pin **offers** a refresh:
+  interactive, default No, EOF declines, and it **never blocks** a launch. A
+  non-interactive run prints one advisory and continues.
+- Opt out with `ACQ_UPDATE_CHECK=0` or `acq run --no-update-check`.
+
+Backend behavior: **sbx** injects any absent built-in kits during the heal pass;
+**msb** re-applies all built-in kits idempotently. Both rewrite provenance only
+after a successful apply. Staleness is an exact-ref mismatch against the local
+pin (no git ancestry, no network) — the local checkout is the source of truth.
+See [ADR-0016](adr/0016-kit-bundle-provenance-and-stale-refresh.md).
+
 ---
 
 ## Shipped in 1.2.0
@@ -532,6 +554,11 @@ Manage kits with `acq kit list | validate PATH | apply NAME KITREF`.
 - `acq kit apply|list|validate` — kit management subcommands
 - Neutral `hybrid/v1` kit spec + `kit-translate.sh` (multi-backend kits)
 - `msb` (microsandbox) backend
+
+## Shipped later
+
+- `acq kit check|update` + host-side kit-bundle provenance and stale-sandbox
+  refresh (quickstart#236, ADR-0016)
 
 ## Still deferred
 
@@ -541,3 +568,4 @@ Manage kits with `acq kit list | validate PATH | apply NAME KITREF`.
 - `ppp` (Podman-Plus-Proxy) backend — Phase 3, in development at
   [GSA-TTS/ppp](https://github.com/GSA-TTS/ppp)
 - Removal of `qsbx` (Phase 4 / 2.0.0)
+- Advisory "your Quickstart checkout is behind origin" check (quickstart#237)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -161,28 +161,21 @@ the active backend automatically. Inspect and manage them with:
 
 ### Keeping existing sandboxes current
 
-`acq` pins the built-in kit bundle (USAi config, playbook, Zscaler CA,
-git-ssh-sign) to one commit of the patterns repo. When that pin is bumped,
-**new** sandboxes get the new bundle right away. For an **existing** sandbox,
-`acq` records which bundle ref it was built from and can tell you if it is behind:
+`acq` pins the built-in kit bundle to one commit of the patterns repo. **New**
+sandboxes get the pinned bundle automatically; for an **existing** sandbox, `acq`
+can tell you if it is behind and refresh it in place:
 
 ```bash
 ./acq kit check my-sandbox        # is this sandbox on the pinned bundle?
 ./acq kit update my-sandbox       # refresh the bundle in place (asks first)
-./acq kit update my-sandbox --yes # refresh without the prompt
 ```
 
-- `acq run` on an existing sandbox that is behind the pin **offers** a refresh.
-  It is interactive, defaults to **No**, and **never blocks** a launch — declining
-  (or a non-interactive run) just continues.
-- A refresh updates the kits **in place**. Your sessions, secrets, unrelated
-  config, and project files are kept. It never deletes or recreates the sandbox.
-- To skip the automatic check: `ACQ_UPDATE_CHECK=0` (whole session) or
-  `./acq run --no-update-check ...` (one run).
-- A sandbox created before this feature has **no record**; `acq` reports it as
-  `unknown` and offers a refresh. Refreshing is safe and idempotent.
+`acq run` also offers a refresh when a sandbox is behind; it defaults to No and
+never blocks a launch. Refreshes are in place (sessions, secrets, and project
+files are kept). Skip the automatic check with `ACQ_UPDATE_CHECK=0` or
+`./acq run --no-update-check`.
 
-See [ADR-0016](adr/0016-kit-bundle-provenance-and-stale-refresh.md) for the
+See [ADR-0016](adr/0016-kit-bundle-provenance-and-stale-refresh.md) for the full
 design and trust model.
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -159,6 +159,32 @@ the active backend automatically. Inspect and manage them with:
 ./acq kit apply my-sandbox KITREF # apply a kit to an existing sandbox
 ```
 
+### Keeping existing sandboxes current
+
+`acq` pins the built-in kit bundle (USAi config, playbook, Zscaler CA,
+git-ssh-sign) to one commit of the patterns repo. When that pin is bumped,
+**new** sandboxes get the new bundle right away. For an **existing** sandbox,
+`acq` records which bundle ref it was built from and can tell you if it is behind:
+
+```bash
+./acq kit check my-sandbox        # is this sandbox on the pinned bundle?
+./acq kit update my-sandbox       # refresh the bundle in place (asks first)
+./acq kit update my-sandbox --yes # refresh without the prompt
+```
+
+- `acq run` on an existing sandbox that is behind the pin **offers** a refresh.
+  It is interactive, defaults to **No**, and **never blocks** a launch — declining
+  (or a non-interactive run) just continues.
+- A refresh updates the kits **in place**. Your sessions, secrets, unrelated
+  config, and project files are kept. It never deletes or recreates the sandbox.
+- To skip the automatic check: `ACQ_UPDATE_CHECK=0` (whole session) or
+  `./acq run --no-update-check ...` (one run).
+- A sandbox created before this feature has **no record**; `acq` reports it as
+  `unknown` and offers a refresh. Refreshing is safe and idempotent.
+
+See [ADR-0016](adr/0016-kit-bundle-provenance-and-stale-refresh.md) for the
+design and trust model.
+
 ---
 
 ## Migration from qsbx

--- a/docs/adr/0016-kit-bundle-provenance-and-stale-refresh.md
+++ b/docs/adr/0016-kit-bundle-provenance-and-stale-refresh.md
@@ -32,9 +32,9 @@ not:
 Nothing inside or beside a sandbox recorded **which** bundle ref was applied, so
 "is this sandbox current?" was unanswerable. Users silently drifted.
 
-This is issue quickstart#236 (PR2 of the epic quickstart#235). PR1 landed the
-additive `provenance` block on the hybrid/v1 kit schema in the patterns repo
-(GSA-TTS/agentic-coding-patterns#273, merged as `5c55bcf`).
+The prerequisite for this work — an additive `provenance` block on the
+`hybrid/v1` kit schema — is provided by the pinned `PATTERNS_KIT_REF` in the
+patterns repo.
 
 ## Decision
 
@@ -98,8 +98,8 @@ in-place refresh.
 - `acq kit check` answers "is this sandbox current?" deterministically and
   offline.
 - No new network or trust surface: provenance is local, and the source of truth
-  stays the pinned SHA. The deferred "checkout behind origin" network check
-  (quickstart#237) is intentionally separate.
+  stays the pinned SHA. A separately-tracked "checkout behind origin" network
+  check is intentionally out of scope here.
 - Fail-open throughout: a lost record, an unreadable file, or a non-TTY run never
   blocks a launch.
 
@@ -123,7 +123,7 @@ in-place refresh.
 
 - **Guest-side provenance** (write inside each sandbox). Survives host-state
   loss, but costs an `exec` per check and needs per-backend paths/ownership.
-  Rejected for PR2 as heavier; revisit if host-local proves insufficient.
+  Rejected as heavier; revisit if host-local proves insufficient.
 - **Git-ancestry staleness** (flag only when the recorded ref is a true ancestor
   of the local pin). More precise, but needs a git call against patterns history,
   adds a network/trust surface, and cannot run offline. Rejected: exact-ref
@@ -150,8 +150,4 @@ removed with no effect on sandboxes. No sandbox state is touched by a rollback.
 
 ## References
 
-- Epic: quickstart#235 (safe kit-bundle update propagation)
-- This PR: quickstart#236
-- Deferred follow-up: quickstart#237 (advisory "checkout behind origin" check)
-- Patterns PR1 (provenance schema): GSA-TTS/agentic-coding-patterns#273 (`5c55bcf`)
 - ADR-0009 (in-place kit healing), ADR-0011 (msb backend and neutral kits)

--- a/docs/adr/0016-kit-bundle-provenance-and-stale-refresh.md
+++ b/docs/adr/0016-kit-bundle-provenance-and-stale-refresh.md
@@ -1,0 +1,157 @@
+---
+title: "Record Kit-Bundle Provenance and Offer a Safe Stale-Sandbox Refresh"
+status: accepted
+date: 2026-07-30
+decision_makers: ["William Zujkowski"]
+category: maintainability
+nist_controls: ["CM-2", "CM-3", "CM-8", "SA-10", "SI-7"]
+impact_level: low
+ato_relevance: yes-process
+risk_treatment: mitigate
+supersedes: []
+---
+
+# ADR-0016: Record Kit-Bundle Provenance and Offer a Safe Stale-Sandbox Refresh
+
+## Context and Problem Statement
+
+`acq` applies a built-in "bundle" of four neutral kits (USAi provider, playbook,
+Zscaler CA, git-ssh-sign) to each sandbox, pinned to a full 40-char
+`PATTERNS_KIT_REF` in `acq.backends/common.sh`. When a maintainer bumps that pin
+(for example, after USAi adds new models to the canonical `opencode.jsonc` in the
+patterns repo), **new** sandboxes get the new bundle. **Existing** sandboxes do
+not:
+
+- On **sbx**, `acq_backend_ensure_kits_applied` only injects kits that are
+  *absent* (a feature-probe). A kit that is present but built from an older ref is
+  never refreshed.
+- On **msb**, every kit is re-applied idempotently each run, so the files can
+  update — but nothing tells the user it happened, and there was no way to answer
+  the basic question "is this sandbox on my current pin?"
+
+Nothing inside or beside a sandbox recorded **which** bundle ref was applied, so
+"is this sandbox current?" was unanswerable. Users silently drifted.
+
+This is issue quickstart#236 (PR2 of the epic quickstart#235). PR1 landed the
+additive `provenance` block on the hybrid/v1 kit schema in the patterns repo
+(GSA-TTS/agentic-coding-patterns#273, merged as `5c55bcf`).
+
+## Decision
+
+`acq` records **host-side** kit-bundle provenance for each sandbox and uses it to
+detect staleness against the **local** pinned `PATTERNS_KIT_REF`, offering a safe
+in-place refresh.
+
+1. **Provenance record (host-side).** After a successful bundle apply — in
+   `acq_backend_provision` and `acq_backend_ensure_kits_applied` for both
+   backends — acq writes a small `key=value` record under
+   `${XDG_STATE_HOME:-$HOME/.local/state}/acq/provenance/<backend>/<sandbox>.env`
+   (overridable with `ACQ_PROVENANCE_DIR`). It records the bundle name, source
+   repo, the exact applied `PATTERNS_KIT_REF`, the backend, and an ISO-8601 UTC
+   timestamp. The write is atomic (temp file + `mv`) and **only after success**,
+   so a failed apply never claims currency.
+
+2. **Host-side, not guest-side.** The record lives on the machine running acq,
+   keyed by backend + sandbox name. Reading it needs no guest `exec`, so the
+   check is fast and works for a stopped sandbox. If host state is lost, the
+   sandbox reads as `unknown`, which is treated as "offer a refresh" — never a
+   destructive default.
+
+3. **Staleness = exact-ref mismatch, fail-open.** `acq_provenance_status`
+   returns `current` (recorded ref == local pin), `stale` (recorded ref != local
+   pin), or `unknown` (no/unreadable record). No git-ancestry check and no
+   network call: the comparison is deterministic and offline-safe, and the
+   **local checkout's pin is the source of truth** (never the mutable patterns
+   `main`). A newer-but-different pin correctly offers a refresh.
+
+4. **Automatic advisory on `acq run`.** For an **existing** sandbox,
+   `maybe_offer_bundle_refresh` runs after the heal step. When the sandbox is
+   `stale`/`unknown` it offers an in-place refresh. It is **interactive only**,
+   defaults to **No**, treats EOF/Ctrl-D as decline, and a decline never blocks
+   launch. In a **non-interactive** run (no TTY) it prints one concise advisory
+   and continues — it never blocks. A just-provisioned sandbox is current by
+   construction, so the offer is only on the existing-sandbox paths.
+
+5. **Explicit commands.** `acq kit check SANDBOX` reports status read-only (no
+   mutation). `acq kit update SANDBOX [--yes]` reapplies the bundle in place;
+   `--yes` skips the confirmation and is honored **only** on this explicit
+   command (the automatic run-check never auto-updates). A non-interactive
+   `acq kit update` without `--yes` refuses rather than guessing.
+
+6. **Opt-out.** `ACQ_UPDATE_CHECK=0` (env) or `acq run --no-update-check` (single
+   run) silences the automatic check. The explicit commands still work.
+
+7. **Whole-bundle reconcile via the existing idempotent path.** The refresh
+   reuses `acq_backend_ensure_kits_applied` — sbx injects any absent kits, msb
+   re-applies all kits idempotently — then rewrites provenance. It is an in-place
+   kit reapply: sessions, secrets, unrelated config, and project overrides are
+   preserved. It never deletes or recreates the sandbox. If a backend cannot
+   update cleanly, acq explains, preserves the sandbox, and prints a manual
+   recovery path (`acq kit update` again, or `acq rm && acq run`).
+
+## Consequences
+
+### Positive
+
+- A maintainer bumps `PATTERNS_KIT_REF` once; existing sandboxes are detected as
+  stale and can be refreshed in place, on the user's terms.
+- `acq kit check` answers "is this sandbox current?" deterministically and
+  offline.
+- No new network or trust surface: provenance is local, and the source of truth
+  stays the pinned SHA. The deferred "checkout behind origin" network check
+  (quickstart#237) is intentionally separate.
+- Fail-open throughout: a lost record, an unreadable file, or a non-TTY run never
+  blocks a launch.
+
+### Negative / trade-offs
+
+- Provenance is host-local: if the user deletes `~/.local/state/acq` or moves to a
+  new machine, existing sandboxes read as `unknown` and re-offer a refresh. This
+  is safe (a refresh is idempotent) but can prompt once unnecessarily. Chosen
+  over a guest-side record to avoid a per-run `exec` round-trip and per-backend
+  read/write code; a guest mirror can be added later if needed.
+- Staleness is exact-ref, so a *downgrade* of the local pin also reads as `stale`.
+  That is correct behavior (the sandbox does not match the pin) even if it is not
+  strictly "older".
+
+### Neutral
+
+- The record format is a dependency-free flat `key=value` file, matching the
+  awk-parsed acq config convention (no YAML/JSON parser added to the shell path).
+
+## Alternatives Considered
+
+- **Guest-side provenance** (write inside each sandbox). Survives host-state
+  loss, but costs an `exec` per check and needs per-backend paths/ownership.
+  Rejected for PR2 as heavier; revisit if host-local proves insufficient.
+- **Git-ancestry staleness** (flag only when the recorded ref is a true ancestor
+  of the local pin). More precise, but needs a git call against patterns history,
+  adds a network/trust surface, and cannot run offline. Rejected: exact-ref
+  mismatch matches "the local pin is the source of truth".
+- **Auto-refresh on run.** Rejected: mutating a user's sandbox without consent
+  violates the fail-safe posture. The default is always No / advisory.
+
+## Security Considerations
+
+- The sandbox name is sanitized to a safe filename charset before it is used in a
+  filesystem path (defense-in-depth against traversal via a crafted name).
+- No secrets are read or written by the provenance path; the record holds only a
+  commit SHA, a bundle name, a repo slug, a backend name, and a timestamp.
+- SHA pinning is preserved: `PATTERNS_KIT_REF` remains a full 40-char SHA and the
+  refresh fetches exactly that ref, never mutable `main`.
+- The backend abstraction is preserved: the shared logic lives in `common.sh`;
+  each adapter only calls `acq_provenance_write` after its own successful apply.
+
+## Rollback
+
+Revert the commits on the feature branch. The provenance records under
+`~/.local/state/acq/provenance` are inert data; they can be left in place or
+removed with no effect on sandboxes. No sandbox state is touched by a rollback.
+
+## References
+
+- Epic: quickstart#235 (safe kit-bundle update propagation)
+- This PR: quickstart#236
+- Deferred follow-up: quickstart#237 (advisory "checkout behind origin" check)
+- Patterns PR1 (provenance schema): GSA-TTS/agentic-coding-patterns#273 (`5c55bcf`)
+- ADR-0009 (in-place kit healing), ADR-0011 (msb backend and neutral kits)

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -164,6 +164,9 @@ MSBSTUB
   # Force the acq secret store to a throwaway file backend (never touch the real
   # OS keychain in tests).
   export ACQ_SECRET_STORE_DIR="$STUBDIR/secrets"
+  # Isolate the host-side kit-bundle provenance store (quickstart#236) to this
+  # test's temp dir so provenance reads/writes never touch the real XDG state.
+  export ACQ_PROVENANCE_DIR="$STUBDIR/provenance"
 }
 
 cleanup_stubs() { [ -n "${STUBDIR:-}" ] && rm -rf "$STUBDIR"; }
@@ -1821,6 +1824,206 @@ SPEC
 out=$(ACQ_BACKEND=msb "$ACQ" kit apply mybox "$applykit" 2>/dev/null || true)
 log=$(cat "$CALLS")
 assert_contains "kit: apply (msb) runs msb exec" "$log" "msb exec mybox"
+cleanup_stubs
+
+# ===========================================================================
+# 9p. Kit-bundle provenance + staleness (quickstart#236)
+# ===========================================================================
+# These drive the provenance helpers directly (host-side, no sandbox exec) and
+# the `acq kit check|update` subcommands via the stubbed backends. ACQ_PROVENANCE_DIR
+# is isolated per-test by make_stubs.
+
+# 9p1. Fresh (no record) reads as "unknown"; write makes it "current"; a local
+#      pin bump makes it "stale".
+make_stubs; load_acq
+_pin=$(printf '%s' "$PATTERNS_KIT_REF")
+assert_eq "provenance: no record -> unknown" "unknown" "$(acq_provenance_status sbx pbox)"
+acq_provenance_write sbx pbox
+assert_eq "provenance: after write -> current" "current" "$(acq_provenance_status sbx pbox)"
+assert_eq "provenance: records applied_ref" "$_pin" "$(acq_provenance_field sbx pbox applied_ref)"
+assert_eq "provenance: records bundle name" "acq-builtin" "$(acq_provenance_field sbx pbox bundle)"
+(
+  PATTERNS_KIT_REF="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  assert_eq "provenance: pin bump -> stale" "stale" "$(acq_provenance_status sbx pbox)"
+)
+cleanup_stubs
+
+# 9p2. Backend keying: same name under sbx vs msb does not collide.
+make_stubs; load_acq
+acq_provenance_write sbx dup
+assert_eq "provenance: sbx write doesn't affect msb" "unknown" "$(acq_provenance_status msb dup)"
+acq_provenance_write msb dup
+assert_eq "provenance: msb now current" "current" "$(acq_provenance_status msb dup)"
+assert_eq "provenance: sbx still current" "current" "$(acq_provenance_status sbx dup)"
+cleanup_stubs
+
+# 9p3. Sandbox name with path metacharacters is sanitized to a safe filename
+#      (no directory traversal in the state dir).
+make_stubs; load_acq
+acq_provenance_write sbx "evil/../../name"
+_travel=$(find "$ACQ_PROVENANCE_DIR" -name '*.env' 2>/dev/null | head -n1)
+# Slashes are collapsed to underscores (no path escape); the record file lives
+# directly under the sbx dir, not in a traversed parent.
+assert_contains "provenance: name sanitized (no slash escape)" "$_travel" "evil_.._.._name"
+assert_contains "provenance: record stays under sbx dir" "$_travel" "/sbx/"
+cleanup_stubs
+
+# 9p3b. Two distinct names that sanitize to the same string do NOT alias onto one
+#       record (cksum suffix disambiguates "a/b" vs "a_b").
+make_stubs; load_acq
+acq_provenance_write sbx "a/b"          # -> current
+# "a_b" has no record of its own; it must read as unknown, not inherit "a/b".
+assert_eq "provenance: sanitizer collision disambiguated" "unknown" "$(acq_provenance_status sbx "a_b")"
+cleanup_stubs
+
+# 9p4. `acq kit check` reports status without mutating the record (read-only).
+make_stubs; load_acq
+printf 'cbox\n' > "$STUBDIR/.sandbox_list"   # sandbox exists
+acq_provenance_write sbx cbox           # seed a current record
+out=$(ACQ_BACKEND=sbx "$ACQ" kit check cbox 2>&1); rc=$?
+assert_eq "kit check: exits 0" "0" "$rc"
+assert_contains "kit check: reports current" "$out" "current"
+assert_contains "kit check: shows applied ref" "$out" "$_pin"
+# Read-only: still current, and CALLS shows no sbx kit add.
+log=$(cat "$CALLS")
+assert_not_contains "kit check: does not add kits" "$log" "sbx kit add"
+cleanup_stubs
+
+# 9p5. `acq kit check` on a legacy sandbox (no record) reports unknown + hint.
+make_stubs; load_acq
+printf 'legacybox\n' > "$STUBDIR/.sandbox_list"   # sandbox exists to sbx
+out=$(ACQ_BACKEND=sbx "$ACQ" kit check legacybox 2>&1)
+assert_contains "kit check: unknown status" "$out" "unknown"
+assert_contains "kit check: suggests update" "$out" "acq kit update legacybox"
+cleanup_stubs
+
+# 9p6. `acq kit check` with no sandbox arg errors.
+make_stubs; load_acq
+out=$(ACQ_BACKEND=sbx "$ACQ" kit check 2>&1); rc=$?
+assert_eq "kit check: missing arg exits 1" "1" "$rc"
+assert_contains "kit check: usage on missing arg" "$out" "usage: acq kit check"
+cleanup_stubs
+
+# Helper: seed a STALE provenance record for a sandbox via the real helper path
+# (so the cksum-suffixed filename matches what acq will look up), then rewrite the
+# applied_ref to an older value in place.
+_seed_stale_provenance() {
+  local backend="$1" name="$2" f
+  acq_provenance_write "$backend" "$name"
+  f=$(_acq_provenance_file "$backend" "$name")
+  # Replace the current applied_ref line with an obviously-old ref.
+  awk '/^applied_ref=/ { print "applied_ref=oldoldoldoldoldoldoldoldoldoldoldoldoldo"; next } { print }' "$f" > "$f.seed" && mv -f "$f.seed" "$f"
+}
+
+# 9p7. `acq kit update SANDBOX --yes` reapplies the bundle and refreshes
+#      provenance (stale -> current) on the sbx backend.
+make_stubs; load_acq
+printf 'ubox\n' > "$STUBDIR/.sandbox_list"        # sandbox exists
+_seed_stale_provenance sbx ubox
+assert_eq "kit update: precondition stale" "stale" "$(acq_provenance_status sbx ubox)"
+out=$(ACQ_BACKEND=sbx "$ACQ" kit update ubox --yes 2>&1); rc=$?
+assert_eq "kit update --yes: exits 0" "0" "$rc"
+assert_eq "kit update --yes: now current" "current" "$(acq_provenance_status sbx ubox)"
+cleanup_stubs
+
+# 9p8. `acq kit update` already-current is a no-op success (no reapply).
+make_stubs; load_acq
+printf 'okbox\n' > "$STUBDIR/.sandbox_list"
+acq_provenance_write sbx okbox          # current
+out=$(ACQ_BACKEND=sbx "$ACQ" kit update okbox --yes 2>&1); rc=$?
+assert_eq "kit update: current is no-op exit 0" "0" "$rc"
+assert_contains "kit update: says already current" "$out" "already on the pinned bundle"
+cleanup_stubs
+
+# 9p9. `acq kit update` non-interactively WITHOUT --yes refuses (safety).
+make_stubs; load_acq
+printf 'nbox\n' > "$STUBDIR/.sandbox_list"
+_seed_stale_provenance sbx nbox
+out=$(ACQ_BACKEND=sbx "$ACQ" kit update nbox </dev/null 2>&1); rc=$?
+assert_eq "kit update: no --yes non-interactive exits 1" "1" "$rc"
+assert_contains "kit update: refuses without --yes" "$out" "without --yes"
+cleanup_stubs
+
+# 9p10. `acq kit update` on a missing sandbox errors clearly.
+make_stubs; load_acq
+: > "$STUBDIR/.sandbox_list"             # no sandboxes
+out=$(ACQ_BACKEND=sbx "$ACQ" kit update ghost --yes 2>&1); rc=$?
+assert_eq "kit update: missing sandbox exits 1" "1" "$rc"
+assert_contains "kit update: no such sandbox" "$out" "no such sandbox"
+cleanup_stubs
+
+# 9p11. maybe_offer_bundle_refresh is silent + non-blocking when current.
+make_stubs; load_acq
+acq_provenance_write sbx runbox
+out=$(maybe_offer_bundle_refresh sbx runbox </dev/null 2>&1); rc=$?
+assert_eq "run-check: current returns 0" "0" "$rc"
+assert_eq "run-check: current is silent" "" "$out"
+cleanup_stubs
+
+# 9p12. maybe_offer_bundle_refresh non-interactive on a stale sandbox advises
+#       but NEVER blocks (returns 0, no prompt).
+make_stubs; load_acq
+_seed_stale_provenance sbx stalebox
+out=$(maybe_offer_bundle_refresh sbx stalebox </dev/null 2>&1); rc=$?
+assert_eq "run-check: stale non-interactive returns 0" "0" "$rc"
+assert_contains "run-check: advises kit update" "$out" "acq kit update stalebox"
+assert_contains "run-check: mentions opt-out" "$out" "ACQ_UPDATE_CHECK=0"
+cleanup_stubs
+
+# 9p12b. A pre-heal status arg of "stale" makes the helper offer even though the
+#        on-disk record now reads current (models the real acq run ordering:
+#        heal writes current, but we captured stale beforehand). Non-interactive
+#        so it advises + returns 0.
+make_stubs; load_acq
+acq_provenance_write sbx orderbox     # on-disk = current
+out=$(maybe_offer_bundle_refresh sbx orderbox stale </dev/null 2>&1); rc=$?
+assert_eq "run-check: pre-heal-stale arg returns 0" "0" "$rc"
+assert_contains "run-check: pre-heal-stale arg still advises" "$out" "acq kit update orderbox"
+cleanup_stubs
+
+# 9p13. ACQ_UPDATE_CHECK=0 fully silences the run-check even when stale.
+make_stubs; load_acq
+_seed_stale_provenance sbx optout
+out=$( ACQ_UPDATE_CHECK=0; maybe_offer_bundle_refresh sbx optout </dev/null 2>&1 )
+assert_eq "run-check: opt-out silences advisory" "" "$out"
+cleanup_stubs
+
+# 9p13b. A failed built-in kit apply must NOT write provenance (no false
+#        "current"). Force every `sbx kit add` to fail and confirm status stays
+#        unknown after a heal.
+make_stubs; load_acq
+# Make the sbx stub report kits ABSENT (so the add path runs) but fail `kit add`.
+cat >"$STUBDIR/sbx" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'sbx'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >>"$CALLS"
+case "${1:-}" in
+  kit) [ "${2:-}" = "add" ] && exit 1 || exit 0 ;;
+  exec)
+    # Feature-probe wrapper prints "absent" so ensure_kits_applied tries kit add.
+    snippet=""; prev=""
+    for a in "$@"; do [ "$prev" = "-c" ] && { snippet="$a"; break; }; prev="$a"; done
+    case "$snippet" in *present*) printf 'absent\n' ;; *) exit 0 ;; esac ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$STUBDIR/sbx"
+printf 'failbox\n' > "$STUBDIR/.sandbox_list"
+acq_backend_ensure_kits_applied failbox >/dev/null 2>&1 || true
+assert_eq "heal(sbx): failed apply leaves status unknown" "unknown" "$(acq_provenance_status sbx failbox)"
+cleanup_stubs
+
+# 9p14. Provision records provenance on the sbx backend (write-after-success).
+make_stubs; load_acq
+: > "$CALLS"
+acq_backend_provision provbox shell /tmp >/dev/null 2>&1 || true
+assert_eq "provision(sbx): records provenance" "current" "$(acq_provenance_status sbx provbox)"
+cleanup_stubs
+
+# 9p15. ensure_kits_applied (heal) records provenance on the sbx backend.
+make_stubs; load_acq
+printf 'healbox\n' > "$STUBDIR/.sandbox_list"
+acq_backend_ensure_kits_applied healbox >/dev/null 2>&1 || true
+assert_eq "heal(sbx): records provenance" "current" "$(acq_provenance_status sbx healbox)"
 cleanup_stubs
 
 # ===========================================================================

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1984,7 +1984,7 @@ cleanup_stubs
 # 9p13. ACQ_UPDATE_CHECK=0 fully silences the run-check even when stale.
 make_stubs; load_acq
 _seed_stale_provenance sbx optout
-out=$( ACQ_UPDATE_CHECK=0; maybe_offer_bundle_refresh sbx optout </dev/null 2>&1 )
+out=$( ACQ_UPDATE_CHECK=0 maybe_offer_bundle_refresh sbx optout </dev/null 2>&1 )
 assert_eq "run-check: opt-out silences advisory" "" "$out"
 cleanup_stubs
 


### PR DESCRIPTION
## Summary

Implements quickstart#236 (PR2 of epic #235): `acq` records **host-side kit-bundle provenance** for each sandbox and uses it to detect drift against the locally pinned `PATTERNS_KIT_REF`, offering a **safe in-place refresh**. Pins the patterns kit ref to `5c55bcf` (bundle provenance schema, patterns#273 — merged).

## What it does

- **Provenance (host-side):** after a **successful** bundle apply, records `bundle / repo / applied_ref / backend / applied_at` under `${XDG_STATE_HOME:-~/.local/state}/acq/provenance/<backend>/<name>` (override `ACQ_PROVENANCE_DIR`). Atomic write; sandbox name sanitized + cksum-suffixed (no traversal, no aliasing).
- **Staleness:** `current | stale | unknown` by **exact-ref mismatch** vs the local pin — no git ancestry, no network, offline-safe. The local checkout is the source of truth. Fail-open.
- **`acq run` (existing sandbox):** offers a refresh when stale/unknown. Interactive, **default No**, EOF declines, and **non-interactive never blocks** a launch. Staleness is captured **before** the heal (which rewrites provenance), so the offer isn't dead.
- **Opt-out:** `ACQ_UPDATE_CHECK=0` or `acq run --no-update-check` (stripped before the backend, only before `--`).
- **Explicit commands:** `acq kit check SANDBOX` (read-only) and `acq kit update SANDBOX [--yes]` (in-place reapply; `--yes` only here; non-interactive without `--yes` refuses; already-current is a no-op).
- **Reconcile:** reuses each backend's heal path with `ACQ_FORCE_KIT_REAPPLY=1` — sbx re-adds all built-in kits (incl. git-ssh-sign); msb re-applies idempotently. State (sessions, secrets, unrelated config, project files) preserved; never deletes/recreates. Both backends now **return non-zero** from `ensure_kits_applied` on any built-in-kit failure, so provenance is never written after a failed apply.

## Review done before opening

Ran adversarial security + accuracy/vestigial subagent reviews and fixed everything they surfaced:
- BLOCKER: heal wrote provenance even when kit apply failed → now gated on success (both backends). Test `heal(sbx): failed apply leaves status unknown`.
- The `acq run` auto-offer was dead (heal rewrote provenance to current before the offer) → now captures pre-heal status. Test `run-check: pre-heal-stale arg still advises`.
- `--no-update-check` was stripped from agent args after `--` → now only before `--`.
- Sanitizer aliased distinct names to one record → cksum suffix. Test `provenance: sanitizer collision disambiguated`.
- sbx heal skipped present-but-stale kits → force-reapply covers the whole bundle; **live sbx duplicate-`kit add` behavior tracked in #240**.
- Corrected an inaccurate "sbx reconciles a stale bundle" comment and the "older than" wording.

## Verification

- `bash -n` on all four shell files: clean.
- `shellcheck -S warning acq acq.backends/*.sh`: clean.
- `scripts/test-acq`: **346 pass**, +38 new provenance/check/update cases. The 5 `msb …` failures are the pre-existing local real-`sbx`-on-PATH flake (#217) — they fail on `main` too and are unrelated.
- `npm run lint:md`: 0 errors.

## Docs

- New ADR-0016 (numbered 16 to avoid colliding with mogul's unmerged 0014/0015 on `feat/msb-parity`).
- QUICKSTART + BACKEND_GUIDE updated.

## Security impact

No secrets read/written (record holds only a SHA + names + timestamp). SHA pinning preserved (full 40-char ref, never mutable `main`). Backend abstraction preserved (all provenance logic in `common.sh`).

## Rollback

Revert the commit; provenance records are inert data.

AI-assisted (OpenCode); requires human review. Part of #235; unblocks #240 (live sbx validation) and #237 (deferred remote check).