### PR TITLE
ci: use system shellcheck binary to fix cold-run fetch hang (#242)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -31,10 +31,14 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-      # Cache the pre-commit hook environments (incl. the shellcheck-py binary
-      # that is otherwise re-fetched every run). Keyed on the config so a pin
-      # bump busts the cache. This removes the per-run binary download that was
-      # hanging and killing the shellcheck step with SIGTERM (exit 143). See #242.
+      # The shellcheck hook uses the SYSTEM shellcheck binary (preinstalled on
+      # ubuntu runners) to avoid the shellcheck-py cold-run binary fetch that was
+      # hanging and SIGTERM-killing the job (#242). Fail loudly if a future runner
+      # image ever drops it, rather than silently skipping the lint.
+      - name: Verify shellcheck is available
+        run: shellcheck --version
+      # Cache the remaining pre-commit hook environments (node for markdownlint,
+      # etc.), keyed on the config so a pin bump busts the cache.
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -31,14 +31,11 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-      # The shellcheck hook uses the SYSTEM shellcheck binary (preinstalled on
-      # ubuntu runners) to avoid the shellcheck-py cold-run binary fetch that was
-      # hanging and SIGTERM-killing the job (#242). Fail loudly if a future runner
-      # image ever drops it, rather than silently skipping the lint.
+      # We double-check that shellcheck is here since the shellcheck hook needs it.
       - name: Verify shellcheck is available
         run: shellcheck --version
-      # Cache the remaining pre-commit hook environments (node for markdownlint,
-      # etc.), keyed on the config so a pin bump busts the cache.
+      # Cache the pre-commit hook environments (node for markdownlint, etc.),
+      # keyed on the config so a pin bump busts the cache.
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
         with:
           path: ~/.cache/pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,13 +37,8 @@ repos:
       - id: markdownlint-cli2
         args: ["--fix"]
 
-  # Shell script linting. Uses the SYSTEM `shellcheck` binary (preinstalled on
-  # GitHub's ubuntu runners; `brew install shellcheck` / `apt install shellcheck`
-  # locally) rather than the shellcheck-py hook. shellcheck-py fetches a
-  # shellcheck binary from GitHub releases on a cold run; that fetch has been
-  # hanging and getting SIGTERM-killed in CI (#242). The system binary removes
-  # that network dependency entirely. Enforcement (severity=warning over the
-  # same shell files) is unchanged.
+  # Shell script linting via the system shellcheck binary
+  # (`brew install shellcheck` / `apt install shellcheck`; preinstalled on CI).
   - repo: local
     hooks:
       - id: shellcheck
@@ -51,9 +46,6 @@ repos:
         entry: shellcheck --severity=warning
         language: system
         types: [shell]
-        # Skip if shellcheck is not installed locally (CI always has it); a
-        # missing local binary should not block a commit of non-shell files.
-        require_serial: false
 
   # acq offline unit suite — runs the host-side logic (backend resolution, name
   # derivation, kit-translate, git-identity/path pre-flight) on every push. This

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,23 @@ repos:
       - id: markdownlint-cli2
         args: ["--fix"]
 
-  # Shell script linting (shellcheck-py: native binary, no Docker required)
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: 745eface02aef23e168a8afb6b5737818efbea95  # v0.11.0.1
+  # Shell script linting. Uses the SYSTEM `shellcheck` binary (preinstalled on
+  # GitHub's ubuntu runners; `brew install shellcheck` / `apt install shellcheck`
+  # locally) rather than the shellcheck-py hook. shellcheck-py fetches a
+  # shellcheck binary from GitHub releases on a cold run; that fetch has been
+  # hanging and getting SIGTERM-killed in CI (#242). The system binary removes
+  # that network dependency entirely. Enforcement (severity=warning over the
+  # same shell files) is unchanged.
+  - repo: local
     hooks:
       - id: shellcheck
-        args: ["--severity=warning"]
+        name: shellcheck (system binary)
+        entry: shellcheck --severity=warning
+        language: system
+        types: [shell]
+        # Skip if shellcheck is not installed locally (CI always has it); a
+        # missing local binary should not block a commit of non-shell files.
+        require_serial: false
 
   # acq offline unit suite — runs the host-side logic (backend resolution, name
   # derivation, kit-translate, git-identity/path pre-flight) on every push. This


### PR DESCRIPTION
## Summary

Follow-up to #243. The env cache alone did not fix #242. Confirmed root cause: the `shellcheck-py` pre-commit hook fetches the **shellcheck binary** from GitHub releases on a **cold run** into its venv, and that fetch is what hangs — the `~/.cache/pre-commit` venv cache does not prevent it, and a new branch's cold cache key re-triggers the fetch, so the hook stalls ~4 min and is SIGTERM-killed (exit 143). (Seen again on #241 after rebasing onto the #243 cache fix.)

## Change

- `.pre-commit-config.yaml`: replace the `shellcheck-py` hook with a `local` hook that runs the **system** `shellcheck` binary (preinstalled on GitHub's ubuntu runners; `brew`/`apt` locally). Same enforcement: `--severity=warning`, `types: [shell]` (covers shebang-detected `acq`/`qsbx`, `*.sh`, `scripts/test-acq`).
- `.github/workflows/pre-commit.yml`: add a `shellcheck --version` step that fails loudly if a future runner image ever drops shellcheck (no silent skip). Keep the `~/.cache/pre-commit` cache from #243 (still speeds the node/markdownlint envs).

## Why this is safe

- Removes the flaky GitHub-releases binary fetch entirely — deterministic.
- Enforcement is identical (same severity, same file set).
- Local run: `pre-commit run shellcheck --all-files` passes via the system binary and resolves all shell files, including the extension-less `acq`/`qsbx`.
- No hook that still needs a network install is affected; markdownlint etc. keep their pinned repos + the cache.

Fixes #242. Unblocks #241 and mogul's `feat/msb-parity`.

AI-assisted (OpenCode); requires human review.