### PR TITLE
test(acq): make the offline suite host-agnostic so it passes locally on any backend (#217)

### DIFF
--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -862,6 +862,13 @@ make_stubs; load_acq
   unset ACQ_BACKEND 2>/dev/null || true
   export XDG_CONFIG_HOME="$STUBDIR/noconfig"
   rm -f "$STUBDIR/sbx"          # remove sbx so only msb remains
+  # Constrain PATH to the stub dir ONLY (#217): _auto_detect_backend runs
+  # `command -v sbx`, which would otherwise find a REAL sbx on the developer's
+  # base PATH and make this fall back-to-msb assertion flake to "sbx". Provide a
+  # coreutils dir so the sourced scripts still find standard tools.
+  _coreutils_dir=$(dirname "$(command -v env)")
+  PATH="$STUBDIR:$_coreutils_dir"
+  export PATH
   # shellcheck disable=SC1090
   ACQ_SOURCE_ONLY=1 . "$ACQ"
   # shellcheck source=acq.backends/msb.sh

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -995,9 +995,12 @@ assert_not_contains "msb: provision does NOT bind github to github.com (git tran
 assert_not_contains "msb: provision does NOT bind github to codeload" "$prov_log" "GITHUB_TOKEN@codeload"
 assert_eq "msb: provision never leaks secret values to argv" "CLEAN" "$prov_leaks"
 # Workspace is mounted at the SAME absolute path in the guest (sbx-parity), not
-# remapped under /home/agent (which fails to mount pre-user-create).
-assert_contains "msb: workspace mounted at same guest path (sbx-parity)" "$prov_log" "--volume /tmp:/tmp"
-assert_not_contains "msb: workspace NOT remapped under /home/agent" "$prov_log" "--volume /tmp:/home/agent/workspace"
+# remapped under /home/agent (which fails to mount pre-user-create). acq
+# canonicalizes the host path first (macOS /tmp -> /private/tmp symlink), so the
+# assertion must compare against the canonicalized form, not the literal /tmp.
+_prov_ws=$(canonicalize_path /tmp)
+assert_contains "msb: workspace mounted at same guest path (sbx-parity)" "$prov_log" "--volume ${_prov_ws}:${_prov_ws}"
+assert_not_contains "msb: workspace NOT remapped under /home/agent" "$prov_log" "--volume ${_prov_ws}:/home/agent/workspace"
 cleanup_stubs
 
 # 8m1b. Multi-workspace: every workspace positional after the agent is mounted at
@@ -1019,9 +1022,13 @@ mkdir -p "$STUBDIR/ws-app" "$STUBDIR/ws-lib"
   acq_backend_provision mwbox opencode "$STUBDIR/ws-app" "$STUBDIR/ws-lib:ro" >/dev/null 2>&1
 )
 mw_log=$(cat "$CALLS")
-assert_contains "msb: multi-ws mounts primary at its host path" "$mw_log" "--volume ${STUBDIR}/ws-app:${STUBDIR}/ws-app"
-assert_contains "msb: multi-ws mounts extra ro at its host path" "$mw_log" "--volume ${STUBDIR}/ws-lib:${STUBDIR}/ws-lib:ro"
-assert_contains "msb: multi-ws start dir is the FIRST (primary) workspace" "$mw_log" "'${STUBDIR}/ws-app' > /var/lib/acq/workspace"
+# acq canonicalizes host workspace paths before mounting (macOS $TMPDIR is a
+# /var -> /private/var symlink), so compare against the resolved real paths.
+_ws_app=$(canonicalize_path "$STUBDIR/ws-app")
+_ws_lib=$(canonicalize_path "$STUBDIR/ws-lib")
+assert_contains "msb: multi-ws mounts primary at its host path" "$mw_log" "--volume ${_ws_app}:${_ws_app}"
+assert_contains "msb: multi-ws mounts extra ro at its host path" "$mw_log" "--volume ${_ws_lib}:${_ws_lib}:ro"
+assert_contains "msb: multi-ws start dir is the FIRST (primary) workspace" "$mw_log" "'${_ws_app}' > /var/lib/acq/workspace"
 assert_not_contains "msb: multi-ws does NOT fall back to /home/agent/workspace" "$mw_log" "'/home/agent/workspace' > /var/lib/acq/workspace"
 
 # Single workspace records that mount as the start dir.
@@ -1034,7 +1041,7 @@ assert_not_contains "msb: multi-ws does NOT fall back to /home/agent/workspace" 
   acq_backend_provision swbox opencode "$STUBDIR/ws-app" >/dev/null 2>&1
 )
 sw_log=$(cat "$CALLS")
-assert_contains "msb: single-ws records that mount as start dir" "$sw_log" "'${STUBDIR}/ws-app' > /var/lib/acq/workspace"
+assert_contains "msb: single-ws records that mount as start dir" "$sw_log" "'${_ws_app}' > /var/lib/acq/workspace"
 cleanup_stubs
 
 # 8m1c. Symlinked host workspace is canonicalized before mounting. msb cannot


### PR DESCRIPTION
## Summary

Fixes the local-only failures in `scripts/test-acq` that forced contributors (and the agent) to `SKIP=test-acq` when committing. Root cause: two **test-hermeticity** bugs — the suite implicitly assumed a Linux host with no real backend installed. Neither is an `acq` defect. With both fixed, the full offline suite passes locally on any host/backend combination (sbx-only, msb-only, neither, both).

## Fixes

1. **A real `sbx` on PATH leaked in** (`185dbba`). The `msb: auto-detect falls back to msb` test removed the stub sbx and asserted `_auto_detect_backend` returns `msb`, but `command -v sbx` found a system sbx and returned `sbx`. Constrain that subshell's PATH to the stub dir + coreutils.

2. **macOS symlinked paths** (`720922c`). Five msb-provision assertions compared recorded `--volume` mounts / start dir against **literal** host paths (`/tmp`, `$STUBDIR/...`). acq canonicalizes host workspace paths before mounting (msb can't mount a symlink), and on macOS `/tmp → /private/tmp` and `$TMPDIR` is under `/var → /private/var`. Compare against `canonicalize_path` (the same helper acq uses) instead.

## Verification

- `bash scripts/test-acq` → **351 passed, 0 failed** locally on macOS with a real `sbx` present (previously 6 failed).
- `shellcheck --severity=warning scripts/test-acq` — clean.
- CI (Linux) was already green; this makes local runs green too, so `SKIP=test-acq` is no longer needed for correctness.

## Scope

Test-only. No change to `acq` or any backend adapter. Resolves the #217 PATH-robustness complaint and the macOS provision-path failures.

Closes #217.

AI-assisted (OpenCode); requires human review.