### PR TITLE
docs: make sbx exec the primary fix for the opencode postinstall gap

### DIFF
--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1180,14 +1180,30 @@ a fresh image pull just fetched a newer opencode build with this gap.
 
 ### Fix
 
-Run opencode's own postinstall inside the sandbox, then re-run:
+Apply the fix with **`sbx exec`**, not `sbx run` / `acq run`. `sbx run` and
+`acq run` **launch opencode**, which re-hits the missing-binary guard and exits
+before you can do anything — so you cannot fix it from a `run`. `sbx exec` runs a
+command in the sandbox **without launching the agent**, so it works even when
+`run` fails.
 
 ```bash
+# 1. Find the sandbox that was created (its name, e.g. opencode-<project>):
+sbx ls
+
+# 2. Run opencode's postinstall inside it via sbx exec (no agent launch):
 sbx exec <sandbox-name> -- sh -c 'cd "$(npm root -g)/opencode-ai" && node postinstall.mjs'
 sbx exec <sandbox-name> -- opencode --version   # confirm the binary now runs
+
+# 3. Now attach normally:
+./acq run opencode <path>          # or: sbx run <sandbox-name>
 ```
 
-Then `./acq run opencode <path>` (or `sbx run <sandbox>`) works.
+If `sbx exec` reports the sandbox is not running, start it first
+(`sbx start <sandbox-name>`) then re-run the exec.
+
+> Do **not** try to "run the fix inside the sandbox" by launching it — a fresh
+> `./acq run` / `sbx run` just re-triggers the error. The `sbx exec` path above
+> is what works from a failed launch (confirmed by affected users).
 
 ### Prevention / Status
 


### PR DESCRIPTION
## Summary

Two affected users hit a dead end applying KNOWN_FAILURE_MODES entry 29: the workaround said "run inside the sandbox, then retry `./acq run`", but `acq run` / `sbx run` **launch opencode**, which re-hits the missing-binary guard and exits — so you can't apply the fix from a run. `sbx exec` runs a command **without** launching the agent, and works from a failed launch (user-confirmed: `sbx exec <name> -- opencode --version` succeeded where `sbx run` kept failing).

## Change (docs-only)

Rewrite entry 29's **Fix** to:
1. Find the created sandbox with `sbx ls`.
2. Run the postinstall via `sbx exec <name> -- sh -c '…node postinstall.mjs'` (no agent launch).
3. Then attach with `./acq run opencode <path>`.

Plus an explicit note **not** to apply the fix via a `run` (it re-triggers the error) and a `sbx start` fallback if the sandbox is stopped.

## Verification

`npm run lint:md` → 0 errors. Docs-only; no behavior change.

Relates to [docker/sbx-releases#395](https://github.com/docker/sbx-releases/issues/395).

AI-assisted (OpenCode); requires human review.