### PR TITLE
feat(msb): stage kit startup commands as a create-time script

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -226,6 +226,11 @@ ACQ_MSB_SSH_DIR="${ACQ_MSB_SSH_DIR:-${ACQ_STATE_DIR}/ssh}"
 ACQ_MSB_SSH_KEY="${ACQ_MSB_SSH_KEY:-${ACQ_MSB_SSH_DIR}/msb_id_ed25519}"
 ACQ_MSB_SSH_KNOWN_HOSTS="${ACQ_MSB_SSH_KNOWN_HOSTS:-${ACQ_MSB_SSH_DIR}/known_hosts}"
 ACQ_MSB_PORTS_DIR="${ACQ_MSB_PORTS_DIR:-${ACQ_STATE_DIR}/ports}"
+# Create-time startup-script staging state (ADR-0017). The staged host file list
+# is reset per provision; declare it at module scope so cleanup references are
+# always defined even if provision is not the entry point.
+_ACQ_MSB_STARTUP_STAGE_FILES=()
+_ACQ_MSB_STARTUP_STAGED=""
 # SSH user for the serve listener. `msb ssh serve` authorizes a key host-wide;
 # the login user on the loopback listener defaults to root (override if a
 # deployment's msb serve expects a different account).
@@ -358,70 +363,74 @@ _acq_msb_wait_for_exec_ready() {
 # Kit application helpers (msb drives the neutral spec itself)
 # ---------------------------------------------------------------------------
 #
-# DESIGN NOTE — why kit commands still stage via `msb exec`, not `--script`
-# (evaluated against msb 0.6.7's create/run-time script flags).
+# DESIGN NOTE — the staging boundary: create-time `--script-path` for the
+# startup phase, `msb exec` for install and every mid-life apply (ADR-0017).
 # ---------------------------------------------------------------------------
 # msb 0.6.7 offers first-class script registration on `create`/`run`:
 #   --script NAME=BODY        (inline; escape-decoded; shebang from --shell)
 #   --script-raw NAME=BODY    (exact bytes, no shebang)
 #   --script-path NAME:PATH   (body read verbatim from a host file)
 # Registered scripts land executable at /.msb/scripts/<name>, on the guest PATH.
-# The appeal is real: staging a kit command via --script-path passes the body as
-# a FILE (no assembling a shell string from kit-provided content). We evaluated
-# replacing the kit-command-injection path (_acq_msb_run_commands ->
-# _acq_msb_exec_command) with it and DELIBERATELY KEPT the exec-based path. The
-# refactor is not a clean net win as this adapter is currently shaped:
 #
-#   1) TIMING. `--script*` register ONLY at create/run time. But kit commands are
-#      NOT all applied at create: _acq_msb_apply_kit_dir is also driven MID-LIFE
-#      by acq_backend_apply_kit (`acq kit apply NAME KITREF`, acq:293) and by
-#      acq_backend_ensure_kits_applied (the re-attach heal loop, acq:434/461),
-#      long after the sandbox was created. A create-time flag cannot register a
-#      script into an already-running sandbox, so the mid-life path MUST stay
-#      exec-based regardless. Introducing --script only at provision would fork
-#      the code into two dissimilar command-dispatch paths (create=script,
-#      mid-life=exec) — MORE surface, MORE divergence, for the same observable
-#      behavior. A single exec-based path that works in both phases is simpler
-#      and is what the whole apply pipeline is already built around.
+# An earlier revision of this adapter kept ALL kit-command staging on `msb exec`
+# and treated `--script*` as net-negative, on the grounds that kit commands run
+# both at create AND mid-life and that the exec path never interpolates kit
+# bytes into a shell string. Both of those observations are still true — but they
+# do NOT apply to one specific slice, and ADR-0017 carves that slice out:
 #
-#   2) THE STRING WE WOULD AVOID ISN'T BUILT FROM KIT CONTENT. The safety win of
-#      --script is "stop interpolating kit-provided bytes into an `sh -c`
-#      string." But this adapter ALREADY does not do that for kit argv: a kit
-#      command is carried as base64-encoded argv tokens (kit_spec_commands ->
-#      __CMD__ records), decoded into a bash array, and handed to
-#      `msb exec … -- "$@"` as SEPARATE ARGV ELEMENTS. Kit content never enters
-#      an interpolated shell string on this path; the only `sh -c` around it is
-#      the fixed background-detach wrapper (`nohup "$@" … ` with the argv as
-#      positional params — still no interpolation). So the injection risk
-#      --script is designed to remove is already absent here; --script would
-#      restage the same already-safe argv through a different primitive without
-#      reducing attack surface.
+#   THE ONE CLEAN WIN IS THE CREATE-TIME, RE-RUNNABLE STARTUP BODY.
+#   A kit's `startup`-phase commands are re-run on EVERY apply (they carry no
+#   run-once marker — unlike install), and they are exactly what a microsandbox-
+#   native restart (`msb stop`+`msb start`, or a reboot that restarts the guest)
+#   must replay to bring kit background supervisors back up. microsandbox can
+#   replay them itself only if it holds them as a registered startup script. So
+#   we now STAGE the startup phase as a single create-time script registered via
+#   `--script-path` (see _acq_msb_stage_startup_script). That is a genuinely
+#   create-time-only, re-runnable command body whose natural form is a script
+#   file — the narrow case the older note itself named as the clean win, which
+#   ADR-0017 confirms now exists in the pinned vocabulary (the `startup` phase).
 #
-#   3) IDEMPOTENCY/USER SEMANTICS LIVE IN THE EXEC PATH, NOT IN REGISTRATION.
-#      install-phase commands are run-once via a root-owned marker keyed on a
-#      hash of the argv (_acq_msb_exec_command: /var/lib/acq/install-<cksum>),
-#      tested+written as uid 0 so the gate is independent of the command's own
-#      user; initFiles/startup re-run every apply. Per-phase run-as-user
-#      (install=root, 1000/agent -> `-u agent` + HOME) and the non-interactive
-#      git guards (GIT_TERMINAL_PROMPT=0 …) are all applied at INVOCATION. A
-#      registered /.msb/scripts/<name> still has to be INVOKED (as the right
-#      user, marker-gated, with the right env) — i.e. we would keep the entire
-#      exec+marker+uflag/eflag machinery AND add a registration+guard step on
-#      top. Net: strictly more moving parts, identical behavior.
+#   WHY `--script-path` (not --script / --script-raw): the body is read VERBATIM
+#   from a host file, so we never hand microsandbox a shell string assembled from
+#   kit content, and we do not depend on shebang derivation from --shell — the
+#   generated body carries its own `#!/bin/sh`. The generated file emits each kit
+#   argv token single-quote-escaped (SI-10): kit bytes become quoted data inside
+#   a here-shaped command line, never an interpolated program fragment.
 #
-#   4) FILE STAGING IS ORTHOGONAL. files[] already stage via `msb copy` +
-#      verify + chown (_acq_msb_copy_file_verified); paths are charset-validated
-#      and never interpolated. --script-path would only cover the COMMAND body,
-#      not files[], so it cannot subsume that path either.
+# THE BOUNDARY — what stays on `msb exec`, and WHY it MUST:
 #
-# CONCLUSION: keep the exec-based kit-command
-# staging. The one place --script/--script-path would be a clean, contained win
-# — a create-time-ONLY, run-once command whose body is genuinely a script file —
-# does not exist in the pinned neutral kit vocabulary today (kit commands are
-# argv sequences across three phases, applied both at create and mid-life). If a
-# future kit schema adds a create-time-only "script" concept, revisit this with
-# --script-path for that narrow case only; until then a second dispatch path is
-# net-negative. No behavior change; the mid-life exec path is load-bearing.
+#   1) INSTALL PHASE stays exec-based. install commands are run-once, gated by a
+#      root-owned marker keyed on a hash of the argv
+#      (_acq_msb_exec_install: /var/lib/acq/install-<cksum>), tested+written as
+#      uid 0 so the gate is independent of the command's own user. A create-time
+#      script re-runs on every restart by design — the OPPOSITE of run-once — so
+#      folding install into the startup script would break its idempotency
+#      contract. install therefore stays out of the staged script entirely.
+#
+#   2) MID-LIFE APPLY stays exec-based. _acq_msb_apply_kit_dir is also driven
+#      long after create by acq_backend_apply_kit (`acq kit apply NAME KITREF`)
+#      and by acq_backend_ensure_kits_applied (the re-attach heal loop). A
+#      create-time flag cannot register a script into an ALREADY-RUNNING sandbox,
+#      so the mid-life path MUST stay exec-based regardless. Create-time staging
+#      owns the reboot/`msb start` replay path; exec owns the in-place kit-add /
+#      heal path. They are complementary, not a fork: do not collapse one into
+#      the other.
+#
+#   3) FILE STAGING IS ORTHOGONAL. files[] stage via `msb copy` + verify + chown
+#      (_acq_msb_copy_file_verified); paths are charset-validated and never
+#      interpolated. `--script-path` covers only the startup COMMAND body, not
+#      files[], so it does not subsume that path.
+#
+# INCREMENT BOUNDARY (ADR-0017 delivers this in two steps). THIS increment is
+# runtime-neutral: it GENERATES the startup script body and REGISTERS it at
+# `msb create` via `--script-path acq-startup:<hostpath>`, but it does NOT yet
+# invoke it, wire it into microsandbox's persisted startup, or remove the exec-
+# based startup application that still runs after create. Registering a script
+# with no invocation is a deliberate no-op in msb 0.6.7 for now; the point of
+# this increment is to land the staging plumbing, the flag, and the generated-
+# body correctness under test. The persisted-restart wiring (making startup
+# re-run on a native restart, and retiring the now-redundant post-create exec
+# application of startup) is the FOLLOW-UP increment.
 
 # Fetch a kit ref into the cache and echo its local dir. Returns 1 on failure.
 _acq_msb_fetch_kit() {
@@ -915,6 +924,291 @@ _acq_msb_exec_command() {
 }
 
 # ---------------------------------------------------------------------------
+# Create-time startup-script staging (ADR-0017, increment 1)
+# ---------------------------------------------------------------------------
+# These helpers GENERATE a single host-side `/bin/sh` script that reproduces the
+# semantics the exec path applies to STARTUP-phase kit commands, and stage it as
+# a `--script-path acq-startup:<hostpath>` create flag. See the DESIGN NOTE above
+# for the boundary: only the `startup` phase is staged here; install and mid-life
+# apply stay exec-based, and this increment REGISTERS the script without invoking
+# it (the persisted-restart wiring is the follow-up).
+#
+# TRANSLATION from the exec path to an IN-GUEST script:
+#   - The exec path picks run-as-user via `msb exec -u agent`/`-u <user>`. Inside
+#     the guest the script cannot use `msb exec`, so it runs each command through
+#     `su`/`runuser` (whichever exists) for the agent/uid-1000 case, and directly
+#     for root. HOME=/home/agent is set for the agent case exactly as the exec
+#     path sets `-e HOME=/home/agent`.
+#   - The kit environment[] vars and the non-interactive git guards
+#     (GIT_TERMINAL_PROMPT=0, GIT_ASKPASS/SSH_ASKPASS=/bin/false unless the kit
+#     set GIT_TERMINAL_PROMPT) are emitted as an `env NAME=value …` prefix on the
+#     command — the in-guest equivalent of the exec path's `-e` flags. The prefix
+#     uses the portable, busybox-safe `env NAME=value … sh -c 'exec "$@"' sh ARGV`
+#     form: NO `--` terminator (unsupported by busybox/alpine `env`); see
+#     _acq_msb_startup_emit_command for the full rationale.
+#   - A `background:true` startup command is detached with the SAME nohup wrapper
+#     the exec path uses (`nohup … >/dev/null 2>&1 & exit-through`), so a
+#     never-exiting supervisor does not block the script.
+#
+# SI-10 / ESCAPING: kit-provided argv tokens and env values are NEVER interpolated
+# as shell fragments. Each argv token and each env value is single-quote-escaped
+# by _acq_msb_sq (embedded single quotes become '\'' ) before it is written to
+# the file, so kit bytes are emitted as inert quoted DATA, not executable syntax.
+# The body is a FILE read verbatim by `--script-path`; acq never assembles a
+# shell string from kit content and hands it to msb.
+
+# _acq_msb_sq STRING — echo STRING single-quote-escaped for safe emission into a
+# generated /bin/sh script line. Embedded single quotes become the classic
+# '\'' close/escape/reopen sequence.
+_acq_msb_sq() {
+  local _s="$1" _q="'\\''"
+  # Replace every ' with '\'' then wrap the whole thing in single quotes.
+  printf "'%s'" "${_s//\'/$_q}"
+}
+
+# _acq_msb_startup_env_prefix_into PREFIX_ARRVAR USER KITENV_ARRVAR — build the
+# in-guest `env NAME=value …` prefix tokens for one startup command: HOME for the
+# agent user, the kit env vars, and the git non-interactive guards (unless the
+# kit set GIT_TERMINAL_PROMPT). Mirrors _acq_msb_exec_flags_into's -e set, but as
+# `env` argv rather than `msb exec -e`. Tokens are RAW here (NAME=value); the
+# caller single-quote-escapes each before writing it to the script.
+_acq_msb_startup_env_prefix_into() {
+  local _prefixn="$1" _user="$2" _envarrn="$3"
+  eval "$_prefixn=()"
+
+  case "$_user" in
+    1000|agent) eval "$_prefixn+=(\"HOME=/home/agent\")" ;;
+  esac
+
+  # Kit-declared env vars (already NAME-validated by kit_spec_env).
+  local _ev
+  eval "set -- \${${_envarrn}[@]+\"\${${_envarrn}[@]}\"}"
+  for _ev in "$@"; do
+    eval "$_prefixn+=(\"\$_ev\")"
+  done
+
+  # Non-interactive git guards, unless the kit set GIT_TERMINAL_PROMPT itself.
+  local _kit_env_str
+  eval "_kit_env_str=\" \${${_envarrn}[*]-} \""
+  case "$_kit_env_str" in
+    *" GIT_TERMINAL_PROMPT="*) : ;;
+    *) eval "$_prefixn+=(\"GIT_TERMINAL_PROMPT=0\" \"GIT_ASKPASS=/bin/false\" \"SSH_ASKPASS=/bin/false\")" ;;
+  esac
+}
+
+# _acq_msb_startup_emit_command USER BACKGROUND PREFIX_ARRVAR ARGV_ARRVAR — echo
+# one /bin/sh line that runs one startup command in the guest with the correct
+# run-as-user, env prefix, and (if background) nohup detach. Every kit-derived
+# token is single-quote-escaped (SI-10); the run-as-user/su/nohup scaffolding is
+# adapter-owned fixed text.
+_acq_msb_startup_emit_command() {
+  local _user="$1" _background="$2" _prefixn="$3" _argvn="$4"
+
+  # PORTABLE ENV PREFIX (busybox/alpine-safe). The exec path threads env via
+  # `msb exec -e NAME=value`; the in-guest equivalent is the shell/POSIX `env`
+  # utility. We MUST NOT use the `env NAME=value -- argv` form: the `--`
+  # end-of-options terminator is a GNU coreutils >= 8.30 extension and is NOT
+  # accepted by busybox `env` (alpine) or older coreutils — there
+  # `env FOO=bar -- echo hi` fails with `env: '--': No such file or directory`.
+  # Since the git non-interactive guards are injected into nearly every command
+  # and the adapter supports plain-OCI base images (alpine/node), the emitted
+  # body must be portable.
+  #
+  # Portable construct: `env NAME=value … sh -c 'exec "$@"' sh ARGV…`. Per POSIX,
+  # `env` consumes only the leading NAME=value operands and treats the first
+  # non-assignment operand (`sh`) as the utility to run; no `--` is needed and
+  # none is emitted. Passing the kit argv as positional parameters to
+  # `sh -c 'exec "$@"' sh …` (rather than as bare `env` operands) means an env
+  # value or an argv token that *looks* like an option is never re-interpreted
+  # as one — `exec "$@"` runs argv[0] as the program with the rest as its args,
+  # verbatim. Every env token and argv token is single-quote-escaped by
+  # _acq_msb_sq (SI-10), so kit bytes stay inert quoted DATA.
+  local _payload="" _tok
+  eval "set -- \${${_prefixn}[@]+\"\${${_prefixn}[@]}\"}"
+  if [ "$#" -gt 0 ]; then
+    _payload="env"
+    for _tok in "$@"; do
+      _payload="$_payload $(_acq_msb_sq "$_tok")"
+    done
+  fi
+  # Argv follows via `sh -c 'exec "$@"' sh ARGV…`: this is the utility `env` runs
+  # (or, when there is no env prefix, the command itself). The literal
+  # `sh -c 'exec "$@"' sh` is adapter-owned fixed text; only the argv tokens are
+  # kit-derived and escaped. `sh` (argv0 for the -c shell, then $0 placeholder)
+  # is never a flag, so `env` always has a valid non-assignment utility operand.
+  eval "set -- \${${_argvn}[@]+\"\${${_argvn}[@]}\"}"
+  [ "$#" -gt 0 ] || return 0
+  _payload="$_payload sh -c 'exec \"\$@\"' sh"
+  for _tok in "$@"; do
+    _payload="$_payload $(_acq_msb_sq "$_tok")"
+  done
+
+  # background:true -> detach under nohup so a supervisor loop doesn't block.
+  if [ "$_background" = "true" ]; then
+    _payload="nohup sh -c $(_acq_msb_sq "$_payload") >/dev/null 2>&1 & :"
+  fi
+
+  # Run-as-user: root runs directly; the agent/uid-1000 contract runs via
+  # su/runuser (whichever the guest has) as the `agent` user. The inner command
+  # is passed to `sh -c` so the env prefix / nohup form is honored.
+  case "$_user" in
+    ""|0|root)
+      printf '%s\n' "$_payload"
+      ;;
+    1000|agent)
+      # Prefer runuser (util-linux) if present, else su. Both invoke the agent
+      # user's login-ish shell with our command. The command string is single-
+      # quote-escaped so kit content stays inert.
+      printf 'if command -v runuser >/dev/null 2>&1; then runuser -u agent -- sh -c %s; else su agent -c %s; fi\n' \
+        "$(_acq_msb_sq "$_payload")" "$(_acq_msb_sq "$_payload")"
+      ;;
+    *)
+      # A named non-root user: run via su as that user (name already validated by
+      # kit_spec_commands to ^[A-Za-z0-9_-]+$, but escape defensively anyway).
+      printf 'su %s -c %s\n' "$(_acq_msb_sq "$_user")" "$(_acq_msb_sq "$_payload")"
+      ;;
+  esac
+}
+
+# _acq_msb_generate_startup_script SPEC OUTFILE — write the guest startup script
+# for one kit spec's STARTUP-phase commands into OUTFILE. Returns 0 and writes a
+# non-empty script iff the kit HAS at least one startup command; returns 1 (and
+# writes nothing) when there are none, so the caller registers no empty script.
+# Parses the same __CMD__/base64-argv stream _acq_msb_run_commands consumes, but
+# keeps ONLY startup-phase records.
+_acq_msb_generate_startup_script() {
+  local _spec="$1" _out="$2"
+
+  # Collect the kit's environment[] entries (same validation as the exec path).
+  local _kit_env=() eline ekey eval_v
+  while IFS= read -r eline; do
+    [ -n "$eline" ] || continue
+    ekey=$(printf '%s' "$eline" | cut -f1)
+    eval_v=$(printf '%s' "$eline" | cut -f2-)
+    [ -n "$ekey" ] || continue
+    _kit_env+=("${ekey}=${eval_v}")
+  done <<EOF
+$(kit_spec_env "$_spec")
+EOF
+
+  # Buffer the command stream first (kit_spec_commands runs its own subshell; no
+  # msb exec here, but keep the buffer-then-parse shape for consistency).
+  local _lines=() line
+  while IFS= read -r line; do
+    _lines+=("$line")
+  done <<EOF
+$(kit_spec_commands "$_spec")
+EOF
+
+  # Build the body in a temp buffer; only write OUTFILE if we found a startup cmd.
+  local _body="" _emitted=0
+  local phase="" user="" argv=() reading=0 _i background="false"
+  for _i in ${_lines[@]+"${!_lines[@]}"}; do
+    line="${_lines[$_i]}"
+    case "$line" in
+      "__CMD__"*)
+        phase=$(printf '%s' "$line" | cut -f2)
+        user=$(printf '%s' "$line" | cut -f3)
+        background=$(printf '%s' "$line" | cut -f4)
+        [ -n "$background" ] || background="false"
+        argv=()
+        reading=1
+        ;;
+      "__END__")
+        reading=0
+        if [ "$phase" = "startup" ] && [ "${#argv[@]}" -gt 0 ]; then
+          # Build the env prefix + one guest command line for this record.
+          local _prefix=() _cmdline
+          _acq_msb_startup_env_prefix_into _prefix "$user" _kit_env
+          _cmdline=$(_acq_msb_startup_emit_command "$user" "$background" _prefix argv)
+          if [ -n "$_cmdline" ]; then
+            _body="${_body}${_cmdline}
+"
+            _emitted=1
+          fi
+        fi
+        ;;
+      *)
+        if [ "$reading" -eq 1 ]; then
+          argv+=("$(printf '%s' "$line" | base64 -d)")
+        fi
+        ;;
+    esac
+  done
+
+  [ "$_emitted" -eq 1 ] || return 1
+
+  # Emit the file: a self-contained /bin/sh with its own shebang (so --script-path
+  # reads a complete verbatim body; no --shell shebang derivation dependency).
+  {
+    printf '#!/bin/sh\n'
+    printf '# acq-generated msb startup script (ADR-0017). Reproduces kit startup\n'
+    printf '# commands so microsandbox can replay them on a native restart.\n'
+    printf '# Generated verbatim into a host file and registered via --script-path;\n'
+    printf '# kit argv/env tokens are single-quote-escaped (SI-10), never interpolated.\n'
+    printf '%s' "$_body"
+  } > "$_out"
+  return 0
+}
+
+# _acq_msb_stage_startup_script SPEC ARRVAR — generate the startup script for one
+# kit SPEC and, if non-empty, append a `--script-path acq-startup:<hostfile>`
+# entry into the create-flags array named ARRVAR. The host file is created under
+# ACQ_MSB_STARTUP_STAGE_DIR (a private 0700 dir under the acq state tree, so kit
+# content is never world-readable) and recorded in _ACQ_MSB_STARTUP_STAGE_FILES
+# for cleanup by the caller after create. A kit with no startup commands stages
+# nothing (no empty script is registered).
+#
+# NOTE (increment 1): only the FIRST kit that contributes startup commands stakes
+# the fixed `acq-startup` script name; if multiple kits carried startup commands
+# they would need a merged/uniquely-named script — but the pinned built-in kits
+# put startup commands in a single kit, and the follow-up increment that actually
+# invokes/persists the script will finalize multi-kit merging. Guarded here so a
+# second contributing kit does not silently overwrite the first's registration.
+#
+# VERIFIED NEUTRALITY ASSUMPTION (ADR-0017): registering a script via
+# `--script-path acq-startup:<file>` only STAGES the body on the guest PATH (as
+# /.msb/scripts/acq-startup) — it does NOT enroll the script in microsandbox's
+# persisted startup, so microsandbox does NOT auto-run it at guest boot. This was
+# confirmed against microsandbox source: `crates/cli/lib/commands/start.rs` and
+# `restart.rs` re-run a persisted `LaunchConfig.startup` on
+# `Sandbox::start_detached()`, and acq never populates `LaunchConfig.startup`.
+# Only an explicit startup registration is replayed at boot; a plain
+# `--script-path` registration is not. This is what makes increment 1
+# runtime-neutral: the script is present but inert. Enrolling it in the persisted
+# startup (so it replays on a native restart) is the follow-up increment's job.
+ACQ_MSB_STARTUP_SCRIPT_NAME="acq-startup"
+_acq_msb_stage_startup_script() {
+  local _spec="$1" _arrn="$2"
+
+  # One staged script per sandbox provision. If we already staged one, skip
+  # (increment-1 scope; see NOTE above).
+  if [ -n "${_ACQ_MSB_STARTUP_STAGED:-}" ]; then
+    return 0
+  fi
+
+  # Private staging dir (0700) under the acq state tree — not a world-readable
+  # /tmp. Mirrors how ssh keys/state are kept under ACQ_STATE_DIR.
+  local _dir="${ACQ_MSB_STARTUP_STAGE_DIR:-${ACQ_STATE_DIR}/msb-startup}"
+  mkdir -p "$_dir" 2>/dev/null || true
+  chmod 700 "$_dir" 2>/dev/null || true
+
+  local _file
+  _file=$(mktemp "${_dir}/acq-startup.XXXXXX" 2>/dev/null) || return 0
+  chmod 600 "$_file" 2>/dev/null || true
+
+  if _acq_msb_generate_startup_script "$_spec" "$_file"; then
+    eval "$_arrn+=(--script-path \"${ACQ_MSB_STARTUP_SCRIPT_NAME}:\$_file\")"
+    _ACQ_MSB_STARTUP_STAGE_FILES+=("$_file")
+    _ACQ_MSB_STARTUP_STAGED=1
+    acq_debug "msb startup-script staged: --script-path ${ACQ_MSB_STARTUP_SCRIPT_NAME}:${_file}"
+  else
+    # No startup commands in this kit — remove the empty temp file.
+    rm -f "$_file" 2>/dev/null || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # acq_backend_provision — create a sandbox and apply the kits
 # ---------------------------------------------------------------------------
 # msb create takes an IMAGE + flags. acq derives the sandbox name at the acq
@@ -940,6 +1234,12 @@ acq_backend_provision() {
   local create_flags=()
   local trust_host_cas=0
   local kitdirs=()
+
+  # Create-time startup-script staging (ADR-0017, increment 1). Reset the
+  # per-provision guard + staged-file list so a prior provision in the same
+  # process does not leak into this one; the files are cleaned up after create.
+  _ACQ_MSB_STARTUP_STAGED=""
+  _ACQ_MSB_STARTUP_STAGE_FILES=()
 
   # Fetch each built-in kit and gather its create-time contributions.
   local kitref kitdir
@@ -985,6 +1285,15 @@ acq_backend_provision() {
     local pp=()
     _acq_msb_port_flags_into pp "$spec"
     [ "${#pp[@]}" -gt 0 ] && create_flags+=("${pp[@]}")
+
+    # Startup-phase commands → a create-time `--script-path acq-startup:<file>`
+    # (ADR-0017, increment 1). Runtime-neutral: the script is REGISTERED at create
+    # but not yet invoked or wired into microsandbox's persisted startup (the
+    # follow-up increment). install + mid-life apply stay exec-based (see the
+    # DESIGN NOTE and _acq_msb_apply_kit_dir, which still applies startup via
+    # exec after create for now). Only the first kit with startup commands stakes
+    # the fixed script name this increment (see _acq_msb_stage_startup_script).
+    _acq_msb_stage_startup_script "$spec" create_flags
   done
 
   [ "$trust_host_cas" -eq 1 ] && create_flags+=(--trust-host-cas)
@@ -1225,6 +1534,17 @@ EOF
   for _ev in ${_secret_env_names[@]+"${_secret_env_names[@]}"}; do
     unset "$_ev"
   done
+  # Remove the staged startup-script host file(s) now that `msb create` has read
+  # the --script-path body (ADR-0017). Runs on success and failure so kit content
+  # never lingers in the private staging dir. The registration lives in the
+  # sandbox; the host copy is transient (mirrors the transient-secret scrub).
+  # ACQ_MSB_KEEP_STARTUP_STAGE=1 preserves the file (used by the offline test
+  # harness to inspect the generated body; never set in normal operation).
+  local _sf
+  for _sf in ${_ACQ_MSB_STARTUP_STAGE_FILES[@]+"${_ACQ_MSB_STARTUP_STAGE_FILES[@]}"}; do
+    [ -n "${ACQ_MSB_KEEP_STARTUP_STAGE:-}" ] || rm -f "$_sf" 2>/dev/null || true
+  done
+  [ -n "${ACQ_MSB_KEEP_STARTUP_STAGE:-}" ] || _ACQ_MSB_STARTUP_STAGE_FILES=()
   if [ "$_create_rc" -ne 0 ]; then
     echo "acq(msb): error: 'msb create' failed for '$name'." >&2
     echo "acq(msb):   flags: ${create_flags[*]}" >&2

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -435,6 +435,19 @@ _acq_msb_wait_for_exec_ready() {
 # Fetch a kit ref into the cache and echo its local dir. Returns 1 on failure.
 _acq_msb_fetch_kit() {
   local kitref="$1" slug dest
+  # Offline/test escape hatch: when ACQ_MSB_KIT_LOCAL_DIR is set, resolve REMOTE
+  # (git+) kit refs to that local directory instead of fetching. Mirrors the sbx
+  # adapter's ACQ_SBX_KIT_PASSTHROUGH: it keeps the offline unit harness fully
+  # network-free even when acq is invoked as a CHILD process (e.g. `acq start`),
+  # where a test cannot shadow this function. LOCAL kit paths are still used
+  # as-is (a test that passes an explicit local kit dir must get THAT dir), so
+  # the hatch only diverts refs that would otherwise hit the network. Never set
+  # in production — a real kit body is required there.
+  if [ -n "${ACQ_MSB_KIT_LOCAL_DIR:-}" ]; then
+    case "$kitref" in
+      git+*|*://*) printf '%s\n' "$ACQ_MSB_KIT_LOCAL_DIR"; return 0 ;;
+    esac
+  fi
   # Derive a stable cache subdir from the ref (sha + dir tail).
   slug=$(printf '%s' "$kitref" | tr -c 'A-Za-z0-9._-' '_' )
   dest="${ACQ_MSB_KIT_CACHE}/${slug}"

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -1083,29 +1083,34 @@ _acq_msb_startup_emit_command() {
   esac
 }
 
-# _acq_msb_generate_startup_script SPEC OUTFILE — write the guest startup script
-# for one kit spec's STARTUP-phase commands into OUTFILE. Returns 0 and writes a
-# non-empty script iff the kit HAS at least one startup command; returns 1 (and
-# writes nothing) when there are none, so the caller registers no empty script.
-# Parses the same __CMD__/base64-argv stream _acq_msb_run_commands consumes, but
-# keeps ONLY startup-phase records.
-_acq_msb_generate_startup_script() {
-  local _spec="$1" _out="$2"
-
-  # Collect the kit's environment[] entries (same validation as the exec path).
-  local _kit_env=() eline ekey eval_v
+# _acq_msb_collect_kit_env_into ARRVAR SPEC — read SPEC's environment[] entries
+# (via kit_spec_env, same validation as the exec path) and append each as a
+# NAME=value element to the array named ARRVAR.
+_acq_msb_collect_kit_env_into() {
+  local _arrn="$1" _spec="$2" eline ekey eval_v
   while IFS= read -r eline; do
     [ -n "$eline" ] || continue
     ekey=$(printf '%s' "$eline" | cut -f1)
     eval_v=$(printf '%s' "$eline" | cut -f2-)
     [ -n "$ekey" ] || continue
-    _kit_env+=("${ekey}=${eval_v}")
+    eval "$_arrn+=(\"\${ekey}=\${eval_v}\")"
   done <<EOF
 $(kit_spec_env "$_spec")
 EOF
+}
 
-  # Buffer the command stream first (kit_spec_commands runs its own subshell; no
-  # msb exec here, but keep the buffer-then-parse shape for consistency).
+# _acq_msb_startup_body_into BODYVAR SPEC — parse SPEC's __CMD__/base64-argv
+# command stream (the same stream _acq_msb_run_commands consumes) and append one
+# guest command line per STARTUP-phase record to the variable named BODYVAR.
+# Returns 0 iff at least one startup command line was emitted. Non-startup phases
+# are ignored here (install/initFiles stay on the exec path — ADR-0017).
+_acq_msb_startup_body_into() {
+  local _bodyn="$1" _spec="$2"
+
+  local _kit_env=()
+  _acq_msb_collect_kit_env_into _kit_env "$_spec"
+
+  # Buffer the command stream first (kit_spec_commands runs its own subshell).
   local _lines=() line
   while IFS= read -r line; do
     _lines+=("$line")
@@ -1113,8 +1118,7 @@ EOF
 $(kit_spec_commands "$_spec")
 EOF
 
-  # Build the body in a temp buffer; only write OUTFILE if we found a startup cmd.
-  local _body="" _emitted=0
+  local _emitted=0
   local phase="" user="" argv=() reading=0 _i background="false"
   for _i in ${_lines[@]+"${!_lines[@]}"}; do
     line="${_lines[$_i]}"
@@ -1130,13 +1134,12 @@ EOF
       "__END__")
         reading=0
         if [ "$phase" = "startup" ] && [ "${#argv[@]}" -gt 0 ]; then
-          # Build the env prefix + one guest command line for this record.
           local _prefix=() _cmdline
           _acq_msb_startup_env_prefix_into _prefix "$user" _kit_env
           _cmdline=$(_acq_msb_startup_emit_command "$user" "$background" _prefix argv)
           if [ -n "$_cmdline" ]; then
-            _body="${_body}${_cmdline}
-"
+            # Append "<cmdline>\n" by name; $'\n' is a literal newline (ANSI-C).
+            eval "$_bodyn=\${$_bodyn}\$_cmdline\$'\\n'"
             _emitted=1
           fi
         fi
@@ -1149,7 +1152,17 @@ EOF
     esac
   done
 
-  [ "$_emitted" -eq 1 ] || return 1
+  [ "$_emitted" -eq 1 ]
+}
+
+# _acq_msb_generate_startup_script SPEC OUTFILE — write the guest startup script
+# for one kit spec's STARTUP-phase commands into OUTFILE. Returns 0 and writes a
+# non-empty script iff the kit HAS at least one startup command; returns 1 (and
+# writes nothing) when there are none, so the caller registers no empty script.
+_acq_msb_generate_startup_script() {
+  local _spec="$1" _out="$2" _body=""
+
+  _acq_msb_startup_body_into _body "$_spec" || return 1
 
   # Emit the file: a self-contained /bin/sh with its own shebang (so --script-path
   # reads a complete verbatim body; no --shell shebang derivation dependency).
@@ -1190,6 +1203,12 @@ EOF
 # `--script-path` registration is not. This is what makes increment 1
 # runtime-neutral: the script is present but inert. Enrolling it in the persisted
 # startup (so it replays on a native restart) is the follow-up increment's job.
+#
+# This assumption is load-bearing and unverifiable from this repo, so it MUST be
+# re-verified on each msb version bump — if a future msb auto-runs a registered
+# `--script-path` at boot, kit startup would double-run (boot replay + acq heal).
+# See docs/KNOWN_FAILURE_MODES.md ("msb May Auto-Run a --script-path-Registered
+# Script at Boot") for the re-verification procedure and remediation.
 ACQ_MSB_STARTUP_SCRIPT_NAME="acq-startup"
 _acq_msb_stage_startup_script() {
   local _spec="$1" _arrn="$2"
@@ -1207,7 +1226,13 @@ _acq_msb_stage_startup_script() {
   chmod 700 "$_dir" 2>/dev/null || true
 
   local _file
-  _file=$(mktemp "${_dir}/acq-startup.XXXXXX" 2>/dev/null) || return 0
+  _file=$(mktemp "${_dir}/acq-startup.XXXXXX" 2>/dev/null) || {
+    # Staging is best-effort (the script is inert until a later increment
+    # invokes it), but a silent no-op would be undiagnosable — warn so the
+    # cause is visible rather than a mysteriously missing --script-path.
+    echo "acq(msb): warning: could not create startup-script staging file in ${_dir}; skipping --script-path." >&2
+    return 0
+  }
   chmod 600 "$_file" 2>/dev/null || true
 
   if _acq_msb_generate_startup_script "$_spec" "$_file"; then

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -3,7 +3,7 @@ title: "Known Failure Modes"
 description: "Real-world failure patterns when using Docker SBX + USAi + agent frameworks"
 status: canonical
 tier: 2
-last_updated: "2026-07-08"
+last_updated: "2026-08-03"
 audience: "developers"
 keywords: ["debugging", "troubleshooting", "sbx", "usai", "failures"]
 ---
@@ -1084,6 +1084,57 @@ Recover least-destructive first:
 - Until then, `sbx reset --preserve-secrets` is the reliable recovery after a
   restart leaves a sandbox unusable. (`--preserve-secrets` avoids re-running the
   Step 3 secret setup.)
+
+---
+
+## 28. msb May Auto-Run a `--script-path`-Registered Script at Boot (Re-Verify on Version Bump)
+
+### Symptoms
+
+Not a bug you hit today — a **latent** failure to watch for after a microsandbox
+(`msb`) version bump. If a future msb release starts auto-executing a registered
+`--script-path` script at guest boot, kit `startup` commands could run **twice**
+on a resume: once from microsandbox's own boot replay, and again from acq's
+`start`/`restart` heal (which re-runs the startup phase via `msb exec`).
+
+### Root Cause
+
+The acq msb adapter stages kit `startup` commands as a create-time script
+registered with `--script-path acq-startup:<hostfile>` (ADR-0017). This is only
+safe/runtime-neutral because, on the pinned msb version, a bare `--script-path`
+registration merely places the script on the guest PATH
+(`/.msb/scripts/acq-startup`) — microsandbox does **not** auto-run it at boot.
+Boot replay is driven only by a persisted `LaunchConfig.startup`
+(`runtime.entrypoint`/`runtime.cmd`), which acq never populates. This was
+confirmed against microsandbox source (`crates/cli/lib/commands/start.rs`,
+`restart.rs`, `Sandbox::start_detached()`).
+
+This is a **load-bearing, unverifiable-from-this-repo assumption**: it depends on
+microsandbox internals that could change in a future release.
+
+### Prevention / Re-Verification
+
+On each msb version bump (part of the quarterly re-verification cadence), confirm
+`--script-path` boot-inertness still holds:
+
+```bash
+# Create a sandbox with a sentinel startup command staged via --script-path,
+# then stop + start it WITHOUT going through acq, and check the sentinel ran
+# 0 times (inert) rather than 1 (auto-run at boot):
+msb create --name inert-probe --script-path acq-startup:/path/to/sentinel.sh <image>
+msb stop inert-probe && msb start inert-probe
+# inspect: the sentinel's side effect must NOT have fired on the bare start
+msb rm inert-probe
+```
+
+If a future msb **does** auto-run the registered script at boot, the adapter must
+stop double-running startup — e.g. drop the acq `start`/`restart` heal's
+startup re-run for msb, or stop staging the script. See the "VERIFIED NEUTRALITY
+ASSUMPTION" note in `_acq_msb_stage_startup_script` (`acq.backends/msb.sh`).
+
+### Related
+
+- ADR-0017 (msb create-time startup-script staging).
 
 ---
 

--- a/docs/adr/0017-msb-create-time-startup-script-staging.md
+++ b/docs/adr/0017-msb-create-time-startup-script-staging.md
@@ -1,0 +1,115 @@
+---
+title: "Stage msb kit startup commands as a create-time script for restart durability"
+status: accepted
+date: 2026-08-02
+decision_makers: ["Bret Mogilefsky"]
+category: architecture
+nist_controls: ["CM-2", "CM-3", "CM-6", "CM-7", "SA-8", "SA-15", "SI-10", "SI-17"]
+impact_level: low
+ato_relevance: no
+risk_treatment: accept
+supersedes: []
+---
+
+# ADR-0017: Stage msb kit startup commands as a create-time script for restart durability
+
+## Context and Problem Statement
+
+On the msb backend, kit `startup` commands (including long-lived `background`
+supervisors) are applied imperatively via `msb exec` at provision time and on
+the acq re-attach heal loop. They do **not** re-run on a microsandbox-native
+restart (`msb stop` + `msb start`, or a host reboot that restarts the guest),
+because acq never populates microsandbox's persisted `LaunchConfig.startup`. A
+sandbox that is stopped and started back up *outside* acq therefore comes back
+without its kit-defined background services running.
+
+ADR-0011's msb adapter deliberately kept kit-command injection exec-based and
+parked a `--script`/`--script-path` staging approach (recorded in the
+`acq.backends/msb.sh` design note). This ADR revisits that parked decision for
+the **narrow, specific case the note itself named as the one clean win**: a
+create-time, re-runnable command body staged as a script file — because that is
+exactly the mechanism microsandbox needs to re-run startup on restart.
+
+## Decision Drivers
+
+- Restart durability: a stopped-then-started msb sandbox must bring its kit
+  background services back up without an `acq run` re-attach (the concrete
+  failure motivating this: a supervised UI stack goes dark after `msb stop`/
+  `msb start`).
+- Preserve the ADR-0011 exec path for install (run-once, root-owned marker
+  gating) and for mid-life kit apply/heal — a create-time flag cannot inject
+  into an already-running sandbox, so the mid-life path stays exec-based.
+- SI-10 untrusted-kit-input hardening: staging a command body as a file
+  (`--script-path`) avoids assembling a shell string from kit-provided content.
+- Keep the neutral `hybrid/v1` kit vocabulary and idempotency/marker semantics
+  unchanged; no new kit-author-visible surface.
+- Minimize divergence: reuse the existing translation/argv pipeline rather than
+  introducing a parallel command model.
+
+## Considered Options
+
+1. **Give acq a `start`/`restart` verb** that re-drives the exec-based apply on
+   every resume. Keeps a single dispatch path, but only heals when the user
+   goes *through acq* — a raw `msb start` or a reboot-driven restart still comes
+   back bare, so it does not close the stated gap.
+2. **Stage kit `startup` commands as a create-time script registered with
+   microsandbox** (`--script-path`), so microsandbox re-runs it on every
+   `start_detached` (both `msb start` and `msb restart`). Keep the exec path for
+   install and mid-life apply.
+3. **Combination** — native create-time persistence for the restart path *plus*
+   an acq resume verb for the in-place heal path.
+
+## Decision Outcome
+
+Chosen option: **Option 2**, because it is the only option that makes startup
+re-run on a microsandbox-native restart (the actual gap), and it does so through
+the exact create-time-only, re-runnable-script case that the ADR-0011 design
+note identified as the clean, contained win for `--script-path`. The exec path
+is retained unchanged for install (run-once marker gating) and mid-life
+apply/heal, so the two mechanisms are complementary, not a fork: create-time
+staging owns the reboot/`msb start` path; exec owns the in-place kit-add path.
+
+This ADR is delivered in two increments. The first (this ADR's enabling change)
+introduces the create-time `--script-path` staging of startup commands and
+rewrites the design note; it is runtime-neutral. The second wires that staged
+script into microsandbox's persisted startup so the observable restart-durable
+behavior lands.
+
+### Positive Consequences
+
+- Kit `startup`/`background` services survive `msb stop`/`msb start` and reboots
+  without an `acq run` re-attach.
+- Command bodies are staged as files, not interpolated shell strings (SI-10).
+- No change to the neutral kit vocabulary or to install/idempotency semantics.
+
+### Negative Consequences
+
+- Two staging mechanisms now coexist (create-time script for startup persistence
+  + exec for install and mid-life). The design note documents the boundary so a
+  future maintainer does not collapse them incorrectly.
+- The create-time script must reproduce the per-command run-as-user and
+  non-interactive git guards the exec path applies at invocation, so that logic
+  is shared/duplicated into the staged body.
+
+### Compliance Consequences
+
+- SI-10 (input validation): kit-provided command bytes are staged as a file
+  body and executed as registered scripts rather than interpolated into an
+  `sh -c` string.
+- SI-17 (fail-safe): background supervisors are restored deterministically after
+  an unplanned restart, reducing silent post-reboot degradation.
+- CM-2/CM-3/CM-6: sandbox startup configuration becomes part of the persisted,
+  reproducible baseline rather than an imperative one-shot.
+
+## Links
+
+- ADR-0011 (msb backend and neutral hybrid/v1 kit translation) — establishes the
+  exec-based kit-command staging this ADR augments for the startup case.
+- ADR-0014 (neutral port-publish and background-command vocabulary) — defines the
+  `background` command flag whose supervisors this ADR keeps alive across
+  restarts.
+- `acq.backends/msb.sh` design note — rewritten to reflect this decision.
+- `docs/explorations/acq-design.md` — will be reconciled with the
+  restart-durable behavior by the follow-up increment that wires the persisted
+  startup. Increment 1 (this ADR) ships only create-time script *staging* and
+  does not touch that document or introduce restart-durable behavior.

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -48,6 +48,20 @@ sleep() { :; }
 # translation itself is exercised separately (see the kit-translate section).
 export ACQ_SBX_KIT_PASSTHROUGH=1
 
+# msb equivalent: resolve every REMOTE kit ref to a local empty spec dir instead
+# of a real git fetch. This keeps the suite network-free for the msb
+# heal/provision paths (acq_backend_provision / acq_backend_ensure_kits_applied),
+# including when acq is invoked as a CHILD process, where a test cannot shadow
+# _acq_msb_fetch_kit. Local kit paths still pass through unchanged, so tests that
+# supply an explicit local kit dir (e.g. mid-life apply) are unaffected;
+# in-process tests that override _acq_msb_fetch_kit still win for the refs they
+# pass. On a CI host with git + network this prevents a real fetch that would
+# otherwise hang.
+_ACQ_MSB_OFFLINE_KIT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/acq-nokit.XXXXXX")
+printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "$_ACQ_MSB_OFFLINE_KIT_DIR/spec.yaml"
+export ACQ_MSB_KIT_LOCAL_DIR="$_ACQ_MSB_OFFLINE_KIT_DIR"
+trap 'rm -rf "$_ACQ_MSB_OFFLINE_KIT_DIR"' EXIT
+
 # ---------------------------------------------------------------------------
 # Stub scaffolding
 # ---------------------------------------------------------------------------
@@ -2396,10 +2410,19 @@ commands:
       - echo MULTI_STARTUP_TWO
 SPEC
   # Point the four built-in kit refs at our two fixtures (the 3rd/4th reuse the
-  # empty nokit) so the REAL provision loop fetches and applies both.
+  # empty nokit) so the REAL provision loop fetches and applies both. These are
+  # consumed by acq_backend_provision's built-in kit list, then routed through the
+  # _acq_msb_fetch_kit override below (indirection shellcheck cannot see).
   mkdir -p "$STUBDIR/nokit"
   printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "$STUBDIR/nokit/spec.yaml"
-  USAI_KIT="k1"; PLAYBOOK_KIT="k2"; ZSCALER_KIT="k3"; GITSSHSIGN_KIT="k4"
+  # shellcheck disable=SC2034  # all four assigned here, read by the provision loop
+  USAI_KIT="k1"
+  # shellcheck disable=SC2034
+  PLAYBOOK_KIT="k2"
+  # shellcheck disable=SC2034
+  ZSCALER_KIT="k3"
+  # shellcheck disable=SC2034
+  GITSSHSIGN_KIT="k4"
   _acq_msb_fetch_kit() {
     case "$1" in
       k1) printf '%s\n' "$mk1" ;;

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -2100,6 +2100,364 @@ assert_contains "239: install cmd marker is written after run (touch)" "$instmar
 assert_contains "239: install marker tested/written as root" "$instmarker_log" "msb exec instmarkerbox -u 0"
 cleanup_stubs
 
+# 8o1d. ADR-0017 (increment 1): provisioning a kit that HAS a startup command
+#        stages a create-time `--script-path acq-startup:<path>` flag on
+#        `msb create`, AND the generated host script file exists and reproduces
+#        the startup command's argv + the correct run-as-user construct. This is
+#        the create-time staging plumbing; it does NOT change how startup is
+#        applied via exec after create (asserted below) — it is runtime-neutral.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/su-secrets"
+  # Preserve the staged host file so this test can read the generated body.
+  export ACQ_MSB_KEEP_STARTUP_STAGE=1
+  export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/startup-stage"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  suk="$STUBDIR/startupkit"; mkdir -p "$suk"
+  cat >"$suk/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: startup-kit
+displayName: Startup Kit
+description: one agent-user startup command staged as a create-time script
+commands:
+  - phase: startup
+    user: "1000"
+    command:
+      - sh
+      - -c
+      - echo STARTUP_MARKER_ALPHA
+SPEC
+  _acq_msb_fetch_kit() { printf '%s\n' "$suk"; }
+  acq_backend_provision startupbox shell /tmp >/dev/null 2>&1
+)
+su_log=$(cat "$CALLS")
+# (a) the create line carries a --script-path acq-startup:<path> flag.
+assert_contains "0017: msb create stages --script-path acq-startup" "$su_log" "--script-path acq-startup:"
+# (b) the generated host script file exists and carries the startup argv +
+#     run-as-user (agent) construct.
+su_file=$(find "$STUBDIR/startup-stage" -type f 2>/dev/null | head -n1)
+su_body=$(cat "$su_file" 2>/dev/null)
+assert_contains "0017: generated script has shebang" "$su_body" "#!/bin/sh"
+assert_contains "0017: generated script includes startup command body" "$su_body" "echo STARTUP_MARKER_ALPHA"
+assert_contains "0017: generated script runs uid-1000 as agent (su/runuser)" "$su_body" "runuser -u agent"
+assert_contains "0017: generated script sets HOME for agent user" "$su_body" "HOME=/home/agent"
+# The staged path in the create flag is the same host file that exists.
+assert_contains "0017: staged path in create flag points at the generated file" "$su_log" "--script-path acq-startup:${su_file}"
+cleanup_stubs
+
+# 8o1e. ADR-0017: a background:true startup command is staged into the generated
+#        script in the nohup-detach form (same detach semantics the exec path
+#        uses), so a never-exiting supervisor doesn't block on restart replay.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/bgsu-secrets"
+  export ACQ_MSB_KEEP_STARTUP_STAGE=1
+  export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/bgstartup-stage"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  bsk="$STUBDIR/bgstartupkit"; mkdir -p "$bsk"
+  cat >"$bsk/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: bgstartup-kit
+displayName: BG Startup Kit
+description: a background startup supervisor staged with nohup detach
+commands:
+  - phase: startup
+    user: "0"
+    background: true
+    command:
+      - supervisor-loop-0017
+SPEC
+  _acq_msb_fetch_kit() { printf '%s\n' "$bsk"; }
+  acq_backend_provision bgstartupbox shell /tmp >/dev/null 2>&1
+)
+bgsu_file=$(find "$STUBDIR/bgstartup-stage" -type f 2>/dev/null | head -n1)
+bgsu_body=$(cat "$bgsu_file" 2>/dev/null)
+assert_contains "0017: background startup staged with nohup detach" "$bgsu_body" "nohup"
+assert_contains "0017: background startup command in generated script" "$bgsu_body" "supervisor-loop-0017"
+cleanup_stubs
+
+# 8o1f. ADR-0017: a kit with NO startup commands stages NO --script-path
+#        acq-startup flag (no empty script is registered). Uses a kit whose only
+#        command is install-phase (not startup).
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/nostartup-secrets"
+  export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/nostartup-stage"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  nsk2="$STUBDIR/nostartupkit"; mkdir -p "$nsk2"
+  cat >"$nsk2/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: nostartup-kit
+displayName: NoStartup Kit
+description: only an install command, no startup phase
+commands:
+  - phase: install
+    user: "0"
+    command:
+      - true
+SPEC
+  _acq_msb_fetch_kit() { printf '%s\n' "$nsk2"; }
+  acq_backend_provision nostartupbox shell /tmp >/dev/null 2>&1
+)
+nostartup_log=$(cat "$CALLS")
+assert_not_contains "0017: no startup cmd => no --script-path acq-startup flag" "$nostartup_log" "--script-path acq-startup"
+cleanup_stubs
+
+# 8o1g. ADR-0017 REGRESSION: install-phase commands still go through `msb exec`
+#        (unchanged) and are NOT folded into the generated startup script. The
+#        install command's run-once marker gate must still be exercised via exec,
+#        and its argv must NOT appear in the staged startup script body.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/mix-secrets"
+  export ACQ_MSB_KEEP_STARTUP_STAGE=1
+  export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/mix-stage"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  mxk="$STUBDIR/mixkit"; mkdir -p "$mxk"
+  cat >"$mxk/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: mix-kit
+displayName: Mix Kit
+description: install stays exec-based; startup is staged
+commands:
+  - phase: install
+    user: "0"
+    command:
+      - sh
+      - -c
+      - echo INSTALL_ONLY_0017
+  - phase: startup
+    user: "0"
+    command:
+      - sh
+      - -c
+      - echo STARTUP_ONLY_0017
+SPEC
+  _acq_msb_fetch_kit() { printf '%s\n' "$mxk"; }
+  acq_backend_provision mixbox shell /tmp >/dev/null 2>&1
+)
+mix_log=$(cat "$CALLS")
+mix_file=$(find "$STUBDIR/mix-stage" -type f 2>/dev/null | head -n1)
+mix_body=$(cat "$mix_file" 2>/dev/null)
+# install still runs through the exec path: marker-gated as root.
+assert_contains "0017: install still exec-based (marker gate via msb exec -u 0)" "$mix_log" "test -f '/var/lib/acq/install-"
+assert_contains "0017: install command body still applied via msb exec" "$mix_log" "echo INSTALL_ONLY_0017"
+# The startup command IS in the generated script; the install command is NOT.
+assert_contains "0017: startup command is in the generated script" "$mix_body" "echo STARTUP_ONLY_0017"
+assert_not_contains "0017: install command is NOT in the generated startup script" "$mix_body" "INSTALL_ONLY_0017"
+cleanup_stubs
+
+# 8o1h. ADR-0017 SECURITY (SI-10): a startup command body carrying shell
+#        metacharacters is emitted into the generated script as SINGLE-QUOTED
+#        DATA (never an interpolated program fragment), so the injected `rm -rf`
+#        is inert text, not executable syntax. Also confirm no secret VALUE ever
+#        reaches the generated script or the create line.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/inj-secrets"
+  export ACQ_MSB_KEEP_STARTUP_STAGE=1
+  export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/inj-stage"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  # Plant a USAi secret so provision binds it; its VALUE must never leak into the
+  # generated script or the create line.
+  printf 'SUPER_SECRET_VALUE_0017\n' | acq_secret_store "$(_acq_secret_key usai injbox)" >/dev/null 2>&1
+  injk="$STUBDIR/injstartupkit"; mkdir -p "$injk"
+  cat >"$injk/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: injstartup-kit
+displayName: InjStartup Kit
+description: metachar startup body stays quoted data (SI-10)
+commands:
+  - phase: startup
+    user: "0"
+    command:
+      - printf
+      - "%s\n"
+      - "hello; rm -rf /tmp/STARTUP_PWNED"
+SPEC
+  _acq_msb_fetch_kit() { printf '%s\n' "$injk"; }
+  acq_backend_provision injbox shell /tmp >/dev/null 2>&1
+)
+inj_log=$(cat "$CALLS")
+inj_file=$(find "$STUBDIR/inj-stage" -type f 2>/dev/null | head -n1)
+inj_body=$(cat "$inj_file" 2>/dev/null)
+# The metachar body is present but single-quoted (inert data): the quoted form
+# `'hello; rm -rf /tmp/STARTUP_PWNED'` appears verbatim in the generated script.
+assert_contains "0017: metachar startup body carried as single-quoted data" "$inj_body" "'hello; rm -rf /tmp/STARTUP_PWNED'"
+# No secret VALUE anywhere in the generated script or the create line.
+assert_not_contains "0017: secret value never in generated startup script" "$inj_body" "SUPER_SECRET_VALUE_0017"
+assert_not_contains "0017: secret value never on the create line" "$inj_log" "SUPER_SECRET_VALUE_0017"
+cleanup_stubs
+
+# 8o1i. ADR-0017 BODY FIDELITY: the generated startup body reproduces the SAME
+#        semantics the exec path threads onto a startup command — the git
+#        non-interactive guards (GIT_TERMINAL_PROMPT=0 + GIT_ASKPASS/SSH_ASKPASS)
+#        AND any kit environment[] var — as a portable `env NAME=value …` prefix
+#        (busybox-safe: no `--` terminator). Uses a kit with a declared env var so
+#        both the guard and the kit var must appear in the generated file.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/fidel-secrets"
+  export ACQ_MSB_KEEP_STARTUP_STAGE=1
+  export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/fidel-stage"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  fdk="$STUBDIR/fidelkit"; mkdir -p "$fdk"
+  cat >"$fdk/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: fidel-kit
+displayName: Fidelity Kit
+description: startup body carries git guards + a kit environment var
+environment:
+  GITLAB_HOST: gitlab.example.gov
+commands:
+  - phase: startup
+    user: "0"
+    command:
+      - sh
+      - -c
+      - echo FIDELITY_MARKER
+SPEC
+  _acq_msb_fetch_kit() { printf '%s\n' "$fdk"; }
+  acq_backend_provision fidelbox shell /tmp >/dev/null 2>&1
+)
+fidel_file=$(find "$STUBDIR/fidel-stage" -type f 2>/dev/null | head -n1)
+fidel_body=$(cat "$fidel_file" 2>/dev/null)
+# (a) git non-interactive guards are threaded onto the startup command body.
+assert_contains "0017: startup body carries GIT_TERMINAL_PROMPT=0 guard" "$fidel_body" "GIT_TERMINAL_PROMPT=0"
+assert_contains "0017: startup body carries GIT_ASKPASS guard" "$fidel_body" "GIT_ASKPASS=/bin/false"
+assert_contains "0017: startup body carries SSH_ASKPASS guard" "$fidel_body" "SSH_ASKPASS=/bin/false"
+# (b) the kit-declared environment[] var is emitted into the body.
+assert_contains "0017: kit environment var emitted into startup body" "$fidel_body" "GITLAB_HOST=gitlab.example.gov"
+# Portability: the env prefix uses NO `--` terminator (unsupported by busybox env).
+assert_contains "0017: env prefix present in body (env NAME=value …)" "$fidel_body" "env "
+assert_not_contains "0017: env prefix uses NO -- terminator (busybox-safe)" "$fidel_body" "env --"
+cleanup_stubs
+
+# 8o1j. ADR-0017 MULTI-KIT SINGLE-STAKE + NO-DROP: when TWO kits each carry a
+#        startup command, only ONE `--script-path acq-startup` is staged at
+#        create (increment-1 single-stake guard) — but the exec-based apply path
+#        (unchanged, runtime-neutral) must STILL run BOTH kits' startup commands
+#        after create, so nothing is dropped at runtime. Drives the REAL provision
+#        with two kit dirs returned by a fetch stub keyed on the kit ref, so both
+#        real kits flow through create-staging AND _acq_msb_apply_kit_dir.
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/multi-secrets"
+  export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/multi-stage"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  mk1="$STUBDIR/multikit1"; mkdir -p "$mk1"
+  cat >"$mk1/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: multi-kit-one
+displayName: Multi Kit One
+description: first kit with a startup command
+commands:
+  - phase: startup
+    user: "0"
+    command:
+      - sh
+      - -c
+      - echo MULTI_STARTUP_ONE
+SPEC
+  mk2="$STUBDIR/multikit2"; mkdir -p "$mk2"
+  cat >"$mk2/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: multi-kit-two
+displayName: Multi Kit Two
+description: second kit with a startup command
+commands:
+  - phase: startup
+    user: "0"
+    command:
+      - sh
+      - -c
+      - echo MULTI_STARTUP_TWO
+SPEC
+  # Point the four built-in kit refs at our two fixtures (the 3rd/4th reuse the
+  # empty nokit) so the REAL provision loop fetches and applies both.
+  mkdir -p "$STUBDIR/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "$STUBDIR/nokit/spec.yaml"
+  USAI_KIT="k1"; PLAYBOOK_KIT="k2"; ZSCALER_KIT="k3"; GITSSHSIGN_KIT="k4"
+  _acq_msb_fetch_kit() {
+    case "$1" in
+      k1) printf '%s\n' "$mk1" ;;
+      k2) printf '%s\n' "$mk2" ;;
+      *)  printf '%s\n' "$STUBDIR/nokit" ;;
+    esac
+  }
+  acq_backend_provision multibox shell /tmp >/dev/null 2>&1
+)
+multi_log=$(cat "$CALLS")
+# Exactly ONE --script-path acq-startup staged at create (single-stake guard).
+multi_stakes=$(printf '%s\n' "$multi_log" | grep -c -- "--script-path acq-startup:")
+assert_eq "0017: multi-kit stakes exactly ONE acq-startup script" "1" "$multi_stakes"
+# NO-DROP: the exec-based apply path still ran BOTH kits' startup commands after
+# create (nothing silently dropped at runtime). Both appear via `msb exec`.
+assert_contains "0017: multi-kit runs kit-one startup via msb exec post-create" "$multi_log" "echo MULTI_STARTUP_ONE"
+assert_contains "0017: multi-kit runs kit-two startup via msb exec post-create" "$multi_log" "echo MULTI_STARTUP_TWO"
+cleanup_stubs
+
+# 8o1k. ADR-0017 NAMED-USER PATH: a startup command whose `user` is a named
+#        non-agent, non-root user emits the `su <user> -c` construct in the
+#        generated body (the run-as-user translation for arbitrary named users).
+make_stubs; load_acq
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/named-secrets"
+  export ACQ_MSB_KEEP_STARTUP_STAGE=1
+  export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/named-stage"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  nmk="$STUBDIR/namedkit"; mkdir -p "$nmk"
+  cat >"$nmk/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: named-kit
+displayName: Named Kit
+description: startup command as a named non-agent user
+commands:
+  - phase: startup
+    user: "postgres"
+    command:
+      - sh
+      - -c
+      - echo NAMED_USER_MARKER
+SPEC
+  _acq_msb_fetch_kit() { printf '%s\n' "$nmk"; }
+  acq_backend_provision namedbox shell /tmp >/dev/null 2>&1
+)
+named_file=$(find "$STUBDIR/named-stage" -type f 2>/dev/null | head -n1)
+named_body=$(cat "$named_file" 2>/dev/null)
+# The username is single-quote-escaped defensively (SI-10), so the construct is
+# `su 'postgres' -c …` — assert the su-as-that-user shape.
+assert_contains "0017: named-user startup emits su <user> -c" "$named_body" "su 'postgres' -c"
+assert_contains "0017: named-user startup command body present" "$named_body" "echo NAMED_USER_MARKER"
+# Not routed through the agent runuser path (that is only for the uid-1000 case).
+assert_not_contains "0017: named-user startup not run as agent" "$named_body" "runuser -u agent"
+cleanup_stubs
+
 # 8o2. SECURITY: a hostile kit `mode` must not reach a root shell. kit_spec_files
 #      drops the record; the msb chmod uses argv (no sh -c interpolation); and
 #      the injected command must never appear in the recorded msb calls.
