### PR TITLE
docs: correct mkfs.erofs Gatekeeper root cause to PATH shadowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,38 +96,36 @@ sbx login
 ```
 
 > [!NOTE]
-> **macOS Gatekeeper will block `sbx` helper binaries — this is an `sbx`
-> dependency issue, not a Quickstart/`acq` bug, and it is expected.** On recent
-> macOS (including Tahoe/26), the block commonly appears at **Step 3**
-> (`sbx policy init balanced`) — the first command that builds a sandbox
-> filesystem — not only at `sbx login`. `sbx` invokes helper binaries that are
-> not Apple-notarized, so macOS blocks their first run with
-> *"…cannot be opened because the developer cannot be verified."* Affected
-> helpers:
+> **macOS Gatekeeper may block `mkfs.erofs` at first sandbox build — this is an
+> `sbx` PATH-resolution bug, not a Quickstart/`acq` bug.** On macOS (including
+> Tahoe/26) the block commonly appears at **Step 3** (`sbx policy init balanced`)
+> with *"mkfs.erofs cannot be opened because the developer cannot be verified."*
+> It only happens if you also have Homebrew `erofs-utils` installed:
 >
-> - `mkfs.erofs` (from the Homebrew `erofs-utils` package, a `docker/tap/sbx` dependency)
-> - `mkfs.ext4`
-> - `containerd-shim-nerdbox-v1`
+> `sbx` ships its **own notarized** `mkfs.erofs` (in its Caskroom `libexec/`),
+> but invokes it via `$PATH`. If Homebrew `erofs-utils` is installed,
+> `/opt/homebrew/bin/mkfs.erofs` — which is **ad-hoc-signed / not notarized** —
+> is earlier on `$PATH` and shadows sbx's bundled copy, so Gatekeeper rejects it.
 >
-> **Fix (do this — it is the reliable one):**
+> **Fix (reliable): make sbx use its own notarized binary.**
 >
-> 1. Open **System Settings → Privacy & Security**.
-> 2. Find the blocked binary and click **"Allow Anyway"**.
-> 3. Re-run the command, then click **"Open"** on the pop-up.
+> ```bash
+> brew uninstall erofs-utils   # if nothing else needs it
+> ```
 >
-> Repeat for each helper if prompted. macOS may also block the `sbx` binary
-> itself the same way (*"sbx is not from a trusted developer"*) — allow it via
-> the same flow, then run `sbx login` again and click "Allow Anyway" in the popup.
+> If you can't remove it, approve the Homebrew binary via **System Settings →
+> Privacy & Security → "Allow Anyway"**, re-run the command, then click **"Open"**.
 >
 > > **Do NOT bother with `xattr`.** `xattr -d com.apple.quarantine <path>` does
 > > **not** clear this, even with `sudo` — for an unnotarized binary the block is
-> > enforced by macOS code-signing assessment, not just the quarantine attribute.
-> > Only the System Settings "Allow Anyway" step above works.
+> > enforced by macOS code-signing assessment, not the quarantine attribute.
+> > (macOS may also block the `sbx` binary itself the same way — allow it via the
+> > same System Settings flow, then run `sbx login` again.)
 >
-> This affects the external `sbx` tool (we do not ship or invoke these binaries).
-> See [`docs/KNOWN_FAILURE_MODES.md`](docs/KNOWN_FAILURE_MODES.md) for details; an
-> upstream request to notarize these helpers has been filed with the Docker `sbx`
-> team ([docker/sbx-releases#392](https://github.com/docker/sbx-releases/issues/392)).
+> This is in the external `sbx` tool. See
+> [`docs/KNOWN_FAILURE_MODES.md`](docs/KNOWN_FAILURE_MODES.md) for details; the
+> upstream fix (have sbx call its bundled binary by absolute path) is tracked at
+> [docker/sbx-releases#392](https://github.com/docker/sbx-releases/issues/392).
 
 </details>
 

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1204,73 +1204,70 @@ Then `./acq run opencode <path>` (or `sbx run <sandbox>`) works.
 
 ---
 
-## 26. macOS Gatekeeper Blocks `mkfs.erofs` (an sbx Helper) at `sbx policy init`
+## 26. macOS Gatekeeper Blocks `mkfs.erofs` at `sbx policy init` (PATH shadowing)
 
 ### Symptoms
 
-On a clean `sbx` install on macOS (seen on **Tahoe / macOS 26**, Apple Silicon),
-**Step 3** of the quickstart — `sbx policy init balanced` — fails when macOS
-blocks a helper binary:
+On macOS (seen on **Tahoe / macOS 26**, Apple Silicon), `sbx policy init balanced`
+— the first command that builds a sandbox filesystem — fails when macOS blocks a
+helper binary:
 
 ```
 "mkfs.erofs" cannot be opened because the developer cannot be verified.
 macOS cannot verify that this app is free from malware.
 ```
 
-The same block can appear for `mkfs.ext4` and `containerd-shim-nerdbox-v1`, and
-sometimes for the `sbx` binary itself. It often surfaces at
-`sbx policy init balanced` (the first command that builds a sandbox filesystem),
-not only at `sbx login`.
-
 `xattr -d com.apple.quarantine /opt/homebrew/bin/mkfs.erofs` does **not** clear
-it — even run with `sudo`.
+it — even run with `sudo`. It only happens on machines that also have Homebrew
+`erofs-utils` installed; users without it never see the block.
 
 ### Root Cause
 
-This is an **`sbx` dependency + macOS notarization** interaction, **not** a
-Quickstart, `acq`, or `msb` issue, and **not** a supply-chain compromise:
+This is an **`sbx` PATH-resolution bug**, **not** a Quickstart / `acq` / `msb`
+issue, and **not** a supply-chain compromise. sbx ships its own **notarized**
+`mkfs.erofs`, but invokes it via `$PATH`, so a Homebrew `erofs-utils` shadows the
+bundled copy:
 
-- `sbx` invokes `mkfs.erofs` to build its sandbox rootfs/overlay layer.
-- `mkfs.erofs` ships from the Homebrew `erofs-utils` formula, which the
-  `docker/tap/sbx` formula pulls in as a dependency. This repo never installs or
-  invokes it.
-- That helper is **not Apple-notarized**. On recent macOS (Tahoe removed the
-  lenient CLI "open anyway" path), first execution of an unnotarized binary is
-  blocked by the code-signing assessment (AMFI / `syspolicyd`), not merely by the
-  `com.apple.quarantine` extended attribute — which is why removing the xattr
-  does nothing.
-- On a **clean install** the freshly downloaded helper is quarantined, so the
-  first sandbox operation (`sbx policy init balanced`) triggers the block
-  deterministically for new macOS users.
+- sbx v0.37.1 bundles a notarized `mkfs.erofs` at
+  `/opt/homebrew/Caskroom/sbx/<version>/libexec/mkfs.erofs`
+  (`spctl` → *accepted*; Developer ID: **Docker Inc (9BNSXJN65R)**).
+- If Homebrew `erofs-utils` is also installed, `/opt/homebrew/bin/mkfs.erofs`
+  (a symlink into `Cellar/erofs-utils/…`) is earlier on `$PATH`. That binary is
+  **ad-hoc-signed / not notarized** (`spctl` → *rejected*, `Signature=adhoc`,
+  no TeamIdentifier).
+- sbx resolves `mkfs.erofs` from `$PATH`, picks up the unnotarized Homebrew
+  binary instead of its own, and macOS Gatekeeper rejects it.
+- There is **no `com.apple.quarantine` xattr** on the rejected binary — the block
+  is the code-signing / AMFI (`syspolicyd`) assessment, which is why removing the
+  xattr does nothing.
 
-The `erofs-utils` Homebrew formula itself was reviewed (source is kernel.org,
-tarball + bottles are SHA256-pinned, recent history is routine maintainer version
-bumps) — no tampering. The problem is purely the missing notarization of an
-sbx-bundled helper.
+The `erofs-utils` Homebrew formula itself is fine (kernel.org source,
+SHA256-pinned bottles). The problem is purely that sbx's PATH lookup picks the
+unnotarized system copy over its own notarized bundled one.
 
 ### Fix
 
-Approve the blocked binary via System Settings — this is the reliable fix:
+Make sbx use its own notarized binary — remove the shadowing Homebrew copy from
+PATH:
 
-1. Open **System Settings → Privacy & Security**.
-2. Scroll to the security prompt for the blocked binary (e.g. `mkfs.erofs`) and
-   click **"Allow Anyway"**.
-3. Re-run the command (`sbx policy init balanced`), then click **"Open"** on the
-   confirmation pop-up.
-4. Repeat for `mkfs.ext4` / `containerd-shim-nerdbox-v1` (and the `sbx` binary
-   itself) if you are prompted for them too.
+```bash
+brew uninstall erofs-utils    # if nothing else needs it; sbx then uses its bundled, notarized mkfs.erofs
+```
 
-Do **not** rely on `xattr -d com.apple.quarantine` — it does not satisfy the
-code-signing gate on an unnotarized binary.
+If you cannot remove it, approve the Homebrew binary via **System Settings →
+Privacy & Security → "Allow Anyway"**, then re-run the command and click **"Open"**
+on the pop-up. Do **not** rely on `xattr -d com.apple.quarantine` — it does not
+satisfy the code-signing gate on an unnotarized binary.
 
 ### Prevention / Status
 
-- We cannot fix this in this repo (the helper is shipped and invoked by the
-  external Docker `sbx` tool). An **upstream request to notarize these helper
-  binaries has been filed with the Docker `sbx` team:
-  [docker/sbx-releases#392](https://github.com/docker/sbx-releases/issues/392).**
-- Until sbx notarizes them, the System Settings "Allow Anyway" flow above is the
-  expected one-time step per new macOS machine.
+- The durable fix is upstream in `sbx`: invoke the bundled
+  `libexec/mkfs.erofs` by absolute path rather than resolving `mkfs.erofs` from
+  `$PATH`. The bundled binary is already notarized, so no notarization change is
+  needed. Tracked at
+  [docker/sbx-releases#392](https://github.com/docker/sbx-releases/issues/392).
+- Until sbx pins the path, `brew uninstall erofs-utils` (or the "Allow Anyway"
+  fallback) unblocks affected machines.
 
 ---
 

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -91,13 +91,14 @@ sbx policy ls
 ```
 
 > **macOS:** the first time `sbx policy init balanced` builds a sandbox
