### PR TITLE
feat(acq): sand rough edges off first-run onboarding (PATH self-repair + auto host check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,22 +66,6 @@ or
 curl -fsSL https://install.microsandbox.dev | sh
 ```
 
-Try running `msb`; you should see the help output.
-
-<details>
-<summary>If you see a message saying the command is not found... (click to expand)</summary>
-You need to ensure the `msb` binary is on your PATH:
-
-```
-case ":$PATH:" in
-  *":$HOME/.local/bin:"*) ;;
-  *) export PATH="$HOME/.local/bin:$PATH" ;;
-esac
-```
-
-...then try again. If this solved the problem, you should make sure that this is copied into the configuration file for your shell, eg `.bashrc`.
-</details>
-
 **Verify that you're ready to run sandboxes**
 
 Run

--- a/README.md
+++ b/README.md
@@ -66,17 +66,6 @@ or
 curl -fsSL https://install.microsandbox.dev | sh
 ```
 
-**Verify that you're ready to run sandboxes**
-
-Run
-
-```
-msb doctor
-```
-
-You should see a report that your host is ready to
-run microVMs. If anything looks awry, you can attempt to fix it with `msb doctor --fix`. If you still see problems, then you're not ready to proceed to the next step. See if you can resolve this first! You can ask us for help via [agentic-coding@gsa.gov](mailto:agentic-coding@gsa.gov).
-
 ### Step 2: Clone this repo
 
 ```bash

--- a/acq
+++ b/acq
@@ -222,7 +222,11 @@ case "$subcommand" in
     sub2="${1:-}"
     case "$sub2" in
       list)
-        # List detected/installed backends.
+        # List detected/installed backends. Recover a backend installed in
+        # ~/.local/bin but not on PATH first, so the listing matches what
+        # `acq run` auto-detect will find.
+        _ensure_local_bin_on_path sbx >/dev/null 2>&1 || true
+        _ensure_local_bin_on_path msb >/dev/null 2>&1 || true
         printf 'Installed backends:\n'
         if command -v sbx >/dev/null 2>&1; then
           local_ver=$(sbx version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1 | sed 's/^v//' || echo "?")

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -554,8 +554,10 @@ _load_backend_adapter() {
   # already probes via _backend_installed, but the explicit/env/config paths set
   # the name directly — so a user who pinned a backend that lives only in
   # ~/.local/bin would otherwise still hit "command not found" in the adapter.
-  # No-op when the backend is already on PATH or not in ~/.local/bin.
-  _ensure_local_bin_on_path "$name" >/dev/null 2>&1 || true
+  # Only attempt the recovery when the backend is NOT already resolvable, so a
+  # user-writable ~/.local/bin copy never shadows a legit system binary that the
+  # agent (and everything acq subsequently execs) would otherwise use.
+  command -v "$name" >/dev/null 2>&1 || _ensure_local_bin_on_path "$name" >/dev/null 2>&1 || true
   # shellcheck disable=SC1090
   . "$adapter"
   ACQ_RESOLVED_BACKEND="$name"

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -418,13 +418,47 @@ _read_config_backend() {
   awk '/^[[:space:]]*backend[[:space:]]*:/ { gsub(/^[[:space:]]*backend[[:space:]]*:[[:space:]]*/,""); gsub(/[[:space:]]*$/,""); print; exit }' "$cfg"
 }
 
+# _ensure_local_bin_on_path — if a backend CLI is not on PATH but IS present in
+# ~/.local/bin (the default install location for `curl … | sh` installers, e.g.
+# microsandbox), prepend ~/.local/bin to PATH for THIS process so acq and the
+# backend adapter can find it. This spares a user who installed msb/sbx but never
+# added ~/.local/bin to their shell PATH from a confusing "command not found".
+# The change is process-local (not persisted); acq prints a one-time hint so the
+# user can make it durable. Idempotent (announces at most once per process).
+_ACQ_LOCAL_BIN_ANNOUNCED=""
+_ensure_local_bin_on_path() {
+  local be="$1"
+  local lb="${HOME:-}/.local/bin"
+  [ -n "${HOME:-}" ] || return 1
+  [ -x "$lb/$be" ] || return 1
+
+  # Already on PATH? Then nothing to do (defensive; caller only reaches here
+  # after `command -v "$be"` failed, but PATH may contain the dir unreadably).
+  case ":$PATH:" in
+    *":$lb:"*) return 1 ;;
+  esac
+
+  PATH="$lb:$PATH"
+  export PATH
+  if [ -z "$_ACQ_LOCAL_BIN_ANNOUNCED" ]; then
+    _ACQ_LOCAL_BIN_ANNOUNCED=1
+    echo "acq: found '$be' in $lb and added it to PATH for this run." >&2
+    echo "      To make this permanent, add the following to your shell startup" >&2
+    echo "      file (e.g. ~/.zshrc or ~/.bashrc):" >&2
+    echo "        export PATH=\"\$HOME/.local/bin:\$PATH\"" >&2
+  fi
+  return 0
+}
+
 # _backend_installed BACKEND — 0 if the named backend CLI is available.
 # Honors a test-only override, ACQ_TEST_INSTALLED_BACKENDS, a space-separated
 # allowlist (e.g. "sbx" or "msb sbx"). Tests set it to pin exactly which
 # backends auto-detect "sees" — `command -v` alone can't, because a developer's
 # real msb/sbx (and the coreutils the sourced scripts need) share PATH dirs, so
 # restricting PATH cannot hide one backend without also breaking the harness.
-# When the override is unset (production), falls back to a real `command -v`.
+# When the override is unset (production), falls back to a real `command -v`, and
+# if that misses, tries to recover a copy sitting in ~/.local/bin (see
+# _ensure_local_bin_on_path) before giving up.
 _backend_installed() {
   local be="$1"
   if [ -n "${ACQ_TEST_INSTALLED_BACKENDS+x}" ]; then
@@ -433,7 +467,9 @@ _backend_installed() {
       *) return 1 ;;
     esac
   fi
-  command -v "$be" >/dev/null 2>&1
+  command -v "$be" >/dev/null 2>&1 && return 0
+  # Not on PATH — self-repair if it is installed in ~/.local/bin.
+  _ensure_local_bin_on_path "$be" && command -v "$be" >/dev/null 2>&1
 }
 
 # _sbx_has_sandboxes — 0 if the sbx CLI reports at least one existing sandbox.
@@ -513,6 +549,13 @@ _load_backend_adapter() {
     echo "acq: error: no backend adapter found for '${name}' (expected: ${adapter})" >&2
     exit 1
   fi
+  # Self-repair PATH for the RESOLVED backend regardless of how it was chosen
+  # (explicit --backend, ACQ_BACKEND, saved config, or auto-detect). Auto-detect
+  # already probes via _backend_installed, but the explicit/env/config paths set
+  # the name directly — so a user who pinned a backend that lives only in
+  # ~/.local/bin would otherwise still hit "command not found" in the adapter.
+  # No-op when the backend is already on PATH or not in ~/.local/bin.
+  _ensure_local_bin_on_path "$name" >/dev/null 2>&1 || true
   # shellcheck disable=SC1090
   . "$adapter"
   ACQ_RESOLVED_BACKEND="$name"
@@ -535,8 +578,10 @@ acq_resolve_backend() {
       name="$cfg_name"
     else
       _auto_detect_backend || {
-        echo "acq: error: no backend detected. Install msb (>= 0.6.0) or sbx (>= 0.35.0)," >&2
-        echo "     or set ACQ_BACKEND." >&2
+        echo "acq: error: no backend detected (looked on PATH and in ~/.local/bin)." >&2
+        echo "     Install msb (>= 0.6.0) or sbx (>= 0.35.0), or set ACQ_BACKEND." >&2
+        echo "     If it is already installed elsewhere, add its directory to PATH," >&2
+        echo "     e.g.:  export PATH=\"\$HOME/.local/bin:\$PATH\"" >&2
         echo "     Run 'acq doctor' for installation hints." >&2
         exit 1
       }
@@ -1408,6 +1453,11 @@ ensure_valid_key() {
 
 acq_print_doctor() {
   local sbx_status msb_status
+
+  # Recover a backend installed in ~/.local/bin but not on PATH, so doctor's
+  # verdict matches what `acq run` will actually find (self-repair parity).
+  _ensure_local_bin_on_path sbx >/dev/null 2>&1 || true
+  _ensure_local_bin_on_path msb >/dev/null 2>&1 || true
 
   # Check sbx
   if command -v sbx >/dev/null 2>&1; then

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -306,13 +306,32 @@ acq_backend_prepare() {
   fi
 
   # msb needs host virtualization (KVM on Linux, HVF on macOS, WHP on Windows).
-  # `msb doctor` reports readiness; surface a clear hint but do not hard-fail
-  # here (provision will fail closed with msb's own error if the host is unfit).
-  if ! msb doctor >/dev/null 2>&1; then
-    echo "acq: note — 'msb doctor' reports the host virtualization prerequisites are not" >&2
-    echo "      fully met (e.g. /dev/kvm missing). Sandbox creation may fail. Run" >&2
-    echo "      'msb doctor --fix' or see docs/BACKEND_GUIDE.md (msb requirements)." >&2
+  # Run the readiness check FOR the user (so the happy path needs no manual `msb
+  # doctor` step and shows nothing). Only speak up when the host is NOT ready:
+  # try an automatic `msb doctor --fix`, re-check, and — if still unfit — surface
+  # an actionable message with where to get help. Do not hard-fail here:
+  # provision fails closed with msb's own error if the host is truly unusable,
+  # and ACQ_SKIP_MSB_DOCTOR=1 opts out entirely (e.g. an environment where the
+  # check is unreliable). The check itself is best-effort (any error running it
+  # is treated as "cannot determine" and stays silent).
+  [ -n "${ACQ_SKIP_MSB_DOCTOR:-}" ] && return 0
+  command -v msb >/dev/null 2>&1 || return 0
+  if msb doctor >/dev/null 2>&1; then
+    return 0
   fi
