### PR TITLE
docs: document macOS Gatekeeper block on sbx helper mkfs.erofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,17 +96,38 @@ sbx login
 ```
 
 > [!NOTE]
-> macOS may prompt you to approve helper binaries the first time you use `sbx`. Allow these if
-> prompted:
+> **macOS Gatekeeper will block `sbx` helper binaries — this is an `sbx`
+> dependency issue, not a Quickstart/`acq` bug, and it is expected.** On recent
+> macOS (including Tahoe/26), the block commonly appears at **Step 3**
+> (`sbx policy init balanced`) — the first command that builds a sandbox
+> filesystem — not only at `sbx login`. `sbx` invokes helper binaries that are
+> not Apple-notarized, so macOS blocks their first run with
+> *"…cannot be opened because the developer cannot be verified."* Affected
+> helpers:
 >
-> - `mkfs.erofs`
+> - `mkfs.erofs` (from the Homebrew `erofs-utils` package, a `docker/tap/sbx` dependency)
 > - `mkfs.ext4`
 > - `containerd-shim-nerdbox-v1`
 >
-> ---
+> **Fix (do this — it is the reliable one):**
 >
-> macOS may say sbx is not from a "trusted developer" and block it. In this case you will need to open System Preferences/Privacy
-> & Security/Security, and click the "Allow anyway" button. Run `sbx login` again and click "Allow anyway" in the popup.
+> 1. Open **System Settings → Privacy & Security**.
+> 2. Find the blocked binary and click **"Allow Anyway"**.
+> 3. Re-run the command, then click **"Open"** on the pop-up.
+>
+> Repeat for each helper if prompted. macOS may also block the `sbx` binary
+> itself the same way (*"sbx is not from a trusted developer"*) — allow it via
+> the same flow, then run `sbx login` again and click "Allow Anyway" in the popup.
+>
+> > **Do NOT bother with `xattr`.** `xattr -d com.apple.quarantine <path>` does
+> > **not** clear this, even with `sudo` — for an unnotarized binary the block is
+> > enforced by macOS code-signing assessment, not just the quarantine attribute.
+> > Only the System Settings "Allow Anyway" step above works.
+>
+> This affects the external `sbx` tool (we do not ship or invoke these binaries).
+> See [`docs/KNOWN_FAILURE_MODES.md`](docs/KNOWN_FAILURE_MODES.md) for details; an
+> upstream request to notarize these helpers has been filed with the Docker `sbx`
+> team.
 
 </details>
 
@@ -238,7 +259,7 @@ in the list of allowed network destinations.
 > to show **Verified** on GitHub you need, one time: a GitHub-verified
 > `user.email` set **in the project** (repo-local config, since the sandbox has
 > its own home and does not see your host global git config) and your **public**
-> signing key registered on GitHub as a _Signing Key_. See
+> signing key registered on GitHub as a *Signing Key*. See
 > [Commits show "Unverified" on GitHub](#troubleshooting) below.
 
 ### Step 4: Create and run a sandbox (as often as you like)
@@ -342,8 +363,8 @@ git config user.name  "Your Name"
 ```
 
 **Step 2 — register your signing key on GitHub.** Add the **public** half of your
