### PR TITLE
docs(agents): reconcile GitHub credential row with per-sandbox default (#186)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,7 +350,7 @@ The agent MUST:
 | Service | Method | Notes |
 |---------|--------|-------|
 | USAi | Custom secret (`sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY`) | Custom endpoint not supported by SBX proxy |
-| GitHub | SBX proxy (`sbx secret set -g github`) | Recommended; agent never sees token |
+| GitHub | SBX proxy, **per-sandbox scoped** (`acq` fine-grained flow, or `sbx secret set <sandbox> github`) | Recommended default: least-privilege, per-sandbox. Global `sbx secret set -g github` kept for back-compat. Agent never sees the token. See [ADR-0013](docs/adr/0013-per-sandbox-github-token-downscoping.md) |
 | GitLab | Custom secret (`sbx secret set-custom -g --host workshop.cloud.gov --env GITLAB_TOKEN`) | Not a built-in SBX service |
 
 See `docs/QUICKSTART_SBX.md` for detailed credential injection patterns.


### PR DESCRIPTION
## Summary

Closes the last open acceptance item on #186. The `AGENTS.md` network/credential-injection table still listed only the global `sbx secret set -g github` proxy method as "Recommended", which no longer matches the per-sandbox fine-grained default landed in ADR-0013 (#229).

## Change

One table row in `AGENTS.md`: recommend the per-sandbox scoped `acq` flow (or `sbx secret set <sandbox> github`) for least-privilege, keep the global `-g` path as back-compat, and link ADR-0013. Matches the guidance already in `QUICKSTART_SBX.md`.

## Verification

- `npm run lint:md` — 0 errors.
- Docs-only; proxy model (agent never sees the token) unchanged.

Closes #186.

AI-assisted (OpenCode); requires human review.