### PR TITLE
docs(adr): drop non-standard "Rollback" section from ADR-0016 (#250)

### DIFF
--- a/docs/adr/0016-kit-bundle-provenance-and-stale-refresh.md
+++ b/docs/adr/0016-kit-bundle-provenance-and-stale-refresh.md
@@ -118,6 +118,10 @@ in-place refresh.
 
 - The record format is a dependency-free flat `key=value` file, matching the
   awk-parsed acq config convention (no YAML/JSON parser added to the shell path).
+- The provenance records under `~/.local/state/acq/provenance` are inert data:
+  they can be deleted with no effect on a sandbox — acq simply re-offers a
+  refresh next run (safe and idempotent). The feature carries no state migration,
+  so it can be reverted with no sandbox-state impact.
 
 ## Alternatives Considered
 
@@ -141,12 +145,6 @@ in-place refresh.
   refresh fetches exactly that ref, never mutable `main`.
 - The backend abstraction is preserved: the shared logic lives in `common.sh`;
   each adapter only calls `acq_provenance_write` after its own successful apply.
-
-## Rollback
-
-Revert the commits on the feature branch. The provenance records under
-`~/.local/state/acq/provenance` are inert data; they can be left in place or
-removed with no effect on sandboxes. No sandbox state is touched by a rollback.
 
 ## References
 


### PR DESCRIPTION
## Summary

Closes #250. Per your review comment ("Can we just... Delete it? Is it even meaningfully useful?") and a 3/3 consensus vote (architect / security / scope-steward, 100% approve), removes the non-standard `## Rollback` section from ADR-0016.

## Why

"Rollback" isn't a MADR heading and read as unmoored from the decision. It conflated two things:
- "revert the commits" — trivially true of every PR, not decision-specific.
- "provenance records are inert / safe to delete" — a real operator fact that already belongs in **Consequences**.

## Change

- Delete the standalone `## Rollback` section.
- Append the one operator-facing nuance to the existing **Consequences → Neutral** bullet: the records under `~/.local/state/acq/provenance` are inert and deletable (acq re-offers a refresh; safe/idempotent), and the feature reverts with no sandbox-state impact.
- Kept the explicit path so an operator grepping the ADR still finds it (per the security voter's note).

Docs-only; no behavior change. `npm run lint:md` clean.

AI-assisted (OpenCode); consensus-reviewed. Requires human review.