+  # Not ready — attempt the fix automatically, then re-check quietly.
+  acq_debug "msb doctor reports host not ready; attempting 'msb doctor --fix'"
+  msb doctor --fix >/dev/null 2>&1 || true
+  if msb doctor >/dev/null 2>&1; then
+    acq_debug "msb doctor: host ready after --fix"
+    return 0
+  fi
+  echo "acq: your machine isn't ready to run microVMs yet." >&2
+  echo "      msb needs host virtualization (KVM on Linux, Apple Silicon's" >&2
+  echo "      hypervisor on macOS, or the Windows Hypervisor Platform on Windows)." >&2
+  echo "      acq tried 'msb doctor --fix' automatically but the host is still not" >&2
+  echo "      ready. For details run 'msb doctor', see docs/QUICKSTART.md#msb-host-setup," >&2
+  echo "      or ask us for help at agentic-coding@gsa.gov." >&2
 }
 
 # ---------------------------------------------------------------------------

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -316,13 +316,20 @@ acq_backend_prepare() {
   # is treated as "cannot determine" and stays silent).
   [ -n "${ACQ_SKIP_MSB_DOCTOR:-}" ] && return 0
   command -v msb >/dev/null 2>&1 || return 0
-  if msb doctor >/dev/null 2>&1; then
+  # All `msb doctor` invocations redirect stdin from /dev/null (file convention):
+  # `msb doctor --fix` may prompt, and acq holds stdin open, so an un-redirected
+  # call would hang indefinitely on the exact unfit-host path this targets.
+  if msb doctor </dev/null >/dev/null 2>&1; then
     return 0
   fi
-  # Not ready — attempt the fix automatically, then re-check quietly.
-  acq_debug "msb doctor reports host not ready; attempting 'msb doctor --fix'"
-  msb doctor --fix >/dev/null 2>&1 || true
-  if msb doctor >/dev/null 2>&1; then
+  # Not ready — attempt the fix automatically, then re-check. `msb doctor --fix`
+  # MUTATES host state (kvm group, device permissions), so announce it on stderr
+  # BEFORE running rather than mutating silently (AGENTS.md classifies infra
+  # changes as approval-worthy; ACQ_SKIP_MSB_DOCTOR=1 opts out entirely).
+  echo "acq: host not ready for microVMs — running 'msb doctor --fix' to set it up" >&2
+  echo "      (set ACQ_SKIP_MSB_DOCTOR=1 to skip this and fix it yourself)." >&2
+  msb doctor --fix </dev/null >/dev/null 2>&1 || true
+  if msb doctor </dev/null >/dev/null 2>&1; then
     acq_debug "msb doctor: host ready after --fix"
     return 0
   fi

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -165,6 +165,8 @@ Tunables:
 |---------|---------|---------|
 | `ACQ_MSB_IMAGE` | `docker.io/docker/sandbox-templates:shell-docker` | Base OCI image (the sbx agent-template: ships the `agent` user + passwordless sudo, node/git/curl/ca-certificates, and an agent-writable npm global prefix). A custom override must be pullable and ship these prerequisites. |
 | `ACQ_MSB_SKIP_PREREQ_CHECK` | (unset) | Skip the base-image prerequisite presence check |
+| `ACQ_SKIP_MSB_DOCTOR` | (unset) | Skip the automatic host-readiness check (`msb doctor`, and the `msb doctor --fix` it runs when the host is not ready). Set when the check is unreliable in your environment or you prefer to run it yourself. |
+| `ACQ_OPENCODE_POSTINSTALL_TIMEOUT` | `120` | Seconds to bound opencode's in-guest `postinstall.mjs` (which fetches a platform binary) so a wedged registry can't hang `acq run`; used only when the guest provides `timeout` |
 | `ACQ_MSB_OPENCODE_PKG` | `opencode-ai` | npm package spec for the opencode install (pin e.g. `opencode-ai@1.2.3`) |
 | `ACQ_MSB_NPM_HOSTS` | `registry.npmjs.org` | npm registry host(s) to allow-list for the agent install (space-separated; set for an internal mirror) |
 | `ACQ_MSB_WORKSPACE` | (first workspace) | Agent's **starting directory** (`-w`) on attach. Does NOT change the mount, which is always host-path:host-path; overrides only where the agent starts. |

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -536,6 +536,60 @@ make_stubs; load_acq
 ) 2>/dev/null; pass "backend: explicit ACQ_BACKEND is silent (no nudge)"
 cleanup_stubs
 
