### PR TITLE
docs: remove internal Slack references for public readiness (#273)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Slack Channel
-    url: https://gsa.enterprise.slack.com/archives/C0B44531QLE
-    about: For quick questions and real-time discussion, ask in the agentic-coding Slack channel
   - name: Agentic Coding Playbook
     url: https://github.com/GSA-TTS/agentic-coding-playbook
     about: For standards, best practices, and compliance documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,11 @@ This repo is one of three in the agentic coding ecosystem:
 | **[Playbook](https://github.com/GSA-TTS/agentic-coding-playbook)** | Standards & practices | Coding standards, skills, templates |
 | **[Patterns](https://github.com/GSA-TTS/agentic-coding-patterns)** | Community sharing | Workflows, lessons learned, tool examples |
 
-**Not sure where your contribution belongs?** Ask in the [agentic-coding Slack channel](https://gsa.enterprise.slack.com/archives/C0B44531QLE).
+**Not sure where your contribution belongs?** Open a GitHub issue to discuss.
 
 ## Getting Help
 
-- **Questions:** Ask in the [agentic-coding Slack channel](https://gsa.enterprise.slack.com/archives/C0B44531QLE) (others benefit too)
+- **Questions:** Open a GitHub issue or start a discussion (others benefit too)
 - **Bugs:** Open a GitHub issue with steps to reproduce
 - **Security issues:** See [SECURITY.md](SECURITY.md) — direct fixes preferred
 
@@ -366,8 +366,8 @@ Releases are **fully automated** via GitHub Actions and release-please:
 
 ## Questions or Issues?
 
-- **Questions:** Ask in the agentic-coding Slack channel
-- **Security issues:** See [SECURITY.md](SECURITY.md) — direct fixes preferred
+- **Questions:** Open a GitHub issue or start a discussion
+- **Security issues:** See [SECURITY.md](SECURITY.md)
 - **Bug reports:** Open a GitHub Issue with:
   - Steps to reproduce
   - Expected vs actual behavior

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ clone is needed.
 
 1. **Troubleshooting:** [docs/KNOWN_FAILURE_MODES.md](docs/KNOWN_FAILURE_MODES.md)
 2. **Agent behavior:** [AGENTS.md](AGENTS.md)
-3. **Questions:** [agentic-coding Slack channel](https://gsa.enterprise.slack.com/archives/C0B44531QLE)
+3. **Questions:** Open a [GitHub issue](https://github.com/GSA-TTS/agentic-coding-quickstart/issues)
 4. **Platform issues:** support@usai.gov
 
 ---

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -580,6 +580,5 @@ The Docker Desktop-integrated `docker sandbox` command is deprecated. For the
 
 ## Getting Help
 
-- **Slack:** #agentic-coding (GSA internal)
 - **GitHub Issues:** [agentic-coding-quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart/issues)
 - **Docker Docs:** [docs.docker.com/ai/sandboxes](https://docs.docker.com/ai/sandboxes/)


### PR DESCRIPTION
## Summary

Public-readiness blocker (epic #276, closes #273). Removes the internal GSA Slack workspace URL and "agentic-coding Slack channel" pointers from public-facing files — external contributors can't access them and they leak internal org topology.

## Changes (docs-only)

- `.github/ISSUE_TEMPLATE/config.yml` — drop the Slack `contact_link` (keep the sibling-repo links)
- `README.md` — "Questions" → open a GitHub issue
- `CONTRIBUTING.md` — 3 Slack pointers → GitHub issues/discussions
- `docs/QUICKSTART_SBX.md` — drop the "#agentic-coding (GSA internal)" line

## Verification

`npm run lint:md` 0 errors; `config.yml` YAML valid; pre-commit (gitleaks, secret scan) pass. Verified 0 residual `gsa.enterprise.slack.com` / internal-Slack references in public-facing files.

Closes #273.

AI-assisted (OpenCode); requires human review.