@@ -2534,6 +2892,11 @@ SPEC
 out=$(ACQ_BACKEND=msb "$ACQ" kit apply mybox "$applykit" 2>/dev/null || true)
 log=$(cat "$CALLS")
 assert_contains "kit: apply (msb) runs msb exec" "$log" "msb exec mybox"
+# ADR-0017 REGRESSION: mid-life `acq kit apply` is a create-time-flag-free path —
+# a --script-path cannot register into an already-running sandbox, so mid-life
+# apply must NEVER stage a create-time startup script (it stays 100% exec-based).
+assert_not_contains "0017: mid-life apply does NOT stage a create-time script" "$log" "--script-path acq-startup"
+assert_not_contains "0017: mid-life apply runs no msb create" "$log" "msb create"
 cleanup_stubs
 
 # ===========================================================================

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -2316,6 +2316,14 @@ assert_contains "0017: metachar startup body carried as single-quoted data" "$in
 # No secret VALUE anywhere in the generated script or the create line.
 assert_not_contains "0017: secret value never in generated startup script" "$inj_body" "SUPER_SECRET_VALUE_0017"
 assert_not_contains "0017: secret value never on the create line" "$inj_log" "SUPER_SECRET_VALUE_0017"
+# Hermetic escaping lock-in: the generated body must be syntactically valid sh —
+# a broken single-quote escape (breakout) would make `sh -n` fail. This catches
+# deep-nesting/backtick/$() escaping regressions without executing the body.
+if [ -n "$inj_file" ] && sh -n "$inj_file" 2>/dev/null; then
+  pass "0017: generated startup body is valid sh (no quote breakout)"
+else
+  fail "0017: generated startup body is valid sh (no quote breakout)" "sh -n failed on $inj_file"
+fi
 cleanup_stubs
 
 # 8o1i. ADR-0017 BODY FIDELITY: the generated startup body reproduces the SAME


