### PR TITLE
docs: public-readiness governance files (SECURITY, CODE_OF_CONDUCT, CONTRIBUTING)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Code of Conduct
+
+## Our standard
+
+This project is part of the U.S. General Services Administration's Technology
+Transformation Services (GSA TTS). We are committed to providing a welcoming,
+respectful, and professional environment for everyone who takes part in this
+community — maintainers, contributors, and members of the public.
+
+We expect all participants to:
+
+- Be respectful and professional in all interactions.
+- Use clear, plain language and assume good faith.
+- Give and accept constructive feedback gracefully.
+- Focus on what is best for the community and the work.
+
+The following behavior is not tolerated:
+
+- Harassment or discrimination of any kind.
+- Insulting, demeaning, or derogatory comments, or personal attacks.
+- Publishing others' private information without their explicit permission.
+- Sexualized language or imagery, or unwelcome sexual attention.
+- Any other conduct that would reasonably be considered inappropriate in a
+  professional setting.
+
+## Federal Community Addendum
+
+This addendum **supplements** the standard above; it does not replace it. Where
+any conflict exists, the stricter expectation applies.
+
+- **Federal government community space.** This is a U.S. federal government
+  community. Participants include federal employees and contractors, and the
+  professional conduct expectations of the federal workplace apply here.
+- **Critique the work, never the person.** This repository maintains a
+  contribution-quality bar. All feedback on a contribution — including quality
+  and scope feedback — MUST target the *artifact* (a pull request, document, or
+  idea), never the contributor or any aspect of their identity. Saying "this PR
+  is out of scope for this repo" is fine; making it about the person is not.
+- **No sensitive data, anywhere.** Do not post secrets, credentials, PII, CUI,
+  or non-public government data in any issue, pull request, comment, example, or
+  other interaction. This mirrors the repository's prohibited-content rules.
+- **Plain language and accessibility are community values.** Prefer clear,
+  plain-language communication and accessible content, consistent with GSA
+  norms.
+- **Assume good faith.** Most mis-scoped or low-quality contributions are honest
+  mistakes, not bad-faith conduct. Quality and scope issues are handled through
+  normal review — not through conduct enforcement. Reserve conduct enforcement
+  for *conduct*, not for contribution quality or scope.
+- **Accountability is about the artifact, not the person.** If a contributor
+  cannot explain a change, that is **feedback on the code** — the change simply
+  isn't ready to merge yet, and it is handled through normal code review. It is
+  **never** misconduct and is never a judgment about the contributor as a person.
+  Do not use an accountability or quality finding as a backdoor conduct sanction.
+
+## Scope
+
+This Code of Conduct applies within all project spaces (issues, pull requests,
+comments, and other repository interactions) and when an individual is
+officially representing the project in public spaces.
+
+## Reporting and enforcement
+
+To report a code-of-conduct concern for this project, email
+**agentic-coding@gsa.gov** with the subject prefixed `[CONDUCT]`. Reports are
+read by the repository maintainers, who will review and respond as promptly and
+fairly as they reasonably can, and who will respect the privacy of the reporter.
+
+Maintainers are responsible for clarifying and enforcing this standard and may
+take any action they deem appropriate, up to and including removing content or
+barring a participant from the project, in response to behavior that violates
+this Code of Conduct.
+
+Security vulnerabilities are **not** handled here — see
+[SECURITY.md](SECURITY.md) for how to report those.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,9 +380,16 @@ Releases are **fully automated** via GitHub Actions and release-please:
 
 ---
 
-## License
+## Public domain
 