-> filesystem, macOS Gatekeeper may block an unnotarized `sbx` helper binary
-> (`mkfs.erofs`, `mkfs.ext4`, or `containerd-shim-nerdbox-v1`) with *"…cannot be
-> opened because the developer cannot be verified."* Approve it via **System
-> Settings → Privacy & Security → "Allow Anyway"**, then re-run and click "Open".
-> `xattr -d com.apple.quarantine` does **not** work. This is an external `sbx`
-> dependency issue — see
-> [KNOWN_FAILURE_MODES.md](KNOWN_FAILURE_MODES.md#26-macos-gatekeeper-blocks-mkfserofs-an-sbx-helper-at-sbx-policy-init).
+> filesystem, macOS Gatekeeper may block `mkfs.erofs` with *"…cannot be opened
+> because the developer cannot be verified"* — but only if you also have Homebrew
+> `erofs-utils` installed (sbx invokes `mkfs.erofs` from `$PATH` and picks up the
+> unnotarized Homebrew copy instead of its own notarized bundled one). Fix:
+> `brew uninstall erofs-utils` (so sbx uses its bundled binary), or approve the
+> Homebrew binary via **System Settings → Privacy & Security → "Allow Anyway"**
+> and re-run. `xattr -d com.apple.quarantine` does **not** work. Details:
+> [KNOWN_FAILURE_MODES.md](KNOWN_FAILURE_MODES.md#26-macos-gatekeeper-blocks-mkfserofs-at-sbx-policy-init-path-shadowing).
 
 ### Understanding Network Policies
 


### PR DESCRIPTION
## Summary

Corrects KNOWN_FAILURE_MODES entry 26 (+ the README NOTE and QUICKSTART_SBX caveat) now that we have the confirmed root cause from an affected machine (via upstream [docker/sbx-releases#392](https://github.com/docker/sbx-releases/issues/392)).

## What changed in the diagnosis

The original entry (merged in #263) attributed the Gatekeeper block to an "unnotarized `erofs-utils` cask dependency." Diagnostics on an affected machine disproved that:

| | sbx-bundled `Caskroom/sbx/0.37.1/libexec/mkfs.erofs` | Homebrew `/opt/homebrew/bin/mkfs.erofs` |
|---|---|---|
| `spctl -a -t install` | **accepted** | **rejected** |
| signing | **Notarized Developer ID — Docker Inc (9BNSXJN65R)** | **ad-hoc**, no TeamIdentifier |
| sha256 | `df5c5a71…` | `be91c6b9…` (different build) |

**Real mechanism:** sbx ships its own *notarized* `mkfs.erofs` but invokes it via `$PATH`; if Homebrew `erofs-utils` is installed, its ad-hoc/unnotarized binary shadows sbx's bundled copy, so Gatekeeper rejects it. Users without Homebrew `erofs-utils` never see it. No `com.apple.quarantine` xattr is present — the block is the code-signing/AMFI assessment (why `xattr` removal never worked).

## Changes (docs-only)

- **KNOWN_FAILURE_MODES entry 26** rewritten: PATH-shadowing root cause, two-binary evidence, fix leads with `brew uninstall erofs-utils` (Allow-Anyway as fallback), upstream ask corrected to "sbx should invoke its bundled `libexec/mkfs.erofs` by absolute path" (no notarization change needed). Heading + anchor updated.
- **README NOTE** and **QUICKSTART_SBX caveat** updated to match; QUICKSTART_SBX anchor points at the new entry-26 slug.

## Verification

`npm run lint:md` → 0 errors. Docs-only; no behavior change.

AI-assisted (OpenCode); requires human review.