### PR TITLE
docs: add KNOWN_FAILURE_MODES entry for opencode postinstall gap in sbx image

### DIFF
--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1138,6 +1138,72 @@ ASSUMPTION" note in `_acq_msb_stage_startup_script` (`acq.backends/msb.sh`).
 
 ---
 
+## 29. `opencode-ai's postinstall script was not run` on a Fresh sbx Sandbox
+
+### Symptoms
+
+A newly created **sbx** `opencode` sandbox fails at launch (the image pull
+succeeds, then the agent exits 1):
+
+```
+Error: opencode-ai's postinstall script was not run.
+
+This occurs when using --ignore-scripts during installation, or when using a
+package manager like pnpm that does not run postinstall scripts by default.
+
+To fix this, run the postinstall script manually:
+  cd node_modules/opencode-ai && node postinstall.mjs
+```
+
+Often appears right after a fresh image pull. Seen with `opencode-ai@1.18.12` on
+macOS/Apple Silicon, sbx v0.37.1.
+
+### Root Cause
+
+This is in the **Docker `sandbox-templates:opencode-docker` image**, not in
+`acq`, the quickstart, or your local setup. On the **sbx** backend opencode is
+baked into that image (acq does not install it — that only happens on the msb
+backend). Since opencode v1.15.1, the `opencode-ai` npm package needs its
+**postinstall** step to fetch the actual platform binary. The image appears to
+install `opencode-ai` at **build time** with lifecycle scripts skipped (e.g.
+`npm ci --ignore-scripts`, or pnpm/bun which skip postinstall by default), so the
+binary is missing in the shipped image and opencode's guard fires on first run.
+
+Evidence it is a build-time script-skip, not your environment (run inside the
+sandbox): `npm config get ignore-scripts` returns `false` (so nothing is
+disabling scripts at runtime), yet `npm ls -g opencode-ai` shows the package
+present without a working binary — the postinstall simply never ran when the
+image was built.
+
+Not a supply-chain compromise and not related to the recent quickstart changes;
+a fresh image pull just fetched a newer opencode build with this gap.
+
+### Fix
+
+Run opencode's own postinstall inside the sandbox, then re-run:
+
+```bash
+sbx exec <sandbox-name> -- sh -c 'cd "$(npm root -g)/opencode-ai" && node postinstall.mjs'
+sbx exec <sandbox-name> -- opencode --version   # confirm the binary now runs
+```
+
+Then `./acq run opencode <path>` (or `sbx run <sandbox>`) works.
+
+### Prevention / Status
+
+- We cannot fix this in this repo — the image is built and shipped by Docker.
+  An upstream report has been filed:
+  [docker/sbx-releases#395](https://github.com/docker/sbx-releases/issues/395).
+  Related upstream: [anomalyco/opencode#27906](https://github.com/anomalyco/opencode/issues/27906)
+  (opencode requires postinstall to fetch its binary since v1.15.1).
+- If a rebuilt image still ships the gap, the manual `node postinstall.mjs` above
+  is the reliable per-sandbox workaround.
+- The **msb** backend installs opencode itself (`npm install -g`, scripts
+  enabled) rather than using this image, so it is a possible alternative if the
+  sbx image stays broken — though it may hit the same opencode packaging issue.
+
+---
+
 ## Debugging Checklist
 
 When something fails, work through this list:


### PR DESCRIPTION
## Summary

A user hit `opencode-ai's postinstall script was not run` at launch on a **fresh sbx** `opencode` sandbox (opencode-ai@1.18.12, sbx v0.37.1, macOS/Apple Silicon). This documents the cause and the fix.

## Root cause (investigated)

Upstream, not us. On the **sbx** backend opencode is baked into Docker's `sandbox-templates:opencode-docker` image (acq only installs opencode on the **msb** backend). Since opencode v1.15.1 the `opencode-ai` package needs its **postinstall** to fetch the platform binary; the image installs the package at build time with lifecycle scripts skipped, so the binary is missing and opencode's guard fires on first run.

Confirmed it is a build-time script-skip, not the user's environment: inside the sandbox `npm config get ignore-scripts` returns `false` yet the postinstall never ran; `node postinstall.mjs` fixes it (`opencode --version` → 1.18.12). Not a supply-chain compromise; a fresh image pull just fetched a newer opencode build with this gap.

## Change (docs-only)

Adds `KNOWN_FAILURE_MODES.md` entry **29** (Symptoms / Root Cause / Fix / Status) with the in-sandbox `node postinstall.mjs` workaround. Numbered 29 to avoid colliding with entry 26 (macOS Gatekeeper) landing in #263.

## Upstream

Filed [docker/sbx-releases#395](https://github.com/docker/sbx-releases/issues/395) (the template image ships opencode-ai without its postinstalled binary), referencing [anomalyco/opencode#27906](https://github.com/anomalyco/opencode/issues/27906).

## Verification

`npm run lint:md` → 0 errors. Docs-only; no behavior change.

AI-assisted (OpenCode); requires human review.