### PR TITLE
fix: Add -f to sbx rm command to cleanup rotation validation sandbox

### DIFF
--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -1066,7 +1066,7 @@ acq_backend_rotate_key() {
   # particular pre-existing sandbox. Created here, removed on exit.
   local validation_sbx="acq-keycheck-$$"
   # shellcheck disable=SC2064
-  trap "sbx rm '$validation_sbx' >/dev/null 2>&1 || true" EXIT
+  trap "sbx rm '$validation_sbx' -f >/dev/null 2>&1 || true" EXIT
 
   echo "Validating new key in a temporary sandbox..." >&2
   # `sbx create` needs an authenticated sbx session. If it has expired, sbx
@@ -1101,7 +1101,7 @@ acq_backend_rotate_key() {
       -H \"Authorization: Bearer \$USAI_API_KEY\" \
       $usai_models_url" 2>/dev/null || true)
 
-  sbx rm "$validation_sbx" >/dev/null 2>&1 || true
+  acq_backend_terminate "$validation_sbx" >/dev/null 2>&1 || true
   trap - EXIT
 
   if [ "$status" = "200" ]; then


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Ensure that `sbx rm` is using the `--force` flag to cleanup the usai key rotation validation sandbox. Previously, it appeared that the validation script was just hanging (took hitting `<enter>` to get it to move along) and the sandbox didn't get cleaned up properly. This was due to the confirmation prompt being redirected to `/dev/null`.

## Related Issues

<!-- Link to related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits format](../CONTRIBUTING.md#commit-message-guidelines) (e.g., `feat:`, `fix:`, `docs:`)
- [x] I have tested my changes locally
- [x] I have updated documentation as needed
- [x] I have not included any secrets, API keys, or sensitive information

## Test Results

<!-- How did you verify this works? Include commands run or screenshots -->
Ran multiple rotations before and after the change to verify behavior.

## Additional Notes

<!-- Any additional context reviewers should know -->