+# 2i. PATH self-repair: a backend installed ONLY in ~/.local/bin (not on PATH)
+#     is recovered by _ensure_local_bin_on_path — acq adds ~/.local/bin to PATH
+#     for the run, prints a one-time durable-fix hint, and detection succeeds.
+#     Regression guard for the "installed but not on PATH -> command not found"
+#     bug: acq must self-repair rather than fail.
+make_stubs; load_acq
+(
+  unset ACQ_BACKEND ACQ_TEST_INSTALLED_BACKENDS 2>/dev/null || true
+  export XDG_CONFIG_HOME="$STUBDIR/noconfig"
+  # Put the msb stub ONLY in a fake ~/.local/bin, NOT on PATH.
+  fake_home="$STUBDIR/home"
+  mkdir -p "$fake_home/.local/bin"
+  mv "$STUBDIR/msb" "$fake_home/.local/bin/msb"
+  # PATH has coreutils but neither backend dir; HOME points at the fake home.
+  _coreutils_dir=$(dirname "$(command -v env)")
+  HOME="$fake_home"; export HOME
+  PATH="$_coreutils_dir"; export PATH
+  # shellcheck source=acq
+  ACQ_SOURCE_ONLY=1 . "$ACQ"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  set +e
+  _backend_installed msb 2>"$STUBDIR/rep_note"
+  rc=$?
+  note=$(cat "$STUBDIR/rep_note")
+  assert_eq "self-repair: backend in ~/.local/bin is detected" "0" "$rc"
+  assert_contains "self-repair: ~/.local/bin added to PATH for this run" "$PATH" "$fake_home/.local/bin"
+  assert_contains "self-repair: prints a durable-fix hint" "$note" "export PATH="
+) 2>/dev/null; pass "self-repair: backend recovered from ~/.local/bin"
+cleanup_stubs
+
+# 2j. PATH self-repair applies on the EXPLICIT path too (not just auto-detect):
+#     _load_backend_adapter recovers a pinned backend that lives only in
+#     ~/.local/bin, so `--backend`/ACQ_BACKEND/config users are not left with
+#     "command not found".
+make_stubs; load_acq
+(
+  export XDG_CONFIG_HOME="$STUBDIR/noconfig"
+  fake_home="$STUBDIR/home2"
+  mkdir -p "$fake_home/.local/bin"
+  mv "$STUBDIR/msb" "$fake_home/.local/bin/msb"
+  _coreutils_dir=$(dirname "$(command -v env)")
+  HOME="$fake_home"; export HOME
+  PATH="$_coreutils_dir"; export PATH
+  ACQ_BACKEND="msb"; export ACQ_BACKEND
+  # shellcheck source=acq
+  ACQ_SOURCE_ONLY=1 . "$ACQ"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  set +e
+  acq_resolve_backend "" >/dev/null 2>&1
+  assert_eq "self-repair (explicit): resolved backend is msb" "msb" "$ACQ_RESOLVED_BACKEND"
+  assert_contains "self-repair (explicit): msb now resolvable on PATH" "$(command -v msb 2>/dev/null)" "$fake_home/.local/bin/msb"
+) 2>/dev/null; pass "self-repair: explicit backend recovered from ~/.local/bin"
+cleanup_stubs
+
 # ===========================================================================
 # 3. Dispatch routing — each subcommand calls the right adapter function
 # ===========================================================================

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -169,7 +169,17 @@ _msb_sub="${1:-}"
 case "$_msb_sub" in
   --version|-V) printf 'msb 0.6.6\n' ;;
   --help|-h) printf 'MSB-TOPLEVEL-HELP for msb\n' ;;