### PR DESCRIPTION
> **Stack #261 — PR 2 of 3.** Base: `fix/msb-secret-ls-keychain-linux` (#258). Review/merge #258 first.
> 1. #258 — `fix/msb-secret-ls-keychain-linux`
> 2. **#259 (this)** — `feat/msb-script-staging`
> 3. #260 — `feat/msb-startup-durable-restart`

## Summary

Implements **GSA-TTS/agentic-coding-quickstart#239**, reframed as the enabling groundwork for GSA-TTS/agentic-coding-quickstart#247, per **ADR-0017** (added in this PR).

On the msb backend, introduces **create-time staging of a kit's `startup`-phase commands** as a microsandbox registered script (`--script-path acq-startup:<hostfile>`). This is increment 1 and is **runtime-neutral**: it generates the script body and registers the flag at `msb create`, but does not yet enroll it in microsandbox's persisted startup, so it is not auto-run at boot. (Increment 2 — the observable restart-durability — is #260.)

## Background

#239 was originally evaluated and **rejected** in an in-code design note (keep exec-based staging; `--script` is net-negative). #247 needs the exact "parked win" that note named — a create-time-only, re-runnable script body — so ADR-0017 documents the reversal for the `startup` case only. Install and mid-life kit apply/heal **remain exec-based and unchanged**; the two mechanisms are complementary, not a fork.

## What changed

- New helpers generate a self-contained `#!/bin/sh` body for a kit's `startup` commands and register it via `--script-path`. The body faithfully reproduces the exec path's semantics: run-as-user (root direct; agent via `runuser`/`su` + `HOME`; named user via `su`), kit `environment[]` vars, git non-interactive guards, and the `background:true` nohup detach.
- The in-guest env prefix uses a **busybox-portable** construct (`env NAME=val sh -c 'exec "$@"' sh …`) — no GNU-only `--` terminator.
- Design note rewritten to reflect the ADR-0017 boundary.
- `docs/adr/0017-msb-create-time-startup-script-staging.md` added.

## Security (SI-10)

- Kit argv and env tokens are single-quote-escaped (`'` → `'\''`); the body is read **verbatim from a host file** via `--script-path`, so kit content is never interpolated into an `sh -c` string.
- Staging dir 0700, file 0600, cleaned up after `msb create` on both success and failure paths. No secret value reaches the script or the create line (asserted).

## Verification transcript

```
$ bash -n acq.backends/msb.sh                     # SYNTAX OK
$ ./scripts/test-acq                              # passed: 551  failed: 0 (at commit time)
$ npm run lint:md                                 # Summary: 0 error(s)
```
New tests: create line carries `--script-path acq-startup:<path>`; body has run-as-user/HOME/git-guards/kit-env/background-detach; no-startup→no-flag; install stays exec + excluded from the script; multi-kit single-stake with no runtime drop; named-user `su`; SI-10 quoting + no-secret.

**Live verification:** BLOCKED — this increment is runtime-neutral and offline-covered; the observable behavior lands in #260, which requires a KVM host. Reviewer (repo owner) will run `scripts/verify-backends` on a KVM host before this stack is marked ready.

## Rollback

Revert this commit; startup commands continue to be applied exec-based at provision/heal exactly as before (this increment adds staging only).

## Review

Independent code review (verdict APPROVE-WITH-NITS); both SHOULD-FIX items addressed (busybox `env` portability; added git-guard/kit-env/multi-kit/named-user body-fidelity tests) and the ADR Links over-claim corrected. Boot-auto-run assumption documented in-code.

---
_AI-assisted (OpenCode); requires human review._