-This project is released under the CC0 1.0 Universal license. See `LICENSE` for details.
+This project is in the public domain within the United States, and copyright and
+related rights in the work worldwide are waived through the
+[CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+See [`LICENSE`](LICENSE) for details.
+
+All contributions to this project will be released under the CC0 dedication. By
+submitting a pull request or issue, you are agreeing to comply with this waiver
+of copyright interest.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,60 +1,46 @@
 # Security Policy
 
+## About this repository
+
+The `agentic-coding-quickstart` provides the `acq` sandbox tooling and setup
+guidance for running AI coding agents in isolated environments. It is shell and
+documentation — there is no hosted service, and it processes no user data.
+
+Because of that, the security issues that matter here are things like: unsafe
+example commands, a supply-chain problem in the tooling, credentials accidentally
+committed to the repository, or a sandbox-isolation weakness in the `acq`
+scripts.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+1. **Preferred — GitHub private Security Advisories.** Open a report from this
+   repository's **Security → Report a vulnerability** tab. This keeps the details
+   private while we look into them.
+2. **Email.** If you can't use Security Advisories, email
+   **agentic-coding@gsa.gov** with the subject prefixed `[SECURITY]`.
+
+Please include what you found, where (file, path, or command), and how to
+reproduce it.
+
 ## Scope
 
-This repository is part of the **Agentic Coding Capability Assessment** — an internal GSA initiative. It contains:
+This policy covers **this repository's own content and tooling**. These repos are
+**out of scope** for GSA's official Vulnerability Disclosure Policy. If your
+report concerns an actual GSA system or service (rather than this repository),
+please use GSA's Vulnerability Disclosure Policy instead:
+<https://www.gsa.gov/website-information/vulnerability-disclosure-policy>.
 
-- Documentation for setting up Docker Sandboxes (SBX) with USAi endpoints
-- Configuration files for AI coding agents
-- Templates for bootstrapping projects
+## What to expect
 
-There are no deployed services or production infrastructure in this repository.
+We're a small maintainer team, and we take security reports seriously. We'll
+acknowledge your report as soon as we reasonably can, and we'll keep you posted
+as we look into it. We can't commit to a formal response timeline, but we
+genuinely appreciate you taking the time to help — thank you for making this
+project better and safer for everyone who uses it.
 
-## Reporting and Fixing Security Issues
+## A note on licensing
 
-This is an **internal assessment repository** with trusted contributors. The appropriate response to most issues is to fix them directly.
-
-### For Content Issues
-
-If you find content that could lead to insecure implementations (incorrect configuration, unsafe patterns, etc.):
-
-1. **Submit a PR to fix it** — This is the preferred approach for internal repos
-2. **Open an issue** if you're unsure how to fix it or want to discuss first
-3. **Ask in the agentic-coding Slack channel** if you have questions or need help coordinating
-
-### For Repository Infrastructure Issues
-
-If you find a security issue with the repository infrastructure (CI/CD, GitHub Actions, dependencies, scripts):
-
-1. **Submit a PR to fix it** — You have access, so fix it directly when possible
-2. **Open an issue** to track the problem if you need help or it requires discussion
-3. **Contact channel admins** if you're unsure about the right approach
-
-Since this is an internal repository, formal security advisories are not required. Use your judgment — if something seems sensitive, discuss with channel admins before posting details publicly.
-
-### For GSA Platform Issues (Outside This Repo)
-
-For security concerns related to GSA systems, USAi platform, or other infrastructure outside the scope of this repository:
-
-- **Follow your normal GSA security reporting processes**
-- **Submit a ticket** or **email GSA security** as appropriate for your organization
-- **USAi-specific issues:** Contact support@usai.gov
-
-These repos are for the assessment — platform and infrastructure security follows standard GSA procedures.
-
-## Security Best Practices
-
-When using this repository:
-
-1. **Never commit secrets** — API keys, tokens, and credentials belong in environment variables
-2. **Use SBX isolation** — Run AI agents inside Docker Sandboxes, not on your host system
-3. **Follow AGENTS.md rules** — The behavioral contract helps prevent unsafe agent actions
-4. **Review agent output** — AI-generated code requires human review before production use
-
-## Supported Versions
-
-This is an active assessment project. Security updates are applied to the `main` branch only.
-
----
-
-**Last Updated:** 2026-05-21
+This project is dedicated to the public domain under
+[CC0 1.0 Universal](./LICENSE).


### PR DESCRIPTION
## Summary

Prepares this repo's community-health files for **public release**. Part of the public-readiness epic (#276); closes sub-issues #271 (SECURITY) and #272 (CoC), and adds the CC0 contribution paragraph. Contact is the now-provisioned monitored group **agentic-coding@gsa.gov**.

## Changes (docs-only)

- **SECURITY.md** — rewritten for external reporters: GitHub private Security Advisories first, `agentic-coding@gsa.gov` fallback (`[SECURITY]` prefix), honest best-effort tone (no SLA — 2-maintainer team), plain scope (non-production `acq` tooling; no hosted service/user data; real risks = unsafe examples, tooling supply-chain, committed secrets, sandbox-isolation weakness), and an explicit **out-of-scope-for-GSA-VDP** statement steering system/service reports to https://www.gsa.gov/website-information/vulnerability-disclosure-policy. Replaces the prior "internal GSA initiative" version.
- **CODE_OF_CONDUCT.md** (new) — self-contained, **values-neutral** professional-conduct standard (prohibits harassment/discrimination without an enumerated-identity list) + the Federal Community Addendum; reports to `agentic-coding@gsa.gov` (`[CONDUCT]` prefix). Self-contained because the **TTS Handbook is archived** (no live upstream CoC to reference).
- **CONTRIBUTING.md** — canonical federal CC0 "Public domain" contribution paragraph.

## Notes

- Approach 7/7 consensus-approved. Values-neutral CoC + single-inbox model were explicit human decisions.
- **Go-public dependency:** enable GitHub **private Security Advisories** at publication (the API can't pre-enable it while the repo is internal) — tracked in epic #276.

## Verification

pre-commit (gitleaks, markdownlint, secret scan) — all pass. Docs-only.

Closes #271. Closes #272.

AI-assisted (OpenCode); consensus-reviewed. Requires human review.