-  doctor) exit 0 ;;
+  doctor)
+    # Model host-readiness. Default: ready (exit 0), so the happy path is silent.
+    # STUB_MSB_DOCTOR_UNFIT=1 models a not-ready host that STAYS unfit even after
+    # --fix. STUB_MSB_DOCTOR_FIXABLE=1 models a host that is unfit until
+    # `msb doctor --fix` runs, then ready (the --fix call plants a marker).
+    case " $* " in
+      *" --fix "*) [ "${STUB_MSB_DOCTOR_FIXABLE:-0}" = "1" ] && : >"$STUBDIR/.msb_fixed"; exit 0 ;;
+    esac
+    if [ "${STUB_MSB_DOCTOR_FIXABLE:-0}" = "1" ] && [ -f "$STUBDIR/.msb_fixed" ]; then exit 0; fi
+    if [ "${STUB_MSB_DOCTOR_UNFIT:-0}" = "1" ] || [ "${STUB_MSB_DOCTOR_FIXABLE:-0}" = "1" ]; then exit 1; fi
+    exit 0 ;;
   create) : >"$STUBDIR/.msb_created" ;;
   inspect)
     # `msb inspect <name> --format json` — emit a create-time published-ports
@@ -1412,6 +1422,63 @@ make_stubs
 out=$(printf 'n\n' | "$ACQ" doctor 2>&1)
 assert_contains "msb: doctor shows msb installed" "$out" "msb: installed v0.6.6"
 assert_not_contains "msb: doctor drops 'coming in 1.2.x'" "$out" "coming in 1.2.x"