-signing key as a **Signing Key**: _Settings → SSH and GPG keys → New SSH key →
-Key type: **Signing Key**_. (The same key may already be an authentication key;
+signing key as a **Signing Key**: *Settings → SSH and GPG keys → New SSH key →
+Key type: **Signing Key***. (The same key may already be an authentication key;
 add it again as a signing key.)
 
 Then make a **new** commit — verification applies going forward.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ sbx login
 > This affects the external `sbx` tool (we do not ship or invoke these binaries).
 > See [`docs/KNOWN_FAILURE_MODES.md`](docs/KNOWN_FAILURE_MODES.md) for details; an
 > upstream request to notarize these helpers has been filed with the Docker `sbx`
-> team.
+> team ([docker/sbx-releases#392](https://github.com/docker/sbx-releases/issues/392)).
 
 </details>
 

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1267,7 +1267,8 @@ code-signing gate on an unnotarized binary.
 
 - We cannot fix this in this repo (the helper is shipped and invoked by the
   external Docker `sbx` tool). An **upstream request to notarize these helper
-  binaries has been filed with the Docker `sbx` team.**
+  binaries has been filed with the Docker `sbx` team:
+  [docker/sbx-releases#392](https://github.com/docker/sbx-releases/issues/392).**
 - Until sbx notarizes them, the System Settings "Allow Anyway" flow above is the
   expected one-time step per new macOS machine.
 

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1204,6 +1204,75 @@ Then `./acq run opencode <path>` (or `sbx run <sandbox>`) works.
 
 ---
 
+## 26. macOS Gatekeeper Blocks `mkfs.erofs` (an sbx Helper) at `sbx policy init`
+
+### Symptoms
+
+On a clean `sbx` install on macOS (seen on **Tahoe / macOS 26**, Apple Silicon),
+**Step 3** of the quickstart — `sbx policy init balanced` — fails when macOS
+blocks a helper binary:
+
+```
+"mkfs.erofs" cannot be opened because the developer cannot be verified.
+macOS cannot verify that this app is free from malware.
+```
+
+The same block can appear for `mkfs.ext4` and `containerd-shim-nerdbox-v1`, and
+sometimes for the `sbx` binary itself. It often surfaces at
+`sbx policy init balanced` (the first command that builds a sandbox filesystem),
+not only at `sbx login`.
+
+`xattr -d com.apple.quarantine /opt/homebrew/bin/mkfs.erofs` does **not** clear
+it — even run with `sudo`.
+
+### Root Cause
+
+This is an **`sbx` dependency + macOS notarization** interaction, **not** a
+Quickstart, `acq`, or `msb` issue, and **not** a supply-chain compromise:
+
+- `sbx` invokes `mkfs.erofs` to build its sandbox rootfs/overlay layer.
+- `mkfs.erofs` ships from the Homebrew `erofs-utils` formula, which the
+  `docker/tap/sbx` formula pulls in as a dependency. This repo never installs or
+  invokes it.
+- That helper is **not Apple-notarized**. On recent macOS (Tahoe removed the
+  lenient CLI "open anyway" path), first execution of an unnotarized binary is
+  blocked by the code-signing assessment (AMFI / `syspolicyd`), not merely by the
+  `com.apple.quarantine` extended attribute — which is why removing the xattr
+  does nothing.
+- On a **clean install** the freshly downloaded helper is quarantined, so the
+  first sandbox operation (`sbx policy init balanced`) triggers the block
+  deterministically for new macOS users.
+
+The `erofs-utils` Homebrew formula itself was reviewed (source is kernel.org,
+tarball + bottles are SHA256-pinned, recent history is routine maintainer version
+bumps) — no tampering. The problem is purely the missing notarization of an
+sbx-bundled helper.
+
+### Fix
+
+Approve the blocked binary via System Settings — this is the reliable fix:
+
+1. Open **System Settings → Privacy & Security**.
+2. Scroll to the security prompt for the blocked binary (e.g. `mkfs.erofs`) and
+   click **"Allow Anyway"**.
+3. Re-run the command (`sbx policy init balanced`), then click **"Open"** on the
+   confirmation pop-up.
+4. Repeat for `mkfs.ext4` / `containerd-shim-nerdbox-v1` (and the `sbx` binary
+   itself) if you are prompted for them too.
+
+Do **not** rely on `xattr -d com.apple.quarantine` — it does not satisfy the
+code-signing gate on an unnotarized binary.
+
+### Prevention / Status
+
+- We cannot fix this in this repo (the helper is shipped and invoked by the
+  external Docker `sbx` tool). An **upstream request to notarize these helper
+  binaries has been filed with the Docker `sbx` team.**
+- Until sbx notarizes them, the System Settings "Allow Anyway" flow above is the
+  expected one-time step per new macOS machine.
+
+---
+
 ## Debugging Checklist
 
 When something fails, work through this list:

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -90,6 +90,15 @@ sbx policy allow network "api.gsa.usai.gov"
 sbx policy ls
 ```
 
+> **macOS:** the first time `sbx policy init balanced` builds a sandbox
+> filesystem, macOS Gatekeeper may block an unnotarized `sbx` helper binary
+> (`mkfs.erofs`, `mkfs.ext4`, or `containerd-shim-nerdbox-v1`) with *"…cannot be
+> opened because the developer cannot be verified."* Approve it via **System
+> Settings → Privacy & Security → "Allow Anyway"**, then re-run and click "Open".
+> `xattr -d com.apple.quarantine` does **not** work. This is an external `sbx`
+> dependency issue — see
+> [KNOWN_FAILURE_MODES.md](KNOWN_FAILURE_MODES.md#26-macos-gatekeeper-blocks-mkfserofs-an-sbx-helper-at-sbx-policy-init).
+
 ### Understanding Network Policies
 
 | Policy | Description | Use Case |


### PR DESCRIPTION
## Summary

A user hit a macOS Gatekeeper block on a **clean sbx install** (macOS **Tahoe/26**, Apple Silicon) at quickstart **Step 3** (`sbx policy init balanced`): the unnotarized helper `mkfs.erofs` fails first-run verification. This documents the cause and the reliable fix.

## Root cause (investigated)

- `sbx` invokes `mkfs.erofs` to build its sandbox filesystem. That binary ships from the Homebrew `erofs-utils` formula, pulled in as a **dependency of `docker/tap/sbx`**. This repo never installs or invokes it.
- The helper is **not Apple-notarized**; recent macOS blocks first-run via the code-signing assessment (AMFI/`syspolicyd`), so `xattr -d com.apple.quarantine` (even sudo) does **not** clear it — only System Settings → Privacy & Security → **Allow Anyway** does.
- On a **clean install** this is deterministic for new macOS users.
- **Not a supply-chain compromise:** I reviewed the `erofs-utils` formula — kernel.org source, SHA256-pinned tarball + bottles, routine maintainer version bumps, no tampering. This is purely a missing-notarization gap in an sbx-bundled helper.

## Changes (docs-only)

- **README.md** — expand the macOS helper-binary NOTE: it can appear at **Step 3** (not only `sbx login`), the Allow-Anyway flow applies to the helper binaries, and `xattr` does not work. Also fixes **4 pre-existing MD049 emphasis-style lint errors** in the git-signing section (underscore → asterisk) that were already on `main` (verified against `origin/main:README.md`), so the docs lint is green.
- **docs/KNOWN_FAILURE_MODES.md** — new entry 26 (Symptoms / Root Cause / Fix / Status).
- **docs/QUICKSTART_SBX.md** — macOS caveat at Step 2 cross-referencing the above.

## Upstream

An upstream request to notarize these helper binaries is being filed with the Docker `sbx` team (the fix has to happen there; we can't notarize their dependency).

## Verification

- `npm run lint:md` → 0 errors.
- Docs-only; no code/behavior change.

## Note

The 4 MD049 fixes are pre-existing errors that merged with GSA-TTS/agentic-coding-quickstart#233 — flagging separately that its Markdown Lint check may not have caught them.

AI-assisted (OpenCode); requires human review.