### PR TITLE
fix(acq): enumerate keychain-linux secrets in acq secret ls

### DIFF
--- a/acq.backends/secret-store.sh
+++ b/acq.backends/secret-store.sh
@@ -163,6 +163,10 @@ acq_secret_store() {
         acq_key "$key" >/dev/null 2>&1 || {
           echo "acq: secret store: keychain write failed for '$key'." >&2; value=""; return 1; }
       value=""
+      # Record the key in the enumeration index so `acq secret ls` can list it:
+      # secret-tool cannot enumerate items by attribute name alone (see the
+      # ACQ_SECRET_INDEX_FILE note), so the keychain store is otherwise opaque.
+      _acq_secret_index_add "$key"
       return 0
       ;;
     file)
@@ -242,6 +246,56 @@ if [ -n "${ACQ_SECRET_STORE_DIR:-}" ]; then
   # Offline-test escape hatch: keep metadata beside the forced file store.
   ACQ_SECRET_META_DIR="${ACQ_SECRET_STORE_DIR%/}/meta"
 fi
+
+# Enumerable KEY INDEX (keychain-linux only) — a NON-SECRET plain file listing
+# one stored `acq.*` key per line. The Linux keychain (libsecret via
+# secret-tool) can look a value up BY attribute value but cannot list every item
+# by attribute NAME, so a keychain-linux store has no way to answer "what keys do
+# I hold?" without knowing the keys in advance. We record each stored key here so
+# `acq secret ls` can enumerate the keychain store the same way the file backend
+# enumerates its directory. Like the endpoint sidecar, this holds KEYS ONLY (no
+# secret values, no hosts) and is a plain 0600 file, not the keychain. The file
+# and macOS backends do NOT use this index — their file directory is already the
+# authoritative on-disk listing — so it is maintained only on keychain-linux to
+# avoid changing macOS/file behavior.
+ACQ_SECRET_INDEX_FILE="${ACQ_SECRET_INDEX_FILE:-${ACQ_SECRET_FILE_DIR%/secrets}/secret-index}"
+if [ -n "${ACQ_SECRET_STORE_DIR:-}" ]; then
+  # Offline-test escape hatch: keep the index beside the forced file store.
+  ACQ_SECRET_INDEX_FILE="${ACQ_SECRET_STORE_DIR%/}/index"
+fi
+
+# _acq_secret_index_add KEY — record KEY in the keychain-linux enumeration index
+# (deduplicated, 0600). Non-secret (a key name only). Best-effort: a failure to
+# update the index never fails the store — it only degrades later enumeration.
+_acq_secret_index_add() {
+  local key="$1" dir line
+  dir=$(dirname "$ACQ_SECRET_INDEX_FILE")
+  ( umask 077; mkdir -p "$dir" ) || return 0
+  # Already present? Nothing to do (keeps the file deduplicated).
+  if [ -f "$ACQ_SECRET_INDEX_FILE" ]; then
+    while IFS= read -r line; do
+      [ "$line" = "$key" ] && return 0
+    done < "$ACQ_SECRET_INDEX_FILE"
+  fi
+  ( umask 077; printf '%s\n' "$key" >> "$ACQ_SECRET_INDEX_FILE" ) || true
+  return 0
+}
+
+# _acq_secret_index_remove KEY — drop KEY from the keychain-linux enumeration
+# index (idempotent). Best-effort: never fails delete.
+_acq_secret_index_remove() {
+  local key="$1" tmp
+  [ -f "$ACQ_SECRET_INDEX_FILE" ] || return 0
+  tmp="${ACQ_SECRET_INDEX_FILE}.tmp.$$"
+  ( umask 077
+    while IFS= read -r line; do
+      [ "$line" = "$key" ] && continue
+      printf '%s\n' "$line"
+    done < "$ACQ_SECRET_INDEX_FILE" > "$tmp"
+  ) || { rm -f "$tmp" 2>/dev/null; return 0; }
+  mv -f "$tmp" "$ACQ_SECRET_INDEX_FILE" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  return 0
+}
 
 _acq_secret_meta_file_for() {
   local key="$1"
@@ -380,14 +434,40 @@ acq_secret_meta_list() {
 # `acq secret ls` to enumerate what the store holds. Scope/service is decoded by
 # the caller (see _acq_secret_decode_key). Order is unspecified; deduplicated.
 #
-# The file backend (and the macOS file fallback) is the authoritative on-disk
-# listing: even on a keychain host, acq_secret_store writes values to the 0600
-# file fallback by default (to keep values off argv — see acq_secret_store), so
-# the file dir reflects the acq-managed values. A pure keychain-only store (only
-# reachable with ACQ_SECRET_ALLOW_ARGV=1 at write time) is NOT enumerable via a
-# per-item API without a broad keychain dump, so those are reported best-effort:
-# a value that resolves is confirmed by acq_secret_resolve at display time.
+# Enumeration is BACKEND-AWARE, because the two store shapes are enumerated
+# differently:
+#
+#   file / keychain-macos: the file directory IS the authoritative listing. On
+#     macOS the default write path is the 0600 file fallback (keeping values off
+#     argv — see acq_secret_store), so acq-managed values live in the file dir on
+#     both backends. We glob the directory for `acq.*` filenames exactly as
+#     before. On macOS with ACQ_SECRET_ALLOW_ARGV=1, a keychain-only write lands
+#     in the keychain instead of the file dir, so it is NOT enumerated by `ls`
+#     (the glob only sees the file dir). Such an entry still resolves normally at
+#     provision time — it just does not appear in the `ls` listing.
+#
+#   keychain-linux: the secret VALUES live in the Linux keychain, NOT in the file
+#     dir — so the file glob above would find nothing. libsecret (secret-tool)
+#     can look a value up by attribute value but cannot list every item by
+#     attribute name, so the keychain cannot answer "what keys do I hold?" on its
+#     own. We therefore enumerate from an acq-maintained NON-SECRET key index
+#     (ACQ_SECRET_INDEX_FILE, written by acq_secret_store / acq_secret_delete),
+#     UNIONED with keys reconstructed from the endpoint sidecar (belt and
+#     suspenders, in case the index lags), and VERIFY each candidate still
+#     resolves via acq_secret_get before emitting it — so a stale index entry for
+#     a deleted secret never shows. This is best-effort and never fails `ls`.
 acq_secret_list_keys() {
+  local backend
+  backend=$(_acq_secret_backend)
+  case "$backend" in
+    keychain-linux) _acq_secret_list_keys_keychain_linux ;;
+    *)              _acq_secret_list_keys_file ;;
+  esac
+}
+
+# File-backend enumeration: glob the value directory for `acq.*` filenames. Used
+# by the file and macOS backends (see acq_secret_list_keys).
+_acq_secret_list_keys_file() {
   local f base seen=" "
   [ -d "$ACQ_SECRET_FILE_DIR" ] || return 0
   for f in "$ACQ_SECRET_FILE_DIR"/*; do
@@ -398,6 +478,48 @@ acq_secret_list_keys() {
     seen="$seen$base "
     printf '%s\n' "$base"
   done
+}
+
+# keychain-linux enumeration: union the acq-maintained key index with keys
+# reconstructed from the endpoint sidecar, verify each still resolves, emit
+# deduplicated `acq.*` keys. See acq_secret_list_keys for the rationale.
+_acq_secret_list_keys_keychain_linux() {
+  local key seen=" " svc
+  # The resolve-check below is inlined at each emit site rather than factored into
+  # a nested helper: a nested function plus `unset -f` would clobber a caller's
+  # same-named function if one existed. Each site: skip non-`acq.*`, skip already
+  # seen, verify the value still resolves (acq_secret_get output discarded — only
+  # its exit status is used; a stale index entry or sidecar-without-value is thus
+  # dropped), then record and emit the raw key.
+
+  # (a) The key index — the primary, self-maintained source of stored keys.
+  if [ -f "$ACQ_SECRET_INDEX_FILE" ]; then
+    while IFS= read -r key; do
+      [ -n "$key" ] || continue
+      case "$key" in acq.*) ;; *) continue ;; esac
+      case "$seen" in *" $key "*) continue ;; esac
+      acq_secret_get "$key" >/dev/null 2>&1 || continue
+      seen="$seen$key "
+      printf '%s\n' "$key"
+    done < "$ACQ_SECRET_INDEX_FILE"
+  fi
+
+  # (b) Belt and suspenders: reconstruct `acq.*` keys from any endpoint sidecars
+  # the index somehow lacks (self-healing if the index file is missing/stale).
+  # Sidecar files are named after the store key (see _acq_secret_meta_file_for),
+  # so the filename IS the `acq.*` key. Only real (resolving) values are emitted,
+  # so a sidecar without a matching value is silently skipped.
+  if [ -d "$ACQ_SECRET_META_DIR" ]; then
+    for svc in "$ACQ_SECRET_META_DIR"/*; do
+      [ -f "$svc" ] || continue
+      key=$(basename "$svc")
+      case "$key" in acq.*) ;; *) continue ;; esac
+      case "$seen" in *" $key "*) continue ;; esac
+      acq_secret_get "$key" >/dev/null 2>&1 || continue
+      seen="$seen$key "
+      printf '%s\n' "$key"
+    done
+  fi
 }
 
 # _acq_secret_decode_key KEY -> "SCOPE<TAB>SERVICE" where SCOPE is "-g" (global)
@@ -455,6 +577,7 @@ acq_secret_delete() {
       # secret-tool clear removes all items matching the attribute; a no-match is
       # not an error for our idempotent contract.
       secret-tool clear acq_key "$key" >/dev/null 2>&1 || true
+      _acq_secret_index_remove "$key"
       _acq_secret_delete_file "$key" || rc=$?
       ;;
     file)

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1375,6 +1375,175 @@ assert_contains "secret ls(msb): empty store still prints header" "$empty_ls" "S
 assert_eq "secret ls(msb): empty store exits 0" "0" "$empty_rc"
 cleanup_stubs
 
+# 8m0h. acq_secret_list_keys on a keychain-linux backend. The bug: list_keys
+#       enumerated ONLY the file directory, but on keychain-linux the values live
+#       in the Linux keychain (via secret-tool), never the file dir — so `ls`
+#       showed no rows. The fix makes list_keys backend-aware and enumerates the
+#       keychain store via an acq-maintained NON-SECRET key index.
+#
+#       We simulate keychain-linux fully offline with a `secret-tool` STUB that
+#       stores attr/value to a stub dir and looks them up, plus overriding
+#       _acq_secret_backend to return keychain-linux (the harness otherwise
+#       forces the file backend via ACQ_SECRET_STORE_DIR — we keep that env for
+#       the index/meta paths, but the value store routes through the stub).
+make_stubs; load_acq
+# Stub secret-tool: store attr+value under a per-key file (value contents are
+# opaque to enumeration — the fix relies on the acq key index, not on scraping
+# secret-tool), lookup returns the stored value, clear removes it.
+cat >"$STUBDIR/secret-tool" <<'STSTUB'
+#!/usr/bin/env bash
+# Minimal libsecret-like stub. Store keys under $STUBDIR/st-store keyed by the
+# acq_key attribute value. Values are held only to answer lookup — the acq fix
+# does NOT enumerate via this stub, so no wildcard/search enumeration is needed.
+_dir="${STUBDIR}/st-store"
+mkdir -p "$_dir" 2>/dev/null || true
+_keyfile() {
+  # $1 = acq_key value; make it filesystem-safe.
+  printf '%s/%s' "$_dir" "$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_')"
+}
+case "${1:-}" in
+  store)
+    # secret-tool store --label=… acq_key <key>   (value on stdin)
+    _k=""; _prev=""
+    for a in "$@"; do [ "$_prev" = "acq_key" ] && { _k="$a"; break; }; _prev="$a"; done
+    [ -n "$_k" ] || exit 1
+    cat > "$(_keyfile "$_k")"
+    exit 0 ;;
+  lookup)
+    # secret-tool lookup acq_key <key>
+    _k=""; _prev=""
+    for a in "$@"; do [ "$_prev" = "acq_key" ] && { _k="$a"; break; }; _prev="$a"; done
+    _f="$(_keyfile "$_k")"
+    [ -f "$_f" ] || exit 1
+    cat "$_f"; exit 0 ;;
+  clear)
+    _k=""; _prev=""
+    for a in "$@"; do [ "$_prev" = "acq_key" ] && { _k="$a"; break; }; _prev="$a"; done
+    rm -f "$(_keyfile "$_k")" 2>/dev/null || true
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+STSTUB
+chmod +x "$STUBDIR/secret-tool"
+
+kl_out=$(
+  # Keep the harness's throwaway index/meta dirs, but force the keychain-linux
+  # value path: override _acq_secret_backend to return keychain-linux and unset
+  # the file-backend forcing so store/get/delete/list route through the stub.
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/kl-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  # The escape hatch above rooted the index/meta beside the (unused) file store;
+  # override the backend so values go to the secret-tool stub, not a file.
+  unset ACQ_SECRET_FORCE_FILE
+  _acq_secret_backend() { printf 'keychain-linux\n'; }
+  export STUBDIR
+
+  # Store a GLOBAL built-in (usai) and a SANDBOX-SCOPED built-in (github). The
+  # github case is the key regression: a built-in has no endpoint sidecar, so a
+  # meta-only enumeration would miss it — the index must carry it.
+  ACQ_SECRET_TEST_VALUE='KL-USAI-VALUE'   acq_secret_set_interactive usai '' >/dev/null 2>&1
+  ACQ_SECRET_TEST_VALUE='KL-GITHUB-VALUE' acq_secret_set_interactive github klbox >/dev/null 2>&1
+
+  printf 'listing=[%s]\n' "$(acq_secret_list_keys | sort | tr '\n' ' ')"
+
+  # Delete the scoped github secret; it must drop out of the listing (stale-index
+  # verification: even if the index still held it, the value no longer resolves).
+  acq_secret_delete "$(_acq_secret_key github klbox)" >/dev/null 2>&1
+  printf 'after-del=[%s]\n' "$(acq_secret_list_keys | sort | tr '\n' ' ')"
+)
+assert_contains "keychain-linux ls: lists global usai key"        "$kl_out" "acq.usai"
+assert_contains "keychain-linux ls: lists scoped github key (no sidecar — regression)" "$kl_out" "acq.klbox.github"
+# The values must NEVER appear in the listing output.
+assert_not_contains "keychain-linux ls: never prints usai value"   "$kl_out" "KL-USAI-VALUE"
+assert_not_contains "keychain-linux ls: never prints github value" "$kl_out" "KL-GITHUB-VALUE"
+# After delete, the github key is gone but usai remains.
+assert_contains     "keychain-linux ls: deleted github key removed" "$kl_out" "after-del=[acq.usai ]"
+cleanup_stubs
+
+# 8m0i. Regression: the plain FILE backend behavior is unchanged by the
+#       backend-aware split — a stored secret still lists, and an empty store
+#       lists nothing.
+make_stubs; load_acq
+file_ls_out=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/file-ls-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  # ACQ_SECRET_STORE_DIR sets ACQ_SECRET_FORCE_FILE=1 -> backend is 'file'.
+  ACQ_SECRET_TEST_VALUE='FILE-VALUE' acq_secret_set_interactive usai '' >/dev/null 2>&1
+  printf 'listing=[%s]\n' "$(acq_secret_list_keys | sort | tr '\n' ' ')"
+)
+empty_file_ls=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/file-empty-ls"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'listing=[%s]\n' "$(acq_secret_list_keys | tr '\n' ' ')"
+)
+assert_contains     "file ls: stored secret still lists"        "$file_ls_out" "acq.usai"
+assert_not_contains "file ls: never prints the file value"      "$file_ls_out" "FILE-VALUE"
+assert_contains     "file ls: empty store lists nothing"        "$empty_file_ls" "listing=[]"
+cleanup_stubs
+
+# 8m0j. Self-healing sidecar branch (keychain-linux). The (b) fallback in
+#       _acq_secret_list_keys_keychain_linux reconstructs `acq.*` keys from the
+#       endpoint sidecars when the key index is missing/stale. We store a CUSTOM
+#       service (host+env => a meta sidecar is written) AND a built-in (no
+#       sidecar), then DELETE the index file entirely to simulate a lost index,
+#       and assert: the custom service's key STILL lists (reconstructed from its
+#       sidecar), while the built-in — which has no sidecar to heal from — is
+#       correctly NOT listed. This proves the fallback heals only sidecar-backed
+#       keys, and does not fabricate keys with no on-disk evidence.
+make_stubs; load_acq
+# Reuse the same minimal secret-tool stub as 8m0h (store/lookup/clear by attr).
+cat >"$STUBDIR/secret-tool" <<'STSTUB'
+#!/usr/bin/env bash
+_dir="${STUBDIR}/st-store"
+mkdir -p "$_dir" 2>/dev/null || true
+_keyfile() { printf '%s/%s' "$_dir" "$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_')"; }
+case "${1:-}" in
+  store)
+    _k=""; _prev=""
+    for a in "$@"; do [ "$_prev" = "acq_key" ] && { _k="$a"; break; }; _prev="$a"; done
+    [ -n "$_k" ] || exit 1
+    cat > "$(_keyfile "$_k")"; exit 0 ;;
+  lookup)
+    _k=""; _prev=""
+    for a in "$@"; do [ "$_prev" = "acq_key" ] && { _k="$a"; break; }; _prev="$a"; done
+    _f="$(_keyfile "$_k")"; [ -f "$_f" ] || exit 1; cat "$_f"; exit 0 ;;
+  clear)
+    _k=""; _prev=""
+    for a in "$@"; do [ "$_prev" = "acq_key" ] && { _k="$a"; break; }; _prev="$a"; done
+    rm -f "$(_keyfile "$_k")" 2>/dev/null || true; exit 0 ;;
+  *) exit 0 ;;
+esac
+STSTUB
+chmod +x "$STUBDIR/secret-tool"
+
+heal_out=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/heal-secrets"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  unset ACQ_SECRET_FORCE_FILE
+  _acq_secret_backend() { printf 'keychain-linux\n'; }
+  export STUBDIR
+
+  # Custom service: HOST+ENV supplied => acq_secret_meta_store writes a sidecar.
+  ACQ_SECRET_TEST_VALUE='KL-GL-VALUE' \
+    acq_secret_set_interactive gitlab '' workshop.cloud.gov GITLAB_TOKEN >/dev/null 2>&1
+  # Built-in: no host/env => NO sidecar written (only the index carries it).
+  ACQ_SECRET_TEST_VALUE='KL-USAI-VALUE' \
+    acq_secret_set_interactive usai '' >/dev/null 2>&1
+
+  # Simulate a lost/missing index: remove it entirely. Only the sidecar-backed
+  # key can now be reconstructed via the (b) self-healing branch.
+  rm -f "$ACQ_SECRET_INDEX_FILE"
+  [ -f "$ACQ_SECRET_INDEX_FILE" ] && printf 'INDEX-STILL-PRESENT\n'
+
+  printf 'listing=[%s]\n' "$(acq_secret_list_keys | sort | tr '\n' ' ')"
+)
+assert_contains     "keychain-linux self-heal: index removed but sidecar-backed key relisted" "$heal_out" "acq.gitlab"
+assert_not_contains "keychain-linux self-heal: built-in w/o sidecar NOT relisted after index loss" "$heal_out" "acq.usai"
+assert_not_contains "keychain-linux self-heal: index file truly removed"                       "$heal_out" "INDEX-STILL-PRESENT"
+# Values never leak into the listing, even on the heal path.
+assert_not_contains "keychain-linux self-heal: never prints gitlab value" "$heal_out" "KL-GL-VALUE"
+cleanup_stubs
+
 
 #       its own absolute host path (sbx-parity), a trailing :ro is preserved, and
 #       the recorded start dir is the FIRST (primary) workspace regardless of how


### PR DESCRIPTION
> **Stack #261 — PR 1 of 3 (bottom).** Base: `main`. This PR is independent of the two above it.
> 1. **#258 (this)** — `fix/msb-secret-ls-keychain-linux`
> 2. #259 — `feat/msb-script-staging`
> 3. #260 — `feat/msb-startup-durable-restart`

## Summary

Fixes **GSA-TTS/agentic-coding-quickstart#252**: `acq secret ls` showed no rows on a Linux `secret-tool` keychain host.

`acq_secret_list_keys` enumerated only the file-backend directory. On a `keychain-linux` host, secrets are written into `secret-tool` (never the file dir), so `ls` printed only its header even when secrets were stored — inaccurate on an entire platform.

## What changed

- `acq_secret_list_keys` is now **backend-aware** (branches on `_acq_secret_backend`):
  - `file` / `keychain-macos`: unchanged file-dir glob (macOS default writes the 0600 file fallback, so the dir stays authoritative).
  - `keychain-linux`: enumerates via a non-secret **0600 key-index file** maintained on store/delete (libsecret cannot enumerate items by attribute name alone), **unioned** with meta-sidecar-reconstructed keys for self-healing, and each candidate is **verified to still resolve** before listing so stale entries drop.
- `acq_secret_store` / `acq_secret_delete` maintain the index on the `keychain-linux` backend only.
- Doc comment corrected (removed the inaccurate "writes to the 0600 file fallback by default" claim, which was true only on macOS).

## Security

- Index and meta sidecar hold **keys/host/env only — never secret values**. Values never reach the index, logs, or `ls` output.
- Index file/dir created under `umask 077` (0600/0700). No argv exposure. Keys flow to `secret-tool`/paths as single quoted argv (no injection); the pre-existing dotted-name fail-closed invariant is preserved.
- `sbx secret ls` is unaffected (separate pass-through path); no sbx regression.

## Verification transcript

```
$ bash -n acq.backends/secret-store.sh            # SYNTAX OK
$ ./scripts/test-acq                              # passed: 521  failed: 0 (at commit time)
$ npm run lint:md                                 # Summary: 0 error(s)
```
New offline tests (keychain-linux enumeration via a `secret-tool` stub): the sidecar-less `github` regression, no-value-leak, stale-delete drop, self-healing sidecar path, and the file-backend no-regression case.

**Live verification:** N/A — this fix is fully covered by the offline harness; no KVM host required.

## Rollback

Revert this commit; `acq_backend_secret_ls` reverts to file-dir-only enumeration.

## Review

Independent code review performed (verdict: APPROVE-WITH-NITS); all three nits addressed (nested-function `unset -f` clobber removed, macmisleading comment corrected, self-healing-sidecar test added).

---
_AI-assisted (OpenCode); requires human review._