+cleanup_stubs
+
+# 8j2. acq runs the msb host-readiness check itself (no manual `msb doctor`
+#      step). Happy path: host ready -> acq_backend_prepare is SILENT.
+make_stubs; load_acq
+(
+  # shellcheck source=acq
+  ACQ_SOURCE_ONLY=1 . "$ACQ"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  set +e
+  out=$(acq_backend_prepare 2>&1)
+  assert_not_contains "msb: ready host -> prepare is silent" "$out" "isn't ready"
+) 2>/dev/null; pass "msb: host-readiness check silent on the happy path"
+cleanup_stubs
+
+# 8j3. Host unfit but fixable: acq runs `msb doctor --fix` itself and, once the
+#      re-check passes, stays SILENT (user does nothing, sees nothing).
+make_stubs; load_acq
+(
+  # shellcheck source=acq
+  ACQ_SOURCE_ONLY=1 . "$ACQ"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  set +e
+  out=$(STUB_MSB_DOCTOR_FIXABLE=1 acq_backend_prepare 2>&1)
+  log=$(cat "$CALLS")
+  assert_contains "msb: prepare auto-runs 'msb doctor --fix'" "$log" "msb doctor --fix"
+  assert_not_contains "msb: fixable host -> silent after --fix" "$out" "isn't ready"
+) 2>/dev/null; pass "msb: auto-fixes a fixable host and stays silent"
+cleanup_stubs
+
+# 8j4. Host unfit and NOT fixable: after auto --fix fails, acq surfaces ONE clear
+#      not-ready message pointing at help — and does not hard-fail (exit 0).
+make_stubs; load_acq
+(
+  # shellcheck source=acq
+  ACQ_SOURCE_ONLY=1 . "$ACQ"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  set +e
+  out=$(STUB_MSB_DOCTOR_UNFIT=1 acq_backend_prepare 2>&1); rc=$?
+  assert_contains "msb: unfit host -> clear not-ready message" "$out" "isn't ready to run microVMs"
+  assert_contains "msb: unfit host -> points at help" "$out" "agentic-coding@gsa.gov"
+  assert_eq "msb: readiness check does not hard-fail" "0" "$rc"
+) 2>/dev/null; pass "msb: unfit host surfaces one actionable message, no hard-fail"
+cleanup_stubs
+
+# 8j5. ACQ_SKIP_MSB_DOCTOR=1 opts out of the readiness check entirely.
+make_stubs; load_acq
+(
+  # shellcheck source=acq
+  ACQ_SOURCE_ONLY=1 . "$ACQ"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  set +e
+  out=$(STUB_MSB_DOCTOR_UNFIT=1 ACQ_SKIP_MSB_DOCTOR=1 acq_backend_prepare 2>&1)
+  log=$(cat "$CALLS")
+  assert_not_contains "msb: skip flag -> no not-ready message" "$out" "isn't ready"
+  assert_not_contains "msb: skip flag -> no doctor call" "$log" "msb doctor"
+) 2>/dev/null; pass "msb: ACQ_SKIP_MSB_DOCTOR opts out of the readiness check"
 cleanup_stubs
 
 # 8k. msb secret set usai stores in the acq store + confirms concisely.

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -174,6 +174,10 @@ case "$_msb_sub" in
     # STUB_MSB_DOCTOR_UNFIT=1 models a not-ready host that STAYS unfit even after
     # --fix. STUB_MSB_DOCTOR_FIXABLE=1 models a host that is unfit until
     # `msb doctor --fix` runs, then ready (the --fix call plants a marker).
+    # STUB_MSB_DOCTOR_READS_STDIN=1 makes the call READ stdin (like a prompting
+    # `msb doctor --fix`); acq must redirect </dev/null or it would hang — the
+    # `cat` drains and returns promptly only because acq closed stdin.
+    [ "${STUB_MSB_DOCTOR_READS_STDIN:-0}" = "1" ] && cat >/dev/null 2>&1
     case " $* " in
       *" --fix "*) [ "${STUB_MSB_DOCTOR_FIXABLE:-0}" = "1" ] && : >"$STUBDIR/.msb_fixed"; exit 0 ;;
     esac
@@ -598,6 +602,59 @@ make_stubs; load_acq
   assert_eq "self-repair (explicit): resolved backend is msb" "msb" "$ACQ_RESOLVED_BACKEND"
   assert_contains "self-repair (explicit): msb now resolvable on PATH" "$(command -v msb 2>/dev/null)" "$fake_home/.local/bin/msb"
 ) 2>/dev/null; pass "self-repair: explicit backend recovered from ~/.local/bin"
+cleanup_stubs
+
+# 2k. The durable-fix hint is announced at most ONCE per process
+#     (_ACQ_LOCAL_BIN_ANNOUNCED): a second recovery in the same process is silent.
+make_stubs; load_acq
+(
+  unset ACQ_BACKEND ACQ_TEST_INSTALLED_BACKENDS 2>/dev/null || true
+  export XDG_CONFIG_HOME="$STUBDIR/noconfig"
+  fake_home="$STUBDIR/home3"
+  mkdir -p "$fake_home/.local/bin"
+  mv "$STUBDIR/msb" "$fake_home/.local/bin/msb"
+  _coreutils_dir=$(dirname "$(command -v env)")
+  HOME="$fake_home"; export HOME
+  PATH="$_coreutils_dir"; export PATH
+  # shellcheck source=acq
+  ACQ_SOURCE_ONLY=1 . "$ACQ"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  set +e
+  _ensure_local_bin_on_path msb 2>"$STUBDIR/n1"    # first: prepends + announces
+  _ensure_local_bin_on_path msb 2>"$STUBDIR/n2"    # second: already on PATH, silent
+  assert_contains "self-repair: first call announces" "$(cat "$STUBDIR/n1")" "export PATH="
+  assert_eq "self-repair: second call is silent" "" "$(cat "$STUBDIR/n2")"
+) 2>/dev/null; pass "self-repair: durable-fix hint announced at most once per process"
+cleanup_stubs
+
+# 2l. _load_backend_adapter must NOT prepend ~/.local/bin when the backend is
+#     already resolvable on PATH — a user-writable ~/.local/bin copy must never
+#     shadow a legit system binary for what acq (and the agent) subsequently exec.
+make_stubs; load_acq
+(
+  export XDG_CONFIG_HOME="$STUBDIR/noconfig"
+  # System msb: keep the stub in $STUBDIR (on PATH). ALSO plant a decoy in
+  # ~/.local/bin; if the gate is wrong it would jump ahead of the system copy.
+  fake_home="$STUBDIR/home4"
+  mkdir -p "$fake_home/.local/bin"
+  printf '#!/bin/sh\necho DECOY\n' > "$fake_home/.local/bin/msb"
+  chmod +x "$fake_home/.local/bin/msb"
+  HOME="$fake_home"; export HOME
+  PATH="$STUBDIR:$(dirname "$(command -v env)")"; export PATH
+  ACQ_BACKEND="msb"; export ACQ_BACKEND
+  # shellcheck source=acq
+  ACQ_SOURCE_ONLY=1 . "$ACQ"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  set +e
+  acq_resolve_backend "" >/dev/null 2>&1
+  # ~/.local/bin must NOT have been prepended (system msb already resolved).
+  case ":$PATH:" in
+    *":$fake_home/.local/bin:"*) resolved_shadow=yes ;;
+    *) resolved_shadow=no ;;
+  esac
+  assert_eq "self-repair: does not shadow a system backend" "no" "$resolved_shadow"
+  assert_eq "self-repair: system msb still first on PATH" "$STUBDIR/msb" "$(command -v msb)"
+) 2>/dev/null; pass "self-repair: gated so it never shadows a system backend"
 cleanup_stubs
 
 # ===========================================================================
@@ -1448,7 +1505,11 @@ make_stubs; load_acq
   out=$(STUB_MSB_DOCTOR_FIXABLE=1 acq_backend_prepare 2>&1)
   log=$(cat "$CALLS")
   assert_contains "msb: prepare auto-runs 'msb doctor --fix'" "$log" "msb doctor --fix"
-  assert_not_contains "msb: fixable host -> silent after --fix" "$out" "isn't ready"
+  # The host-mutating --fix must be ANNOUNCED on stderr before it runs (never a
+  # silent infra change), and name the opt-out.
+  assert_contains "msb: announces before running --fix" "$out" "running 'msb doctor --fix'"
+  assert_contains "msb: announcement names the opt-out" "$out" "ACQ_SKIP_MSB_DOCTOR=1"
+  assert_not_contains "msb: fixable host -> no not-ready message after --fix" "$out" "isn't ready"
 ) 2>/dev/null; pass "msb: auto-fixes a fixable host and stays silent"
 cleanup_stubs
 
@@ -1480,6 +1541,29 @@ make_stubs; load_acq
   assert_not_contains "msb: skip flag -> no doctor call" "$log" "msb doctor"
 ) 2>/dev/null; pass "msb: ACQ_SKIP_MSB_DOCTOR opts out of the readiness check"
 cleanup_stubs
+
+# 8j6. The msb doctor calls redirect stdin from /dev/null, so a prompting
+#      `msb doctor`/`--fix` cannot hang acq (the reviewer reproduced a real
+#      indefinite hang here). The stub READS stdin when STUB_MSB_DOCTOR_READS_STDIN
+#      is set. We give the run a stdin that never reaches EOF on its own (a
+#      background sleep feeding a pipe): if acq failed to redirect the doctor
+#      calls to </dev/null, the stub's `cat` would read that pipe and block until
+#      the sleep ends. `timeout` turns any regression into a loud failure (124)
+#      rather than a hung suite. Skipped only if `timeout` is unavailable.
+if command -v timeout >/dev/null 2>&1; then
+  make_stubs; load_acq
+  hang_rc=0
+  { sleep 30; } | timeout 8 sh -c '
+    ACQ_SOURCE_ONLY=1 . "'"$ACQ"'"
+    . "'"${REPO_ROOT}"'/acq.backends/msb.sh"
+    STUB_MSB_DOCTOR_FIXABLE=1 STUB_MSB_DOCTOR_READS_STDIN=1 acq_backend_prepare
+  ' >/dev/null 2>&1 || hang_rc=$?
+  # 124 = timed out (would-be hang -> redirect regression); anything else = returned.
+  assert_not_contains "msb: doctor calls do not hang on open stdin" "TIMEOUT-$hang_rc" "TIMEOUT-124"
+  cleanup_stubs
+else
+  pass "msb: msb doctor stdin-hang guard skipped (no 'timeout' available)"
+fi
 
 # 8k. msb secret set usai stores in the acq store + confirms concisely.
 make_stubs


### PR DESCRIPTION
## Context

Sanding two rough edges off the first-run onboarding experience, found in
user-testing after #266. Both let the **happy path require nothing and show
nothing**, and give a clear, actionable message only when something is actually
wrong.

AI-assisted (OpenCode). Human-reviewed before merge.

## What changed

**1. Auto-recover a backend installed in `~/.local/bin` but not on `PATH`.**
The microsandbox installer drops `msb` in `~/.local/bin`, which many shells
don't have on `PATH` — so `acq run` failed with a confusing "no backend
detected" even though `msb` was installed, and the README pushed the user to fix
`PATH` by hand. acq now self-repairs: when a backend CLI is missing from `PATH`
but present in `~/.local/bin`, acq prepends it to `PATH` for the current process
and prints a one-time hint with the line to make it durable. This runs on **all**
resolution paths — auto-detect, explicit `--backend`/`ACQ_BACKEND`/config
(`_load_backend_adapter`), and `acq backend list` / `acq doctor`. The change is
process-local (never persisted). The "no backend detected" error now also states
it looked in `~/.local/bin` and shows the `PATH` export.

**2. Run the msb host-readiness check automatically.**
Removed the manual "Verify that you're ready → `msb doctor`" step from the
README. `acq_backend_prepare` (msb) now runs the readiness check itself before
creating a sandbox: silent on a ready host; on an unfit host it attempts
`msb doctor --fix` automatically, re-checks, and only if still unfit surfaces one
clear message (what's needed + where to get help). It does not hard-fail
(provision fails closed with msb's own error if the host is truly unusable), and
`ACQ_SKIP_MSB_DOCTOR=1` opts out.

## Verification

- `./scripts/test-acq` — **629 passed, 0 failed** (verified plainly and under a
  real PTY). New coverage: self-repair (auto-detect + explicit paths, PATH
  mutation, durable-fix hint) and the readiness check (ready-silent,
  fixable-auto-fix-silent, unfit-one-message-no-hard-fail, opt-out).
- `shellcheck -S warning` clean on `acq` + adapters + `scripts/test-acq`;
  `npm run lint:md` clean.

## Rollback

Revert the PR merge commit. Both changes are additive and behind best-effort /
opt-out guards; no data or config is persisted.

## Security impact

None. No auth/authz or data-handling change. The `PATH` prepend is
process-local and only adds the user's own `~/.local/bin`; the readiness check
runs local `msb doctor`.

## Notes

- Cherry-picked from the #266 branch after it merged (these two commits landed
  just after the squash-merge).
- Related follow-up still open: a Zscaler-affected user is verifying whether
  trusting the corporate CA inside the sandbox resolves msb egress (network
  diagnosis already shipped in #266); productizing that, if confirmed, is a
  separate patterns-repo change.
