### PR TITLE
feat(acq): fix subcommand dispatch hygiene and implement 'secret import'

### DIFF
--- a/acq
+++ b/acq
@@ -760,15 +760,30 @@ case "$subcommand" in
       rm)
         shift
         # `acq secret rm [-g | SANDBOX] SERVICE` removes an acq-owned secret from
-        # the acq store (and clears the sbx proxy entry). If the args look like a
-        # scope + service (a known acq service, with -g or a sandbox name), route
-        # to the backend rm. Otherwise (e.g. a raw sbx placeholder token) pass
-        # through to the backend secret CLI unchanged for back-compat.
+        # the acq store (and clears the backend's injector). If the args name a
+        # scope + known acq service (-g or a sandbox name), route to the backend
+        # rm. Otherwise the token is only meaningful to a backend that has its own
+        # `secret` CLI whose placeholder table we can pass a raw token through to
+        # (sbx). msb has NO `secret` subcommand, so a raw passthrough there
+        # produced a confusing `unrecognized subcommand 'secret'` from msb itself.
+        # Detect that case and emit acq's own usage error instead — a scope is
+        # required for a managed removal, and there is no raw-placeholder path.
         if _acq_is_managed_secret_rm "$@"; then
           acq_backend_secret_rm "$@"
+        elif command -v acq_backend_secret_ls >/dev/null 2>&1; then
+          # Backend owns the acq secret store natively (msb): there is no backend
+          # `secret` CLI to fall through to, so a non-managed token cannot be a
+          # raw placeholder. Fail closed with a clear, backend-appropriate error.
+          echo "acq: secret rm: scope required — use -g for global or provide a sandbox name" >&2
+          echo "     usage: acq secret rm [-g | SANDBOX] SERVICE" >&2
+          echo "     examples:" >&2
+          echo "       acq secret rm -g ${1:-SERVICE}            # global" >&2
+          echo "       acq secret rm my-sandbox ${1:-SERVICE}    # sandbox-scoped" >&2
+          exit 1
         else
-          acq_backend_run "" secret rm "$@" 2>/dev/null || \
-            command "${ACQ_RESOLVED_BACKEND}" secret rm "$@"
+          # Backend has its own secret CLI with a placeholder table (sbx): a raw
+          # token is a valid placeholder to remove. Pass through unchanged.
+          command "${ACQ_RESOLVED_BACKEND}" secret rm "$@"
         fi
         ;;
       ls)
@@ -798,7 +813,7 @@ acq secret — manage sandbox secrets
 Usage:
   acq secret set [-g | SANDBOX] SERVICE [--host HOST --env ENV]
   acq secret rm  [-g | SANDBOX] SERVICE      # remove an acq-managed secret
-  acq secret rm  [-g | SANDBOX] <placeholder>  # (raw sbx placeholder → passthrough)
+  acq secret rm  [-g | SANDBOX] <placeholder>  # (sbx only: raw placeholder → passthrough)
   acq secret ls [-g | SANDBOX]               # list acq-managed secrets
   acq secret import [SERVICE] [--all] [--force] [--dry-run]
   acq secret set-custom [-g | SANDBOX] --host HOST --env ENV

--- a/acq
+++ b/acq
@@ -111,7 +111,8 @@ Subcommands:
                                            sandbox, in place (state preserved).
   help                                     Show this help.
 
-Any other subcommand is passed through to the active backend's CLI.
+Any other subcommand is passed through to the active backend's CLI (acq prints
+a notice first so you know the output/errors below it are the backend's).
 
 Global flags (before the subcommand):
   --backend sbx|msb    Override the active backend for this invocation.
@@ -145,6 +146,20 @@ _acq_backend_help() {
     echo "──────── ${be} --help ────────"
     "$be" --help 2>&1 || true
   fi
+}
+
+# _acq_backend_passthrough ARGS... — forward ARGS verbatim to the active backend
+# CLI, but ANNOUNCE the handoff first (stderr, always). This is acq's documented
+# escape hatch (ADR-0010; acq-design §4.4) for verbs acq does not own — but the
+# user must know (a) the handoff happened and (b) any usage/errors they see next
+# come from the backend, not acq. Without the notice, a raw backend error (e.g.
+# `unrecognized subcommand`) reads as an acq bug. The notice goes to stderr so
+# stdout stays clean for a user who is intentionally piping backend output.
+_acq_backend_passthrough() {
+  local be="${ACQ_RESOLVED_BACKEND:-the backend}"
+  echo "acq: '$1' is not an acq subcommand — forwarding to '${be}'." >&2
+  echo "     (output and any errors below are from '${be}', not acq)" >&2
+  command "${ACQ_RESOLVED_BACKEND}" "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -789,8 +804,11 @@ case "$subcommand" in
       ls)
         # `acq secret ls [-g|SANDBOX]` — if the backend defines a native acq
         # secret listing (msb: the acq store is the source of truth, and there is
-        # no `msb secret ls`), use it. Otherwise pass through to the backend's own
-        # secret CLI unchanged (sbx: `sbx secret ls` shows the proxy table).
+        # no `msb secret ls`), use it. Otherwise the backend has its own secret
+        # CLI whose listing we surface (sbx: `sbx secret ls` shows the proxy
+        # table). This is NOT an escape-hatch passthrough — `secret ls` is an
+        # acq-owned verb and sbx's `secret ls` is its intended acq-store view — so
+        # it is delegated silently (no forwarding notice).
         shift
         if command -v acq_backend_secret_ls >/dev/null 2>&1; then
           acq_backend_secret_ls "$@"
@@ -799,10 +817,15 @@ case "$subcommand" in
         fi
         ;;
       import|set-custom)
-        # Pass through to the backend secret CLI unchanged. shift so $sub2 is not
-        # ALSO left in $@ (that would double the subcommand token, e.g.
-        # `sbx secret import import`); re-supply it explicitly.
+        # Delegate to the backend's own secret CLI, but ANNOUNCE it: these
+        # subverbs are NOT wired through the acq secret store (unlike set/rm/ls),
+        # so the user must know the handoff happened and that any output/errors
+        # come from the backend, not acq. shift so $sub2 is not ALSO left in $@
+        # (that would double the subcommand token, e.g. `sbx secret import
+        # import`); re-supply it explicitly.
         shift
+        echo "acq: 'secret $sub2' is not wired through the acq secret store — forwarding to '${ACQ_RESOLVED_BACKEND}'." >&2
+        echo "     (output and any errors below are from '${ACQ_RESOLVED_BACKEND}', not acq)" >&2
         command "${ACQ_RESOLVED_BACKEND}" secret "$sub2" "$@"
         ;;
       --help|-h|"")
@@ -829,8 +852,13 @@ SECRETUSAGE
         command "${ACQ_RESOLVED_BACKEND}" secret --help
         ;;
       *)
-        # Unknown subcommand — pass through to backend.
-        command "${ACQ_RESOLVED_BACKEND}" secret "$@"
+        # `secret` is an acq-owned verb, so an unrecognized subverb is a user
+        # mistake in acq's vocabulary — fail closed with acq's own error rather
+        # than forwarding a token acq claimed to a backend that may reject it
+        # differently (or accept something acq never meant to expose).
+        echo "acq: unknown secret subcommand '${sub2}'." >&2
+        echo "     Try: acq secret set | rm | ls | import | set-custom | --help" >&2
+        exit 1
         ;;
     esac
     ;;
@@ -854,8 +882,9 @@ SECRETUSAGE
     ;;
 
   *)
-    # Pass unknown subcommands through to the active backend CLI unchanged.
-    # For sbx: `sbx <subcommand> [args...]`
-    command "${ACQ_RESOLVED_BACKEND}" "$subcommand" "$@"
+    # Pass unknown subcommands through to the active backend CLI unchanged, but
+    # announce the handoff (see _acq_backend_passthrough) so the user knows the
+    # verb is not acq's and that any output/errors below come from the backend.
+    _acq_backend_passthrough "$subcommand" "$@"
     ;;
 esac

--- a/acq
+++ b/acq
@@ -919,17 +919,14 @@ case "$subcommand" in
         exit 1
         ;;
       import)
-        # FAIL CLOSED — not implemented. The forwarded backend `secret import`
-        # would bypass the acq store (and errors on msb, which has no `secret`
-        # CLI). The INTENDED `acq secret import` is the inverse: a helper that
-        # migrates existing backend secrets INTO the acq store (see
-        # docs/BACKEND_GUIDE.md, "Migration"). Reserve the verb rather than ship
-        # store-bypassing behavior under its name.
-        echo "acq: 'secret import' is not implemented yet." >&2
-        echo "     Planned: migrate existing backend secrets into the acq store" >&2
-        echo "     (see docs/BACKEND_GUIDE.md, \"Migration\"). For now, re-store each" >&2
-        echo "     secret through acq, e.g.: acq secret set -g usai" >&2
-        exit 1
+        # Populate the acq store from known service tokens in the host
+        # environment (usai/github/gitlab). This is the store-POPULATING helper —
+        # the inverse of the removed store-BYPASSING backend passthrough. It
+        # writes only the acq-owned store (both backends read it at provision);
+        # it never invokes the backend's own `secret` CLI. See acq_secret_import
+        # in acq.backends/common.sh and docs/BACKEND_GUIDE.md "Migration".
+        shift
+        acq_secret_import "$@"
         ;;
       --help|-h|"")
         # `acq secret` (no subverb) reaches here; `acq secret --help` is
@@ -949,7 +946,7 @@ case "$subcommand" in
         # than forwarding a token acq claimed to a backend that may reject it
         # differently (or accept something acq never meant to expose).
         echo "acq: unknown secret subcommand '${sub2}'." >&2
-        echo "     Try: acq secret set | rm | ls | --help" >&2
+        echo "     Try: acq secret set | rm | ls | import | --help" >&2
         exit 1
         ;;
     esac

--- a/acq
+++ b/acq
@@ -154,8 +154,9 @@ exposed through acq (it would bypass the acq store).
 
 `acq secret import` scans your host environment for known service tokens
 (usai/github/gitlab) and stores each in the acq store (global by default; pass a
-SANDBOX to scope it). Existing entries are never overwritten silently: interactive
-mode prompts, --all skips overwrites, --force replaces. --dry-run previews only.
+SANDBOX to scope it — a second bare token after a SERVICE is the SANDBOX, not a
+second service). Existing entries are never overwritten silently: interactive
+mode prompts, --all skips overwrites, --force (-f) replaces. --dry-run previews only.
 
 `acq secret rm SERVICE` (usai/github/gitlab) deletes the value from the acq
 store and clears the backend's injector. `acq secret ls` lists the secrets acq
@@ -226,13 +227,16 @@ _acq_backend_help() {
   fi
 }
 
-# _acq_backend_passthrough ARGS... — forward ARGS verbatim to the active backend
-# CLI, but ANNOUNCE the handoff first (stderr, always). This is acq's documented
-# escape hatch (ADR-0010; acq-design §4.4) for verbs acq does not own — but the
-# user must know (a) the handoff happened and (b) any usage/errors they see next
-# come from the backend, not acq. Without the notice, a raw backend error (e.g.
-# `unrecognized subcommand`) reads as an acq bug. The notice goes to stderr so
-# stdout stays clean for a user who is intentionally piping backend output.
+# _acq_backend_passthrough VERB ARGS... — forward `VERB ARGS...` verbatim to the
+# active backend CLI, but ANNOUNCE the handoff first (stderr, always). This is
+# acq's documented escape hatch (ADR-0010; acq-design §4.4) for verbs acq does
+# not own — but the user must know (a) the handoff happened and (b) any
+# usage/errors they see next come from the backend, not acq. Without the notice,
+# a raw backend error (e.g. `unrecognized subcommand`) reads as an acq bug. The
+# notice goes to stderr so stdout stays clean for a user who is intentionally
+# piping backend output. VERB is BOTH the announced label and the forwarded
+# subcommand — callers pass the verb once (do not also leave it in the remaining
+# args, or it would be doubled).
 _acq_backend_passthrough() {
   local be="${ACQ_RESOLVED_BACKEND:-the backend}"
   echo "acq: '$1' is not an acq subcommand — forwarding to '${be}'." >&2
@@ -974,6 +978,10 @@ case "$subcommand" in
     # Pass unknown subcommands through to the active backend CLI unchanged, but
     # announce the handoff (see _acq_backend_passthrough) so the user knows the
     # verb is not acq's and that any output/errors below come from the backend.
+    # $1 is still the subcommand token here (this case block did not shift), so
+    # drop it before forwarding the remaining args — otherwise the verb would be
+    # doubled (e.g. `acq policy init` → `sbx policy policy init`).
+    shift
     _acq_backend_passthrough "$subcommand" "$@"
     ;;
 esac

--- a/acq
+++ b/acq
@@ -816,17 +816,33 @@ case "$subcommand" in
           command "${ACQ_RESOLVED_BACKEND}" secret ls "$@"
         fi
         ;;
-      import|set-custom)
-        # Delegate to the backend's own secret CLI, but ANNOUNCE it: these
-        # subverbs are NOT wired through the acq secret store (unlike set/rm/ls),
-        # so the user must know the handoff happened and that any output/errors
-        # come from the backend, not acq. shift so $sub2 is not ALSO left in $@
-        # (that would double the subcommand token, e.g. `sbx secret import
-        # import`); re-supply it explicitly.
-        shift
-        echo "acq: 'secret $sub2' is not wired through the acq secret store — forwarding to '${ACQ_RESOLVED_BACKEND}'." >&2
-        echo "     (output and any errors below are from '${ACQ_RESOLVED_BACKEND}', not acq)" >&2
-        command "${ACQ_RESOLVED_BACKEND}" secret "$sub2" "$@"
+      set-custom)
+        # FAIL CLOSED — do NOT forward to the backend. Raw `set-custom` is a
+        # strict, store-BYPASSING subset of acq's managed custom-endpoint path:
+        # it writes only the backend's own table (invisible to `acq secret ls`,
+        # never re-fed on rotation, not removable via `acq secret rm SERVICE`),
+        # exposes the value on argv (sbx --value), and on msb there is no `secret`
+        # CLI at all so it just errors. The acq-store-aware equivalent already
+        # does everything it does, better, on BOTH backends:
+        #     acq secret set SERVICE --host HOST --env ENV
+        # (value read off-argv, host/env sidecar recorded, bound at provision).
+        echo "acq: 'secret set-custom' is not supported — it would bypass the acq secret store." >&2
+        echo "     Use the acq-store-aware equivalent (works on both backends, keeps the value off argv):" >&2
+        echo "       acq secret set [-g | SANDBOX] SERVICE --host HOST --env ENV" >&2
+        exit 1
+        ;;
+      import)
+        # FAIL CLOSED — not implemented. The forwarded backend `secret import`
+        # would bypass the acq store (and errors on msb, which has no `secret`
+        # CLI). The INTENDED `acq secret import` is the inverse: a helper that
+        # migrates existing backend secrets INTO the acq store (see
+        # docs/BACKEND_GUIDE.md, "Migration"). Reserve the verb rather than ship
+        # store-bypassing behavior under its name.
+        echo "acq: 'secret import' is not implemented yet." >&2
+        echo "     Planned: migrate existing backend secrets into the acq store" >&2
+        echo "     (see docs/BACKEND_GUIDE.md, \"Migration\"). For now, re-store each" >&2
+        echo "     secret through acq, e.g.: acq secret set -g usai" >&2
+        exit 1
         ;;
       --help|-h|"")
         # Print acq's own summary, then delegate to backend for full detail.
@@ -838,16 +854,23 @@ Usage:
   acq secret rm  [-g | SANDBOX] SERVICE      # remove an acq-managed secret
   acq secret rm  [-g | SANDBOX] <placeholder>  # (sbx only: raw placeholder → passthrough)
   acq secret ls [-g | SANDBOX]               # list acq-managed secrets
-  acq secret import [SERVICE] [--all] [--force] [--dry-run]
-  acq secret set-custom [-g | SANDBOX] --host HOST --env ENV
+
+Custom endpoints: use `acq secret set SERVICE --host HOST --env ENV` — it stores
+the value in the acq store (off argv), records the host/env binding, and works
+on both backends. The raw backend `secret set-custom` is intentionally NOT
+exposed through acq (it would bypass the acq store). `acq secret import` (a
+planned store-migration helper) is not implemented yet.
 
 `acq secret rm SERVICE` (usai/github/gitlab) deletes the value from the acq
 store and clears the backend's injector. `acq secret ls` lists the secrets acq
 manages (scope, service, whether a value is stored, and the ENV@HOST binding) —
 never the values themselves; on msb the acq store is the source of truth, on sbx
-this shows the sbx proxy table. Other subcommands pass through to the backend.
+this shows the sbx proxy table.
 
-Full sbx reference:
+The backend's own secret reference follows for context; acq deliberately routes
+all secret storage through its own store (above) rather than the backend's CLI.
+
+Full backend reference:
 SECRETUSAGE
         command "${ACQ_RESOLVED_BACKEND}" secret --help
         ;;
@@ -857,7 +880,7 @@ SECRETUSAGE
         # than forwarding a token acq claimed to a backend that may reject it
         # differently (or accept something acq never meant to expose).
         echo "acq: unknown secret subcommand '${sub2}'." >&2
-        echo "     Try: acq secret set | rm | ls | import | set-custom | --help" >&2
+        echo "     Try: acq secret set | rm | ls | --help" >&2
         exit 1
         ;;
     esac

--- a/acq
+++ b/acq
@@ -94,6 +94,8 @@ Subcommands:
                                            custom endpoint).
   secret rm  [-g|SANDBOX] SERVICE          Remove a secret acq manages.
   secret ls  [-g|SANDBOX]                  List acq-managed secrets (no values).
+  secret import [SERVICE] [-g|SANDBOX]     Import known service tokens from the
+                                           host environment into the acq store.
   github-scope SANDBOX [PATH]              Scope a GitHub token to the
                                            workspace's repos (least-privilege PAT).
   usai-rotate-api-key                      Rotate the USAi API key.
@@ -127,6 +129,82 @@ run/create flag:
 
 See docs/QUICKSTART.md and docs/BACKEND_GUIDE.md for more.
 HELP
+}
+
+# _acq_secret_usage / _acq_kit_usage — acq's OWN per-verb usage blocks. Printed
+# by both the per-verb `--help` case in the dispatch AND the early help router
+# (_acq_print_topic_help), so `acq secret --help` and `acq secret` show the same
+# acq usage rather than the top-level banner. Kept as functions (single source)
+# so the two call sites can never drift.
+_acq_secret_usage() {
+  cat >&2 <<'SECRETUSAGE'
+acq secret — manage sandbox secrets (via acq's own backend-neutral store)
+
+Usage:
+  acq secret set [-g | SANDBOX] SERVICE [--host HOST --env ENV]
+  acq secret rm  [-g | SANDBOX] SERVICE      # remove an acq-managed secret
+  acq secret rm  [-g | SANDBOX] <placeholder>  # (sbx only: raw placeholder → passthrough)
+  acq secret ls  [-g | SANDBOX]              # list acq-managed secrets
+  acq secret import [SERVICE] [-g | SANDBOX] [--all] [--force] [--dry-run]
+
+Custom endpoints: use `acq secret set SERVICE --host HOST --env ENV` — it stores
+the value in the acq store (off argv), records the host/env binding, and works
+on both backends. The raw backend `secret set-custom` is intentionally NOT
+exposed through acq (it would bypass the acq store).
+
+`acq secret import` scans your host environment for known service tokens
+(usai/github/gitlab) and stores each in the acq store (global by default; pass a
+SANDBOX to scope it). Existing entries are never overwritten silently: interactive
+mode prompts, --all skips overwrites, --force replaces. --dry-run previews only.
+
+`acq secret rm SERVICE` (usai/github/gitlab) deletes the value from the acq
+store and clears the backend's injector. `acq secret ls` lists the secrets acq
+manages (scope, service, whether a value is stored, and the ENV@HOST binding) —
+never the values themselves; on msb the acq store is the source of truth, on sbx
+this shows the sbx proxy table.
+SECRETUSAGE
+}
+
+_acq_kit_usage() {
+  cat >&2 <<'KITUSAGE'
+acq kit — manage neutral hybrid/v1 kits
+
+Usage:
+  acq kit list                 Show the pinned built-in kits (+ extras)
+  acq kit validate PATH        Validate a neutral kit (dir or spec.yaml)
+  acq kit apply NAME KITREF    Apply a kit to an existing sandbox (mid-life)
+  acq kit check SANDBOX        Report if a sandbox is on the pinned bundle
+  acq kit update SANDBOX [--yes]  Refresh the built-in bundle in place
+
+See docs/BACKEND_GUIDE.md and docs/adr/0011-msb-backend-and-neutral-kits.md.
+KITUSAGE
+}
+
+_acq_backend_subcmd_usage() {
+  cat >&2 <<'BACKENDUSAGE'
+acq backend — select the sandbox backend
+
+Usage:
+  acq backend list        List detected/installed backends (sbx, msb)
+  acq backend set NAME    Persist the default backend (sbx | msb)
+  acq backend unset       Clear the persisted default (fall back to auto-detect)
+BACKENDUSAGE
+}
+
+# _acq_print_topic_help TOPIC — print acq's OWN help for a known top-level verb
+# TOPIC (so `acq <verb> --help` documents the acq verb, not just the backend).
+# Returns 0 if TOPIC was a known acq verb (help printed), 1 otherwise (caller
+# should fall back to the top-level banner + backend help). The first WORD of
+# TOPIC is matched, so a multi-word topic like "secret set" routes to `secret`.
+_acq_print_topic_help() {
+  local topic="$1" head
+  head="${topic%% *}"
+  case "$head" in
+    secret)  _acq_secret_usage; return 0 ;;
+    kit)     _acq_kit_usage; return 0 ;;
+    backend) _acq_backend_subcmd_usage; return 0 ;;
+    *)       return 1 ;;
+  esac
 }
 
 # _acq_backend_help SUBCOMMAND — best-effort: print the resolved backend's own
@@ -201,25 +279,43 @@ _acq_wants_help=""
 _acq_help_topic=""
 case "$subcommand" in
   help|--help|-h|"")
-    _acq_wants_help=1
     _acq_help_topic="${2:-}"   # `acq help run` -> backend `run --help`
+    _acq_wants_help=1
     ;;
   *)
-    # `acq <sub> --help|-h` -> help for that subcommand. Only honor a help flag
-    # that belongs to acq/the subcommand itself — STOP at the `--` separator, so
-    # args meant for the agent/inner command (`acq run opencode /app -- tool -h`,
-    # `acq exec box -- cmd --help`) pass through verbatim instead of being
-    # hijacked into acq's help.
+    # `acq <sub> [subsub] --help|-h` -> help for that subcommand. Only honor a
+    # help flag that belongs to acq/the subcommand itself — STOP at the `--`
+    # separator, so args meant for the agent/inner command
+    # (`acq run opencode /app -- tool -h`, `acq exec box -- cmd --help`) pass
+    # through verbatim instead of being hijacked into acq's help. Capture the
+    # sub-subcommand too (e.g. `acq secret set --help` -> topic "secret set") so
+    # the topic router / backend help can be verb-precise.
     for _a in "$@"; do
       case "$_a" in
         --) break ;;
-        --help|-h) _acq_wants_help=1; _acq_help_topic="$subcommand"; break ;;
+        --help|-h)
+          _acq_wants_help=1
+          _acq_help_topic="$subcommand"
+          # If the token right after the subcommand is a plain sub-subcommand
+          # (not a flag), include it in the topic (`secret set`, `kit apply`).
+          case "${2:-}" in
+            ""|-*) ;;
+            *) _acq_help_topic="$subcommand ${2}" ;;
+          esac
+          break
+          ;;
       esac
     done
     ;;
 esac
 if [ -n "$_acq_wants_help" ]; then
-  print_help
+  # Prefer acq's OWN per-verb usage for verbs acq owns (secret/kit/backend), so
+  # `acq secret --help` documents the acq verb rather than only the top banner.
+  # For anything else, print the top-level banner. Then append the backend's own
+  # help (best-effort) for additional context.
+  if ! _acq_print_topic_help "$_acq_help_topic"; then
+    print_help
+  fi
   acq_resolve_backend "${explicit_backend}" 2>/dev/null || true
   _acq_backend_help "$_acq_help_topic"
   # A bare `acq` (no subcommand) is a usage error (exit 2); an explicit help
@@ -415,18 +511,9 @@ case "$subcommand" in
         exit 1
         ;;
       --help|-h|"")
-        cat >&2 <<'KITUSAGE'
-acq kit — manage neutral hybrid/v1 kits
-
-Usage:
-  acq kit list                 Show the pinned built-in kits (+ extras)
-  acq kit validate PATH        Validate a neutral kit (dir or spec.yaml)
-  acq kit apply NAME KITREF    Apply a kit to an existing sandbox (mid-life)
-  acq kit check SANDBOX        Report if a sandbox is on the pinned bundle
-  acq kit update SANDBOX [--yes]  Refresh the built-in bundle in place
-
-See docs/BACKEND_GUIDE.md and docs/adr/0011-msb-backend-and-neutral-kits.md.
-KITUSAGE
+        # `acq kit` (no subverb) reaches here; `acq kit --help` is intercepted
+        # earlier by the help router. Print acq's own kit usage (shared source).
+        _acq_kit_usage
         exit 1
         ;;
       *)
@@ -845,33 +932,15 @@ case "$subcommand" in
         exit 1
         ;;
       --help|-h|"")
-        # Print acq's own summary, then delegate to backend for full detail.
-        cat >&2 <<'SECRETUSAGE'
-acq secret — manage sandbox secrets
-
-Usage:
-  acq secret set [-g | SANDBOX] SERVICE [--host HOST --env ENV]
-  acq secret rm  [-g | SANDBOX] SERVICE      # remove an acq-managed secret
-  acq secret rm  [-g | SANDBOX] <placeholder>  # (sbx only: raw placeholder → passthrough)
-  acq secret ls [-g | SANDBOX]               # list acq-managed secrets
-
-Custom endpoints: use `acq secret set SERVICE --host HOST --env ENV` — it stores
-the value in the acq store (off argv), records the host/env binding, and works
-on both backends. The raw backend `secret set-custom` is intentionally NOT
-exposed through acq (it would bypass the acq store). `acq secret import` (a
-planned store-migration helper) is not implemented yet.
-
-`acq secret rm SERVICE` (usai/github/gitlab) deletes the value from the acq
-store and clears the backend's injector. `acq secret ls` lists the secrets acq
-manages (scope, service, whether a value is stored, and the ENV@HOST binding) —
-never the values themselves; on msb the acq store is the source of truth, on sbx
-this shows the sbx proxy table.
-
-The backend's own secret reference follows for context; acq deliberately routes
-all secret storage through its own store (above) rather than the backend's CLI.
-
-Full backend reference:
-SECRETUSAGE
+        # `acq secret` (no subverb) reaches here; `acq secret --help` is
+        # intercepted earlier by the help router. Print acq's own secret usage
+        # (shared source), then the backend's own reference for context.
+        _acq_secret_usage
+        echo "" >&2
+        echo "The backend's own secret reference follows for context; acq deliberately" >&2
+        echo "routes all secret storage through its own store (above)." >&2
+        echo "" >&2
+        echo "Full backend reference:" >&2
         command "${ACQ_RESOLVED_BACKEND}" secret --help
         ;;
       *)

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -130,6 +130,231 @@ acq_debug() {
 # pass a raw placeholder token through to the backend secret CLI.
 ACQ_MANAGED_SECRET_SERVICES=" usai github gitlab "
 
+# _acq_import_env_vars_for SERVICE — echo the host environment variable name(s)
+# that `acq secret import` reads to populate SERVICE, most-preferred first (space
+# separated). These mirror the env vars each backend already honors when binding
+# the service (see the sbx/msb adapters and the kits' env expectations):
+#   usai   <- USAI_API_KEY
+#   github <- GITHUB_TOKEN, then GH_TOKEN (gh CLI's variable)
+#   gitlab <- GITLAB_TOKEN
+# Only acq-managed services are importable; an unknown service echoes nothing.
+_acq_import_env_vars_for() {
+  case "$1" in
+    usai)   printf 'USAI_API_KEY\n' ;;
+    github) printf 'GITHUB_TOKEN GH_TOKEN\n' ;;
+    gitlab) printf 'GITLAB_TOKEN\n' ;;
+    *)      printf '\n' ;;
+  esac
+}
+
+# _acq_import_detect_value SERVICE -> prints "ENVVAR<TAB>VALUE" for the FIRST of
+# SERVICE's candidate env vars that is set and non-empty; empty output (rc 1) if
+# none is set. The value is read from the environment, never argv.
+_acq_import_detect_value() {
+  local service="$1" var val
+  for var in $(_acq_import_env_vars_for "$service"); do
+    eval "val=\${$var:-}"
+    if [ -n "$val" ]; then
+      printf '%s\t%s\n' "$var" "$val"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# _acq_secret_last4 VALUE -> a masked preview "…WXYZ" (last 4 chars) for a Y/n
+# prompt. Never prints more than the last 4 characters; a short value is fully
+# masked. Used only for interactive confirmation feedback.
+_acq_secret_last4() {
+  local v="$1" n=${#1}
+  if [ "$n" -le 4 ]; then
+    printf '…%s\n' "$(printf '%*s' "$n" '' | tr ' ' '*')"
+  else
+    printf '…%s\n' "${v#"${v%????}"}"
+  fi
+}
+
+# _acq_is_managed_service SERVICE -> 0 if SERVICE is an acq-managed service.
+_acq_is_managed_service() {
+  case "$ACQ_MANAGED_SECRET_SERVICES" in
+    *" $1 "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# acq_secret_import [SERVICE] [-g|--global|SANDBOX] [--all] [--force] [--dry-run]
+# ---------------------------------------------------------------------------
+# Scan the host environment for known acq-managed service tokens (usai, github,
+# gitlab) and store each into the acq secret store — the same store `acq secret
+# set` writes and both backends read at provision. This is acq's store-POPULATING
+# migration helper (the inverse of the removed store-BYPASSING backend passthrough);
+# see docs/BACKEND_GUIDE.md "Migration".
+#
+# Scope: GLOBAL by default (like sbx's global keychain — available to every
+# sandbox); pass a SANDBOX name (or -g explicitly) to scope. Existing stored
+# entries are never overwritten silently:
+#   - interactive (default): prompt Y/n per detected service (last-4 preview),
+#     and prompt again before overwriting an existing entry;
+#   - --all: import newly-detected services without prompting, but SKIP any that
+#     already have a stored value (use --force to replace);
+#   - --force: import unconditionally, overwriting existing entries;
+#   - --dry-run: show what WOULD be imported/skipped, write nothing.
+# The value moves from the environment into the store without ever appearing on
+# argv (acq_secret_store reads it from stdin).
+#
+# Returns 0 if the run completed (even if nothing was imported), non-zero only on
+# a usage error or a store write failure.
+acq_secret_import() {
+  local only_service="" scope_sandbox="" mode="interactive" dry_run=0 arg
+  # Parse args: an optional leading SERVICE, an optional scope (-g/--global or a
+  # bare SANDBOX token), and the flags. Order-tolerant for the flags.
+  for arg in "$@"; do
+    case "$arg" in
+      --all)      mode="all" ;;
+      --force|-f) mode="force" ;;
+      --dry-run)  dry_run=1 ;;
+      -g|--global) scope_sandbox="" ;;   # global is already the default
+      -*)
+        echo "acq: secret import: unknown flag '$arg'" >&2
+        echo "     usage: acq secret import [SERVICE] [-g | SANDBOX] [--all] [--force] [--dry-run]" >&2
+        return 1
+        ;;
+      *)
+        # First bare token that is a managed service -> restrict to it; otherwise
+        # treat a bare token as a SANDBOX scope. (A managed service name and a
+        # sandbox name are disjoint in practice; prefer the service reading.)
+        if [ -z "$only_service" ] && _acq_is_managed_service "$arg"; then
+          only_service="$arg"
+        elif [ -z "$scope_sandbox" ]; then
+          scope_sandbox="$arg"
+        else
+          echo "acq: secret import: unexpected extra argument '$arg'" >&2
+          return 1
+        fi
+        ;;
+    esac
+  done
+
+  if ! command -v acq_secret_store >/dev/null 2>&1; then
+    echo "acq: internal error: secret store not loaded" >&2
+    return 1
+  fi
+
+  # Which services to consider: a single named one, or all managed services.
+  local services
+  if [ -n "$only_service" ]; then
+    services="$only_service"
+  else
+    services="$ACQ_MANAGED_SECRET_SERVICES"
+  fi
+
+  local scope_desc="global"
+  [ -n "$scope_sandbox" ] && scope_desc="sandbox '$scope_sandbox'"
+  echo "acq: scanning host environment for known service tokens (scope: ${scope_desc})…" >&2
+  [ "$dry_run" -eq 1 ] && echo "acq: --dry-run: no values will be written." >&2
+
+  local svc detected envvar value key preview imported=0 skipped=0 none=1
+  for svc in $services; do
+    detected=$(_acq_import_detect_value "$svc") || continue
+    none=0
+    envvar=$(printf '%s' "$detected" | cut -f1)
+    value=$(printf '%s' "$detected" | cut -f2-)
+    preview=$(_acq_secret_last4 "$value")
+
+    # Resolve the target key (fails closed on an ambiguous dotted name).
+    if ! key=$(_acq_secret_key "$svc" "$scope_sandbox"); then
+      echo "acq: secret import: skipping '$svc' — ambiguous scope/service name." >&2
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    # Existing-entry handling (overwrite protection).
+    local exists=0
+    acq_secret_has "$svc" "$scope_sandbox" && exists=1
+
+    # --dry-run previews the decision WITHOUT prompting or writing. It reports
+    # what a real run in the current mode would do: --all skips an existing entry
+    # (needs --force), everything else would import/overwrite. This runs before
+    # the interactive no-TTY skip so `--dry-run` works in any context (CI too).
+    if [ "$dry_run" -eq 1 ]; then
+      if [ "$exists" -eq 1 ] && [ "$mode" = "all" ]; then
+        echo "acq: [dry-run] '$svc' already stored (${scope_desc}); would SKIP (use --force)." >&2
+        skipped=$((skipped + 1))
+      elif [ "$exists" -eq 1 ]; then
+        echo "acq: [dry-run] would OVERWRITE '$svc' (${scope_desc}) from \$${envvar} (${preview})." >&2
+        imported=$((imported + 1))
+      else
+        echo "acq: [dry-run] would import '$svc' from \$${envvar} (${preview}) into ${scope_desc}." >&2
+        imported=$((imported + 1))
+      fi
+      continue
+    fi
+
+    if [ "$exists" -eq 1 ] && [ "$mode" = "all" ]; then
+      echo "acq: '$svc' already stored (${scope_desc}); skipping (use --force to overwrite)." >&2
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    # Decide whether to import this one.
+    local do_import=0
+    case "$mode" in
+      all|force) do_import=1 ;;
+      interactive)
+        local prompt ans=""
+        if [ "$exists" -eq 1 ]; then
+          prompt="acq: overwrite stored '$svc' (${scope_desc}) with \$${envvar} (${preview})? [y/N] "
+        else
+          prompt="acq: import '$svc' from \$${envvar} (${preview}) into ${scope_desc}? [y/N] "
+        fi
+        if [ ! -t 0 ] && [ -z "${ACQ_SECRET_IMPORT_ASSUME_YES:-}" ]; then
+          # Non-interactive without --all/--force and no test override: cannot
+          # prompt. Skip rather than guess.
+          echo "acq: '$svc' detected in \$${envvar} but stdin is not a TTY; skipping (use --all/--force)." >&2
+          skipped=$((skipped + 1))
+          continue
+        fi
+        if [ -n "${ACQ_SECRET_IMPORT_ASSUME_YES:-}" ]; then
+          ans="y"
+        else
+          printf '%s' "$prompt" >&2
+          read -r ans 2>/dev/null || ans=""
+        fi
+        case "$ans" in y|Y|yes|YES) do_import=1 ;; *) do_import=0 ;; esac
+        ;;
+    esac
+
+    if [ "$do_import" -ne 1 ]; then
+      echo "acq: skipped '$svc'." >&2
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    # Store the value (from the env, via stdin — never argv).
+    if printf '%s' "$value" | acq_secret_store "$key"; then
+      echo "acq: imported '$svc' (${scope_desc}) from \$${envvar}." >&2
+      imported=$((imported + 1))
+    else
+      echo "acq: error: failed to store '$svc' (${scope_desc})." >&2
+      return 1
+    fi
+    value=""
+  done
+
+  if [ "$none" -eq 1 ]; then
+    echo "acq: no known service tokens found in the environment." >&2
+    if [ -n "$only_service" ]; then
+      echo "     '$only_service' reads: $(_acq_import_env_vars_for "$only_service")" >&2
+    else
+      echo "     Looked for: USAI_API_KEY, GITHUB_TOKEN/GH_TOKEN, GITLAB_TOKEN." >&2
+    fi
+    return 0
+  fi
+  echo "acq: secret import done — ${imported} imported, ${skipped} skipped." >&2
+  return 0
+}
+
+
 # _acq_is_managed_secret_rm ARGS... -> 0 if the `acq secret rm` args name an
 # acq-managed secret (scope + known service), else 1 (pass through to backend).
 # Recognizes:  -g SERVICE  |  --global SERVICE  |  SANDBOX SERVICE

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -147,26 +147,53 @@ _acq_import_env_vars_for() {
   esac
 }
 
-# _acq_import_detect_value SERVICE -> prints "ENVVAR<TAB>VALUE" for the FIRST of
-# SERVICE's candidate env vars that is set and non-empty; empty output (rc 1) if
-# none is set. The value is read from the environment, never argv.
-_acq_import_detect_value() {
+# _acq_import_detect_var SERVICE -> prints the NAME of the FIRST of SERVICE's
+# candidate env vars that is set and non-empty; empty output (rc 1) if none is
+# set. Returns the variable NAME ONLY — never the value — so the secret value is
+# never packed into a string that is later re-parsed or echoed (which previously
+# truncated multi-line values and leaked a fragment to stderr). Callers read the
+# value directly from the named variable at the point of use and pipe it straight
+# to the store.
+_acq_import_detect_var() {
   local service="$1" var val
   for var in $(_acq_import_env_vars_for "$service"); do
     eval "val=\${$var:-}"
     if [ -n "$val" ]; then
-      printf '%s\t%s\n' "$var" "$val"
+      printf '%s\n' "$var"
       return 0
     fi
   done
   return 1
 }
 
-# _acq_secret_last4 VALUE -> a masked preview "…WXYZ" (last 4 chars) for a Y/n
-# prompt. Never prints more than the last 4 characters; a short value is fully
-# masked. Used only for interactive confirmation feedback.
-_acq_secret_last4() {
-  local v="$1" n=${#1}
+# _acq_import_value_is_storable ENVVAR -> 0 if the value in ENVVAR is safe to
+# store in acq's single-line secret store; 1 otherwise. The store persists a
+# single line, so a value containing a newline or TAB cannot round-trip intact —
+# storing it would silently truncate the credential. Fail closed on such values
+# (the caller reports the rejection WITHOUT ever printing the value). Reads the
+# value by name; never echoes or copies it into argv.
+_acq_import_value_is_storable() {
+  local val nl tab
+  eval "val=\${$1:-}"
+  nl=$(printf '\n_'); nl=${nl%_}   # a literal newline (command subst strips it otherwise)
+  tab=$(printf '\t')
+  case "$val" in
+    *"$nl"*) return 1 ;;
+    *"$tab"*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# _acq_secret_last4_of ENVVAR -> a masked preview "…WXYZ" (last 4 chars) of the
+# value held in ENVVAR, for a Y/n prompt. Reads the value BY NAME (never via
+# argv) and prints at most the last 4 characters; a short value is fully masked.
+# Used only for interactive confirmation feedback. A newline/tab in the value is
+# irrelevant here (such values are rejected before this is called), but the
+# last-4 slice is inherently bounded regardless.
+_acq_secret_last4_of() {
+  local v n
+  eval "v=\${$1:-}"
+  n=${#v}
   if [ "$n" -le 4 ]; then
     printf '…%s\n' "$(printf '%*s' "$n" '' | tr ' ' '*')"
   else
@@ -182,37 +209,112 @@ _acq_is_managed_service() {
   esac
 }
 
-# acq_secret_import [SERVICE] [-g|--global|SANDBOX] [--all] [--force] [--dry-run]
+# _acq_import_decide MODE DRY_RUN EXISTS -> prints one of "import", "skip", or
+# "prompt" on stdout: the decision for a single detected service under MODE
+# (interactive|all|force), whether this is a DRY_RUN (1/0), and whether an entry
+# already EXISTS (1/0). Keeps acq_secret_import's per-service loop small (≤50
+# lines) and the mode/overwrite policy in one testable place. Never touches the
+# secret value.
+_acq_import_decide() {
+  local mode="$1" dry_run="$2" exists="$3"
+  case "$mode" in
+    all)   [ "$exists" -eq 1 ] && { printf 'skip\n'; return 0; }; printf 'import\n' ;;
+    force) printf 'import\n' ;;
+    *)     printf 'prompt\n' ;;   # interactive
+  esac
+}
+
+# _acq_import_confirm SVC ENVVAR SCOPE_DESC EXISTS PREVIEW -> 0 to proceed, 1 to
+# skip. Handles the interactive Y/n gate: honors ACQ_SECRET_IMPORT_ASSUME_YES
+# (test/non-interactive override), skips (rc 1) when stdin is not a TTY, else
+# prompts. All prompt text is built from names/labels only — never the value.
+_acq_import_confirm() {
+  local svc="$1" envvar="$2" scope_desc="$3" exists="$4" preview="$5" ans=""
+  if [ ! -t 0 ] && [ -z "${ACQ_SECRET_IMPORT_ASSUME_YES:-}" ]; then
+    echo "acq: '$svc' detected in \$${envvar} but stdin is not a TTY; skipping (use --all/--force)." >&2
+    return 1
+  fi
+  if [ -n "${ACQ_SECRET_IMPORT_ASSUME_YES:-}" ]; then
+    return 0
+  fi
+  if [ "$exists" -eq 1 ]; then
+    printf 'acq: overwrite stored %s (%s) with $%s (%s)? [y/N] ' "$svc" "$scope_desc" "$envvar" "$preview" >&2
+  else
+    printf 'acq: import %s from $%s (%s) into %s? [y/N] ' "$svc" "$envvar" "$preview" "$scope_desc" >&2
+  fi
+  read -r ans 2>/dev/null || ans=""
+  case "$ans" in y|Y|yes|YES) return 0 ;; *) return 1 ;; esac
+}
+
+# _acq_import_one SVC ENVVAR KEY SCOPE_DESC MODE DRY_RUN EXISTS
 # ---------------------------------------------------------------------------
-# Scan the host environment for known acq-managed service tokens (usai, github,
-# gitlab) and store each into the acq secret store — the same store `acq secret
-# set` writes and both backends read at provision. This is acq's store-POPULATING
-# migration helper (the inverse of the removed store-BYPASSING backend passthrough);
-# see docs/BACKEND_GUIDE.md "Migration".
-#
-# Scope: GLOBAL by default (like sbx's global keychain — available to every
-# sandbox); pass a SANDBOX name (or -g explicitly) to scope. Existing stored
-# entries are never overwritten silently:
-#   - interactive (default): prompt Y/n per detected service (last-4 preview),
-#     and prompt again before overwriting an existing entry;
-#   - --all: import newly-detected services without prompting, but SKIP any that
-#     already have a stored value (use --force to replace);
-#   - --force: import unconditionally, overwriting existing entries;
-#   - --dry-run: show what WOULD be imported/skipped, write nothing.
-# The value moves from the environment into the store without ever appearing on
-# argv (acq_secret_store reads it from stdin).
-#
-# Returns 0 if the run completed (even if nothing was imported), non-zero only on
-# a usage error or a store write failure.
-acq_secret_import() {
+# Handle a single detected service: apply the mode/overwrite decision, prompt if
+# interactive, and (unless --dry-run) store the value. The value is read DIRECTLY
+# from the named env var ($ENVVAR) and piped straight to the store — it is never
+# packed into a parsed string, never placed on argv, and never interpolated into
+# a message (all user-facing text is built from $SVC/$ENVVAR/$SCOPE_DESC only).
+# Prints its own progress to stderr. Echoes a single result token on stdout:
+# "imported", "skipped", or "" + non-zero on a store write failure.
+_acq_import_one() {
+  local svc="$1" envvar="$2" key="$3" scope_desc="$4" mode="$5" dry_run="$6" exists="$7"
+  local preview decision _v
+  preview=$(_acq_secret_last4_of "$envvar")
+
+  if [ "$dry_run" -eq 1 ]; then
+    if [ "$exists" -eq 1 ] && [ "$mode" = "all" ]; then
+      echo "acq: [dry-run] '$svc' already stored (${scope_desc}); would SKIP (use --force)." >&2
+      printf 'skipped\n'
+    elif [ "$exists" -eq 1 ]; then
+      echo "acq: [dry-run] would OVERWRITE '$svc' (${scope_desc}) from \$${envvar} (${preview})." >&2
+      printf 'imported\n'
+    else
+      echo "acq: [dry-run] would import '$svc' from \$${envvar} (${preview}) into ${scope_desc}." >&2
+      printf 'imported\n'
+    fi
+    return 0
+  fi
+
+  decision=$(_acq_import_decide "$mode" "$dry_run" "$exists")
+  if [ "$decision" = "skip" ]; then
+    echo "acq: '$svc' already stored (${scope_desc}); skipping (use --force to overwrite)." >&2
+    printf 'skipped\n'; return 0
+  fi
+  if [ "$decision" = "prompt" ] && ! _acq_import_confirm "$svc" "$envvar" "$scope_desc" "$exists" "$preview"; then
+    # Non-TTY skip already logged its reason; an explicit "no" gets a generic note.
+    [ -t 0 ] && echo "acq: skipped '$svc'." >&2
+    printf 'skipped\n'; return 0
+  fi
+
+  # Store the value read DIRECTLY from the named env var (never argv, never a
+  # parsed copy) piped straight to the single-line store. Read by name into a
+  # local, then pipe — no command substitution (which would strip a trailing
+  # newline) and no interpolation into any message.
+  eval "_v=\${$envvar}"
+  if printf '%s' "$_v" | acq_secret_store "$key"; then
+    _v=""
+    echo "acq: imported '$svc' (${scope_desc}) from \$${envvar}." >&2
+    printf 'imported\n'; return 0
+  fi
+  _v=""
+  echo "acq: error: failed to store '$svc' (${scope_desc})." >&2
+  return 1
+}
+
+# _acq_import_parse_args ARGS... -> on success prints "MODE<TAB>DRY_RUN<TAB>SERVICE<TAB>SANDBOX"
+# (SERVICE/SANDBOX may be empty), rc 0; on a usage error prints nothing and
+# returns 1 (the caller emits the error — this parser writes the specific
+# message to stderr itself before returning). MODE is interactive|all|force.
+# These fields are all flags/short identifiers (never a secret), so the TAB
+# framing is safe here (unlike a secret value). Recognizes: an optional leading
+# managed-SERVICE, then a scope (-g/--global or a bare SANDBOX token), plus
+# --all / --force|-f / --dry-run in any order.
+_acq_import_parse_args() {
   local only_service="" scope_sandbox="" mode="interactive" dry_run=0 arg
-  # Parse args: an optional leading SERVICE, an optional scope (-g/--global or a
-  # bare SANDBOX token), and the flags. Order-tolerant for the flags.
   for arg in "$@"; do
     case "$arg" in
-      --all)      mode="all" ;;
-      --force|-f) mode="force" ;;
-      --dry-run)  dry_run=1 ;;
+      --all)       mode="all" ;;
+      --force|-f)  mode="force" ;;
+      --dry-run)   dry_run=1 ;;
       -g|--global) scope_sandbox="" ;;   # global is already the default
       -*)
         echo "acq: secret import: unknown flag '$arg'" >&2
@@ -220,9 +322,8 @@ acq_secret_import() {
         return 1
         ;;
       *)
-        # First bare token that is a managed service -> restrict to it; otherwise
-        # treat a bare token as a SANDBOX scope. (A managed service name and a
-        # sandbox name are disjoint in practice; prefer the service reading.)
+        # First bare token that is a managed service -> restrict to it; a second
+        # bare token is the SANDBOX scope (NOT a second service).
         if [ -z "$only_service" ] && _acq_is_managed_service "$arg"; then
           only_service="$arg"
         elif [ -z "$scope_sandbox" ]; then
@@ -234,6 +335,41 @@ acq_secret_import() {
         ;;
     esac
   done
+  printf '%s\t%s\t%s\t%s\n' "$mode" "$dry_run" "$only_service" "$scope_sandbox"
+}
+
+# acq_secret_import [SERVICE] [-g|--global|SANDBOX] [--all] [--force] [--dry-run]
+# ---------------------------------------------------------------------------
+# Scan the host environment for known acq-managed service tokens (usai, github,
+# gitlab) and store each into the acq secret store — the same store `acq secret
+# set` writes and both backends read at provision. This is acq's store-POPULATING
+# migration helper (the inverse of the removed store-BYPASSING backend passthrough);
+# see docs/BACKEND_GUIDE.md "Migration".
+#
+# Scope: GLOBAL by default (like sbx's global keychain — available to every
+# sandbox); pass a SANDBOX name (or -g explicitly) to scope. A second bare token
+# after a SERVICE is treated as the SANDBOX scope, NOT a second service. Existing
+# stored entries are never overwritten silently:
+#   - interactive (default): prompt Y/n per detected service (last-4 preview),
+#     and prompt again before overwriting an existing entry;
+#   - --all: import newly-detected services without prompting, but SKIP any that
+#     already have a stored value (use --force / -f to replace);
+#   - --force / -f: import unconditionally, overwriting existing entries;
+#   - --dry-run: show what WOULD be imported/skipped, write nothing.
+# The value moves from the environment into the store without ever appearing on
+# argv (acq_secret_store reads it from stdin). A value containing a newline or TAB
+# is REJECTED (fail closed) because the single-line store cannot round-trip it —
+# the rejection never prints the value.
+#
+# Returns 0 if the run completed (even if nothing was imported), non-zero only on
+# a usage error or a store write failure.
+acq_secret_import() {
+  local parsed mode dry_run only_service scope_sandbox
+  parsed=$(_acq_import_parse_args "$@") || return 1
+  mode=$(printf '%s' "$parsed" | cut -f1)
+  dry_run=$(printf '%s' "$parsed" | cut -f2)
+  only_service=$(printf '%s' "$parsed" | cut -f3)
+  scope_sandbox=$(printf '%s' "$parsed" | cut -f4)
 
   if ! command -v acq_secret_store >/dev/null 2>&1; then
     echo "acq: internal error: secret store not loaded" >&2
@@ -241,104 +377,38 @@ acq_secret_import() {
   fi
 
   # Which services to consider: a single named one, or all managed services.
-  local services
-  if [ -n "$only_service" ]; then
-    services="$only_service"
-  else
-    services="$ACQ_MANAGED_SECRET_SERVICES"
-  fi
+  local services="$ACQ_MANAGED_SECRET_SERVICES"
+  [ -n "$only_service" ] && services="$only_service"
 
   local scope_desc="global"
   [ -n "$scope_sandbox" ] && scope_desc="sandbox '$scope_sandbox'"
   echo "acq: scanning host environment for known service tokens (scope: ${scope_desc})…" >&2
   [ "$dry_run" -eq 1 ] && echo "acq: --dry-run: no values will be written." >&2
 
-  local svc detected envvar value key preview imported=0 skipped=0 none=1
+  local svc envvar key exists result imported=0 skipped=0 none=1
   for svc in $services; do
-    detected=$(_acq_import_detect_value "$svc") || continue
+    envvar=$(_acq_import_detect_var "$svc") || continue
     none=0
-    envvar=$(printf '%s' "$detected" | cut -f1)
-    value=$(printf '%s' "$detected" | cut -f2-)
-    preview=$(_acq_secret_last4 "$value")
-
-    # Resolve the target key (fails closed on an ambiguous dotted name).
+    # Reject values the single-line store cannot round-trip (fail closed; the
+    # value is never printed).
+    if ! _acq_import_value_is_storable "$envvar"; then
+      echo "acq: refusing '$svc' — \$${envvar} contains a newline or tab, which the acq secret store cannot store intact. Set a single-line value and retry." >&2
+      skipped=$((skipped + 1))
+      continue
+    fi
     if ! key=$(_acq_secret_key "$svc" "$scope_sandbox"); then
       echo "acq: secret import: skipping '$svc' — ambiguous scope/service name." >&2
       skipped=$((skipped + 1))
       continue
     fi
-
-    # Existing-entry handling (overwrite protection).
-    local exists=0
+    exists=0
     acq_secret_has "$svc" "$scope_sandbox" && exists=1
-
-    # --dry-run previews the decision WITHOUT prompting or writing. It reports
-    # what a real run in the current mode would do: --all skips an existing entry
-    # (needs --force), everything else would import/overwrite. This runs before
-    # the interactive no-TTY skip so `--dry-run` works in any context (CI too).
-    if [ "$dry_run" -eq 1 ]; then
-      if [ "$exists" -eq 1 ] && [ "$mode" = "all" ]; then
-        echo "acq: [dry-run] '$svc' already stored (${scope_desc}); would SKIP (use --force)." >&2
-        skipped=$((skipped + 1))
-      elif [ "$exists" -eq 1 ]; then
-        echo "acq: [dry-run] would OVERWRITE '$svc' (${scope_desc}) from \$${envvar} (${preview})." >&2
-        imported=$((imported + 1))
-      else
-        echo "acq: [dry-run] would import '$svc' from \$${envvar} (${preview}) into ${scope_desc}." >&2
-        imported=$((imported + 1))
-      fi
-      continue
-    fi
-
-    if [ "$exists" -eq 1 ] && [ "$mode" = "all" ]; then
-      echo "acq: '$svc' already stored (${scope_desc}); skipping (use --force to overwrite)." >&2
-      skipped=$((skipped + 1))
-      continue
-    fi
-
-    # Decide whether to import this one.
-    local do_import=0
-    case "$mode" in
-      all|force) do_import=1 ;;
-      interactive)
-        local prompt ans=""
-        if [ "$exists" -eq 1 ]; then
-          prompt="acq: overwrite stored '$svc' (${scope_desc}) with \$${envvar} (${preview})? [y/N] "
-        else
-          prompt="acq: import '$svc' from \$${envvar} (${preview}) into ${scope_desc}? [y/N] "
-        fi
-        if [ ! -t 0 ] && [ -z "${ACQ_SECRET_IMPORT_ASSUME_YES:-}" ]; then
-          # Non-interactive without --all/--force and no test override: cannot
-          # prompt. Skip rather than guess.
-          echo "acq: '$svc' detected in \$${envvar} but stdin is not a TTY; skipping (use --all/--force)." >&2
-          skipped=$((skipped + 1))
-          continue
-        fi
-        if [ -n "${ACQ_SECRET_IMPORT_ASSUME_YES:-}" ]; then
-          ans="y"
-        else
-          printf '%s' "$prompt" >&2
-          read -r ans 2>/dev/null || ans=""
-        fi
-        case "$ans" in y|Y|yes|YES) do_import=1 ;; *) do_import=0 ;; esac
-        ;;
+    result=$(_acq_import_one "$svc" "$envvar" "$key" "$scope_desc" "$mode" "$dry_run" "$exists") \
+      || return 1
+    case "$result" in
+      imported) imported=$((imported + 1)) ;;
+      skipped)  skipped=$((skipped + 1)) ;;
     esac
-
-    if [ "$do_import" -ne 1 ]; then
-      echo "acq: skipped '$svc'." >&2
-      skipped=$((skipped + 1))
-      continue
-    fi
-
-    # Store the value (from the env, via stdin — never argv).
-    if printf '%s' "$value" | acq_secret_store "$key"; then
-      echo "acq: imported '$svc' (${scope_desc}) from \$${envvar}." >&2
-      imported=$((imported + 1))
-    else
-      echo "acq: error: failed to store '$svc' (${scope_desc})." >&2
-      return 1
-    fi
-    value=""
   done
 
   if [ "$none" -eq 1 ]; then

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -399,9 +399,12 @@ swap-on-access placeholders) remains a larger future effort tracked separately.
 > re-prompted). To pull tokens straight from your shell environment instead, run
 > `acq secret import` — it scans for known service vars (`USAI_API_KEY`,
 > `GITHUB_TOKEN`/`GH_TOKEN`, `GITLAB_TOKEN`) and stores each in the acq store
-> (global by default; pass a SANDBOX to scope). It prompts before each import
+> (global by default; pass a SANDBOX to scope — a second bare token after a
+> SERVICE is the SANDBOX, not a second service). It prompts before each import
 > and before overwriting; `--all` imports non-interactively (skipping existing),
-> `--force` overwrites, and `--dry-run` previews without writing.
+> `--force` (or `-f`) overwrites, and `--dry-run` previews without writing. A
+> value containing a newline or tab is refused (the single-line store cannot hold
+> it intact).
 >
 > **Overwriting:** `acq secret set` is non-destructive toward sbx — if sbx
 > already holds the secret it stops with an `sbx secret rm …` hint rather than

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -396,7 +396,12 @@ swap-on-access placeholders) remains a larger future effort tracked separately.
 
 > **Migration:** if you previously stored the USAi key with `sbx secret …`, run
 > `acq secret set -g usai` once to move it into the acq store (the value is
-> re-prompted). A future `acq secret import` will automate this.
+> re-prompted). To pull tokens straight from your shell environment instead, run
+> `acq secret import` — it scans for known service vars (`USAI_API_KEY`,
+> `GITHUB_TOKEN`/`GH_TOKEN`, `GITLAB_TOKEN`) and stores each in the acq store
+> (global by default; pass a SANDBOX to scope). It prompts before each import
+> and before overwriting; `--all` imports non-interactively (skipping existing),
+> `--force` overwrites, and `--dry-run` previews without writing.
 >
 > **Overwriting:** `acq secret set` is non-destructive toward sbx — if sbx
 > already holds the secret it stops with an `sbx secret rm …` hint rather than

--- a/docs/explorations/acq-design.md
+++ b/docs/explorations/acq-design.md
@@ -79,7 +79,7 @@ The `acq` command surface mirrors the subset of `sbx`/`msb`/`ppp` operations the
   - Warn if no SSH signing key in `ssh-add -L` (for git-ssh-sign kit).
   - Warn if no repo-local `user.email` (for GitHub-verified commits).
 - **Multi-workspace:** `acq run opencode ~/my-app ~/my-other-app:ro` — forward the extra mounts to the backend's mount mechanism.
-- **Pass-through:** unknown `acq` subcommands are forwarded to the active backend's CLI (rare; documented escape hatch). acq prints a one-line stderr notice before forwarding so the user knows the verb is not acq's and that any output/errors below come from the backend, not acq. Verbs acq *owns* (`run`, `create`, `secret`, `kit`, `backend`, …) never fall through — a malformed invocation of an owned verb fails closed with acq's own usage error.
+- **Pass-through:** unknown `acq` subcommands are forwarded to the active backend's CLI (rare; documented escape hatch). acq prints a one-line stderr notice before forwarding so the user knows the verb is not acq's and that any output/errors below come from the backend, not acq. Verbs acq _owns_ (`run`, `create`, `secret`, `kit`, `backend`, …) never fall through — a malformed invocation of an owned verb fails closed with acq's own usage error.
 - **Config search path:** `~/.acq/config.yaml` → `<repo>/.acqrc` → env vars → CLI flags.
 - **`acq doctor`** is platform-aware: it checks what's installed, prints a matrix `[sbx: installed v0.34.0] [ppp: not found] [msb: installed v0.6.1]`, and asks `Choose default backend [sbx/msb/ppp]:` to write to `~/.acq/config.yaml`.
 
@@ -831,8 +831,11 @@ can distinguish "not done yet" from "done differently":
     defaulting to global. This mirrors `sbx secret set` / `set-custom` and
     prevents accidentally overwriting the global USAi key during testing.
     Use `acq secret set -g usai` for global, or `acq secret set SANDBOX usai`
-    to scope to a single sandbox. All other `acq secret` subcommands
-    (`ls`, `rm`, `import`, `set-custom`, `--help`) pass through to sbx unchanged.
+    to scope to a single sandbox. `acq secret rm`/`ls` also route through the acq
+    store. The store-bypassing backend subverbs `set-custom` and `import` are NOT
+    exposed through acq: `set-custom` fails closed with a pointer to
+    `acq secret set … --host … --env …` (the store-aware equivalent), and
+    `import` is reserved for a future store-migration helper (not implemented).
 
 ### What is implemented (Phase 2 / 1.2.0)
 

--- a/docs/explorations/acq-design.md
+++ b/docs/explorations/acq-design.md
@@ -79,7 +79,7 @@ The `acq` command surface mirrors the subset of `sbx`/`msb`/`ppp` operations the
   - Warn if no SSH signing key in `ssh-add -L` (for git-ssh-sign kit).
   - Warn if no repo-local `user.email` (for GitHub-verified commits).
 - **Multi-workspace:** `acq run opencode ~/my-app ~/my-other-app:ro` — forward the extra mounts to the backend's mount mechanism.
-- **Pass-through:** unknown `acq` subcommands are forwarded to the active backend's CLI untouched (rare; documented escape hatch).
+- **Pass-through:** unknown `acq` subcommands are forwarded to the active backend's CLI (rare; documented escape hatch). acq prints a one-line stderr notice before forwarding so the user knows the verb is not acq's and that any output/errors below come from the backend, not acq. Verbs acq *owns* (`run`, `create`, `secret`, `kit`, `backend`, …) never fall through — a malformed invocation of an owned verb fails closed with acq's own usage error.
 - **Config search path:** `~/.acq/config.yaml` → `<repo>/.acqrc` → env vars → CLI flags.
 - **`acq doctor`** is platform-aware: it checks what's installed, prints a matrix `[sbx: installed v0.34.0] [ppp: not found] [msb: installed v0.6.1]`, and asks `Choose default backend [sbx/msb/ppp]:` to write to `~/.acq/config.yaml`.
 
@@ -478,7 +478,7 @@ class IsolationBackend(ABC):
         """List all sandboxes known to this backend. Default raises."""
 ```
 
-The wrapper's common logic (name derivation, USAi key check via `run(curl)`, git identity check, SSH agent check, kit translations) lives in `common.sh` and calls the adapter's abstract methods. Each backend adapter is the only place that knows its backend's specific CLI shape; unknown subcommands pass through untouched (escape hatch).
+The wrapper's common logic (name derivation, USAi key check via `run(curl)`, git identity check, SSH agent check, kit translations) lives in `common.sh` and calls the adapter's abstract methods. Each backend adapter is the only place that knows its backend's specific CLI shape; unknown subcommands pass through to the backend (escape hatch) with an announced stderr notice, while malformed invocations of acq-owned verbs fail closed with acq's own error rather than leaking a raw backend error.
 
 ### Concrete adapter hookups
 
@@ -750,7 +750,8 @@ Both will reference this document (`docs/adr/agentic-coding-quickstart-v2-design
   qsbx-parity subset plus `backend`/`doctor`:
   `run`, `create`, `ls`, `stop`, `rm`, `exec`, `cp`, `ports`, `secret set`,
   `usai-rotate-api-key`, `version`, `doctor`, `backend list`, `backend set`.
-  Unknown subcommands pass through to the active backend CLI.
+  Unknown subcommands pass through to the active backend CLI (announced on
+  stderr).
 - **`acq.backends/common.sh`** — backend-agnostic logic: kit constants (same
   four sbx-kit refs, same pinned `PATTERNS_KIT_REF` as qsbx), backend
   resolution (`--backend` flag → `ACQ_BACKEND` env → XDG config → auto-detect),

--- a/docs/explorations/acq-design.md
+++ b/docs/explorations/acq-design.md
@@ -832,10 +832,12 @@ can distinguish "not done yet" from "done differently":
     prevents accidentally overwriting the global USAi key during testing.
     Use `acq secret set -g usai` for global, or `acq secret set SANDBOX usai`
     to scope to a single sandbox. `acq secret rm`/`ls` also route through the acq
-    store. The store-bypassing backend subverbs `set-custom` and `import` are NOT
-    exposed through acq: `set-custom` fails closed with a pointer to
-    `acq secret set … --host … --env …` (the store-aware equivalent), and
-    `import` is reserved for a future store-migration helper (not implemented).
+    store. `acq secret import` scans the host environment for known service
+    tokens (usai/github/gitlab) and stores each in the acq store (global by
+    default, SANDBOX-scopable; interactive with `--all`/`--force`/`--dry-run`) —
+    the store-populating counterpart to `set`. The store-BYPASSING backend
+    subverb `set-custom` is NOT exposed through acq: it fails closed with a
+    pointer to `acq secret set … --host … --env …` (the store-aware equivalent).
 
 ### What is implemented (Phase 2 / 1.2.0)
 

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1142,6 +1142,22 @@ assert_contains "classify: lone placeholder is passthrough" "$classify_out" "lon
 assert_contains "classify: unknown service is passthrough" "$classify_out" "g-unknown=passthru"
 cleanup_stubs
 
+# 5h3b. Regression: on msb, `acq secret rm SERVICE` with NO scope (a lone token)
+#       must NOT be passed through to a nonexistent `msb secret` CLI (which
+#       produced a confusing "unrecognized subcommand 'secret'" from msb). Since
+#       the msb backend owns the acq secret store natively (it defines
+#       acq_backend_secret_ls) there is no raw-placeholder passthrough — acq must
+#       fail closed with its own scope-required usage error and never invoke msb.
+make_stubs; load_acq
+: > "$CALLS"
+lone_out=$(ACQ_BACKEND=msb "$ACQ" secret rm openchamber-setup 2>&1); lone_rc=$?
+lone_log=$(cat "$CALLS")
+assert_contains "secret rm(msb): lone token errors with scope-required" "$lone_out" "scope required"
+[ "$lone_rc" -ne 0 ] && pass "secret rm(msb): lone token exits non-zero" \
+  || fail "secret rm(msb): lone token must exit non-zero" "rc=$lone_rc"
+assert_not_contains "secret rm(msb): lone token never invokes 'msb secret'" "$lone_log" "msb secret"
+cleanup_stubs
+
 # ===========================================================================
 # 6. Kit list completeness (the four built-in kits)
 # ===========================================================================

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1226,6 +1226,38 @@ assert_contains "help: --help after -- passes through to backend exec" "$afterdd
 assert_not_contains "help: --help after -- did NOT print acq help" "$afterdd_log" "agentic coding quickstart wrapper"
 cleanup_stubs
 
+# 7b2. Per-subcommand `--help` prints acq's OWN per-verb usage for verbs acq owns
+#      (secret/kit/backend), not merely the top-level banner. `acq secret set
+#      --help` (a sub-subcommand) routes to the `secret` usage too. Non-owned
+#      topics (run) still show the top-level banner. All exit 0.
+make_stubs
+# secret family
+sec_help=$(ACQ_BACKEND=sbx "$ACQ" secret --help 2>&1); sec_rc=$?
+assert_eq "help: 'secret --help' exits 0" "0" "$sec_rc"
+assert_contains "help: 'secret --help' shows acq secret usage" "$sec_help" "acq secret — manage sandbox secrets"
+assert_contains "help: 'secret --help' documents import" "$sec_help" "acq secret import"
+assert_not_contains "help: 'secret --help' is NOT just the top banner" "$sec_help" "agentic coding quickstart wrapper"
+secset_help=$(ACQ_BACKEND=sbx "$ACQ" secret set --help 2>&1)
+assert_contains "help: 'secret set --help' routes to secret usage" "$secset_help" "acq secret — manage sandbox secrets"
+secimp_help=$(ACQ_BACKEND=sbx "$ACQ" secret import --help 2>&1)
+assert_contains "help: 'secret import --help' routes to secret usage" "$secimp_help" "acq secret import"
+# kit family
+kit_help=$(ACQ_BACKEND=sbx "$ACQ" kit --help 2>&1); kit_rc=$?
+assert_eq "help: 'kit --help' exits 0" "0" "$kit_rc"
+assert_contains "help: 'kit --help' shows acq kit usage" "$kit_help" "acq kit — manage neutral hybrid/v1 kits"
+kitapply_help=$(ACQ_BACKEND=sbx "$ACQ" kit apply --help 2>&1)
+assert_contains "help: 'kit apply --help' routes to kit usage" "$kitapply_help" "acq kit — manage neutral hybrid/v1 kits"
+# backend family
+be_help=$(ACQ_BACKEND=sbx "$ACQ" backend --help 2>&1); be_rc=$?
+assert_eq "help: 'backend --help' exits 0" "0" "$be_rc"
+assert_contains "help: 'backend --help' shows acq backend usage" "$be_help" "acq backend — select the sandbox backend"
+beset_help=$(ACQ_BACKEND=sbx "$ACQ" backend set --help 2>&1)
+assert_contains "help: 'backend set --help' routes to backend usage" "$beset_help" "acq backend — select the sandbox backend"
+# non-owned verb: still the top-level banner
+run_help=$(ACQ_BACKEND=sbx "$ACQ" run --help 2>&1)
+assert_contains "help: 'run --help' shows the top-level banner" "$run_help" "agentic coding quickstart wrapper"
+cleanup_stubs
+
 # 7c. `acq secret ls` is a silent acq-store view (delegates to the backend on
 #     sbx WITHOUT doubling the token and WITHOUT a passthrough notice — it is an
 #     acq-owned verb, not an escape hatch).

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -717,11 +717,15 @@ log=$(cat "$CALLS")
 assert_contains "dispatch: exec -> sbx exec" "$log" "sbx exec mybox"
 cleanup_stubs
 
-# Verify unknown subcommand passes through to sbx.
+# Verify unknown subcommand passes through to sbx, and that the handoff is
+# ANNOUNCED on stderr (the user must know it left acq's vocabulary and that
+# subsequent output/errors are the backend's, not acq's).
 make_stubs
-out=$(ACQ_BACKEND=sbx "$ACQ" policy init balanced 2>/dev/null; true)
+out=$(ACQ_BACKEND=sbx "$ACQ" policy init balanced 2>&1; true)
 log=$(cat "$CALLS")
 assert_contains "dispatch: unknown passthrough -> sbx" "$log" "sbx policy"
+assert_contains "dispatch: unknown passthrough is announced" "$out" "not an acq subcommand — forwarding to 'sbx'"
+assert_contains "dispatch: passthrough notice attributes output to backend" "$out" "from 'sbx', not acq"
 cleanup_stubs
 
 # --kit interception: a user-supplied `--kit <ref>` on run/create MUST be
@@ -1224,18 +1228,38 @@ cleanup_stubs
 
 # 7c. `acq secret ls|import|set-custom` pass through to the backend WITHOUT
 #     doubling the subcommand token (regression: `sbx secret ls ls`). The set/rm
-#     branches shift; this branch must too.
+#     branches shift; this branch must too. import/set-custom additionally
+#     ANNOUNCE the handoff (they skip the acq secret store) while ls is a silent
+#     acq-store view (no notice).
 make_stubs
 : > "$CALLS"
-ACQ_BACKEND=sbx "$ACQ" secret ls -q >/dev/null 2>&1 || true
+ls_out=$(ACQ_BACKEND=sbx "$ACQ" secret ls -q 2>&1 || true)
 ls_log=$(cat "$CALLS")
 assert_contains "secret ls: forwards a single ls token" "$ls_log" "sbx secret ls -q"
 assert_not_contains "secret ls: does NOT double the token" "$ls_log" "secret ls ls"
+assert_not_contains "secret ls: not announced as a passthrough" "$ls_out" "forwarding to"
 : > "$CALLS"
-ACQ_BACKEND=sbx "$ACQ" secret set-custom -g --host h --env E >/dev/null 2>&1 || true
+sc_out=$(ACQ_BACKEND=sbx "$ACQ" secret set-custom -g --host h --env E 2>&1 || true)
 sc_log=$(cat "$CALLS")
 assert_contains "secret set-custom: single token" "$sc_log" "sbx secret set-custom -g --host h --env E"
 assert_not_contains "secret set-custom: not doubled" "$sc_log" "set-custom set-custom"
+assert_contains "secret set-custom: announces it skips the acq store" "$sc_out" "not wired through the acq secret store"
+assert_contains "secret set-custom: attributes output to backend" "$sc_out" "from 'sbx', not acq"
+cleanup_stubs
+
+# 7d. An unrecognized `secret` subverb is an acq-vocabulary mistake — acq owns
+#     the `secret` verb, so it must fail closed with acq's own error and NOT
+#     forward the token to the backend (which would surface a confusing raw
+#     backend error, or worse, silently accept something acq never meant to
+#     expose).
+make_stubs
+: > "$CALLS"
+bad_out=$(ACQ_BACKEND=sbx "$ACQ" secret bogus-verb 2>&1); bad_rc=$?
+bad_log=$(cat "$CALLS")
+assert_contains "secret bogus: acq's own unknown-subcommand error" "$bad_out" "unknown secret subcommand 'bogus-verb'"
+[ "$bad_rc" -ne 0 ] && pass "secret bogus: exits non-zero" \
+  || fail "secret bogus: must exit non-zero" "rc=$bad_rc"
+assert_not_contains "secret bogus: never forwards to the backend" "$bad_log" "sbx secret"
 cleanup_stubs
 
 # ===========================================================================

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -723,7 +723,10 @@ cleanup_stubs
 make_stubs
 out=$(ACQ_BACKEND=sbx "$ACQ" policy init balanced 2>&1; true)
 log=$(cat "$CALLS")
-assert_contains "dispatch: unknown passthrough -> sbx" "$log" "sbx policy"
+assert_contains "dispatch: unknown passthrough -> sbx" "$log" "sbx policy init balanced"
+# Regression: the verb must NOT be doubled (`sbx policy policy init balanced`).
+# The dispatch case block must shift the subcommand before forwarding.
+assert_not_contains "dispatch: passthrough does NOT double the verb" "$log" "sbx policy policy"
 assert_contains "dispatch: unknown passthrough is announced" "$out" "not an acq subcommand — forwarding to 'sbx'"
 assert_contains "dispatch: passthrough notice attributes output to backend" "$out" "from 'sbx', not acq"
 cleanup_stubs
@@ -1335,6 +1338,36 @@ none_out=$(USAI_API_KEY='' GITHUB_TOKEN='' GH_TOKEN='' GITLAB_TOKEN='' \
 assert_eq "secret import (none found): exits 0" "0" "$none_rc"
 assert_contains "secret import (none found): says nothing found" "$none_out" "no known service tokens found"
 rm -rf "$_impdir"
+cleanup_stubs
+
+# 7c3-integrity. A secret VALUE that the single-line store cannot round-trip
+#      (newline or tab) must be REJECTED (fail closed) — never truncated-and-
+#      stored, and no fragment of the value may leak to stderr. Regression for
+#      the review BLOCKER (framing on TAB + single-line read truncated multi-line
+#      values and leaked the 2nd line).
+make_stubs
+_intdir=$(mktemp -d "${TMPDIR:-/tmp}/acq-int.XXXXXX")
+# Multi-line value: rejected, not stored, and "SECRET2" never appears in output.
+ml_out=$(USAI_API_KEY="$(printf 'line1\nSECRET2')" GITHUB_TOKEN='' GH_TOKEN='' GITLAB_TOKEN='' \
+  ACQ_SECRET_STORE_DIR="$_intdir/ml" ACQ_BACKEND=sbx "$ACQ" secret import --all 2>&1); ml_rc=$?
+assert_eq "secret import (multi-line): run completes rc 0" "0" "$ml_rc"
+assert_contains "secret import (multi-line): rejected with a clear reason" "$ml_out" "contains a newline or tab"
+assert_not_contains "secret import (multi-line): 2nd line never leaks to stderr" "$ml_out" "SECRET2"
+[ ! -e "$_intdir/ml/acq.usai" ] && pass "secret import (multi-line): nothing stored" \
+  || fail "secret import (multi-line): must not store a truncated value" "found acq.usai"
+# Tab value: rejected, not stored, fragment never leaks.
+tab_out=$(USAI_API_KEY="$(printf 'aaa\tTABBED')" GITHUB_TOKEN='' GH_TOKEN='' GITLAB_TOKEN='' \
+  ACQ_SECRET_STORE_DIR="$_intdir/tab" ACQ_BACKEND=sbx "$ACQ" secret import --all 2>&1)
+assert_contains "secret import (tab): rejected" "$tab_out" "contains a newline or tab"
+assert_not_contains "secret import (tab): fragment never leaks" "$tab_out" "TABBED"
+[ ! -e "$_intdir/tab/acq.usai" ] && pass "secret import (tab): nothing stored" \
+  || fail "secret import (tab): must not store" "found acq.usai"
+# A well-formed single-line value with shell-special chars round-trips EXACTLY.
+USAI_API_KEY='a b=c;d$e' GITHUB_TOKEN='' GH_TOKEN='' GITLAB_TOKEN='' \
+  ACQ_SECRET_STORE_DIR="$_intdir/ok" ACQ_BACKEND=sbx "$ACQ" secret import usai --force >/dev/null 2>&1
+[ "$(cat "$_intdir/ok/acq.usai" 2>/dev/null)" = 'a b=c;d$e' ] && pass "secret import: single-line value round-trips exactly" \
+  || fail "secret import: value corrupted" "$(cat "$_intdir/ok/acq.usai" 2>/dev/null)"
+rm -rf "$_intdir"
 cleanup_stubs
 
 # 7c3b. `acq secret import` on msb ALSO never invokes the backend `secret` CLI

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1285,22 +1285,75 @@ assert_contains "secret set-custom: points at the managed equivalent" "$sc_out" 
 assert_not_contains "secret set-custom: never forwards to the backend" "$sc_log" "sbx secret"
 cleanup_stubs
 
-# 7c3. `acq secret import` FAILS CLOSED — not implemented. The forwarded backend
-#      `secret import` would bypass the acq store (and errors on msb); the
-#      intended acq import is the inverse (store-populating migration). acq must
-#      NOT forward it and must say it is not implemented yet.
+# 7c3. `acq secret import` populates the acq store from known host env vars
+#      (usai/github/gitlab) WITHOUT ever invoking the backend's `secret` CLI and
+#      WITHOUT the value touching argv. --dry-run writes nothing; --all imports
+#      detected services and skips existing; --force overwrites; a scope arg
+#      scopes the entry. Global by default.
 make_stubs
+_impdir=$(mktemp -d "${TMPDIR:-/tmp}/acq-import.XXXXXX")
 : > "$CALLS"
-imp_out=$(ACQ_BACKEND=sbx "$ACQ" secret import usai 2>&1); imp_rc=$?
+# --dry-run: detects github from GH_TOKEN, writes nothing, never calls backend.
+imp_out=$(GH_TOKEN=ghp_DRY1234 USAI_API_KEY='' GITHUB_TOKEN='' GITLAB_TOKEN='' \
+  ACQ_SECRET_STORE_DIR="$_impdir/dry" ACQ_BACKEND=sbx "$ACQ" secret import --dry-run 2>&1); imp_rc=$?
 imp_log=$(cat "$CALLS")
-[ "$imp_rc" -ne 0 ] && pass "secret import: exits non-zero" \
-  || fail "secret import: must exit non-zero" "rc=$imp_rc"
-assert_contains "secret import: says not implemented yet" "$imp_out" "not implemented yet"
-assert_not_contains "secret import: never forwards to the backend" "$imp_log" "sbx secret"
+assert_eq "secret import --dry-run: exits 0" "0" "$imp_rc"
+assert_contains "secret import --dry-run: detects github via GH_TOKEN" "$imp_out" "would import 'github' from \$GH_TOKEN"
+assert_contains "secret import --dry-run: previews only last 4 (…1234)" "$imp_out" "…1234"
+assert_not_contains "secret import: value never leaks in output" "$imp_out" "ghp_DRY1234"
+assert_not_contains "secret import: never invokes the backend secret CLI" "$imp_log" "sbx secret"
+[ ! -e "$_impdir/dry/acq.github" ] && pass "secret import --dry-run: wrote nothing" \
+  || fail "secret import --dry-run: must not write" "found acq.github"
+# --all: actually imports usai + github, stores the real values off argv.
+: > "$CALLS"
+USAI_API_KEY=sk-usai-AAAA GITHUB_TOKEN=ghp_BBBB GITLAB_TOKEN='' GH_TOKEN='' \
+  ACQ_SECRET_STORE_DIR="$_impdir/all" ACQ_BACKEND=sbx "$ACQ" secret import --all >/dev/null 2>&1
+all_log=$(cat "$CALLS")
+assert_not_contains "secret import --all: never invokes the backend secret CLI" "$all_log" "sbx secret"
+[ "$(cat "$_impdir/all/acq.usai" 2>/dev/null)" = "sk-usai-AAAA" ] && pass "secret import --all: stored usai value" \
+  || fail "secret import --all: usai value wrong" "$(cat "$_impdir/all/acq.usai" 2>/dev/null)"
+[ "$(cat "$_impdir/all/acq.github" 2>/dev/null)" = "ghp_BBBB" ] && pass "secret import --all: stored github value" \
+  || fail "secret import --all: github value wrong" "$(cat "$_impdir/all/acq.github" 2>/dev/null)"
+# Re-run --all: existing entries are SKIPPED (not overwritten).
+reall_out=$(USAI_API_KEY=sk-usai-CCCC GITHUB_TOKEN=ghp_BBBB \
+  ACQ_SECRET_STORE_DIR="$_impdir/all" ACQ_BACKEND=sbx "$ACQ" secret import --all 2>&1)
+assert_contains "secret import --all: skips existing" "$reall_out" "already stored"
+[ "$(cat "$_impdir/all/acq.usai" 2>/dev/null)" = "sk-usai-AAAA" ] && pass "secret import --all: did NOT overwrite" \
+  || fail "secret import --all: overwrote without --force" "$(cat "$_impdir/all/acq.usai" 2>/dev/null)"
+# --force overwrites.
+USAI_API_KEY=sk-usai-CCCC ACQ_SECRET_STORE_DIR="$_impdir/all" ACQ_BACKEND=sbx "$ACQ" secret import usai --force >/dev/null 2>&1
+[ "$(cat "$_impdir/all/acq.usai" 2>/dev/null)" = "sk-usai-CCCC" ] && pass "secret import --force: overwrote" \
+  || fail "secret import --force: did not overwrite" "$(cat "$_impdir/all/acq.usai" 2>/dev/null)"
+# SANDBOX scope writes a scoped key.
+GITLAB_TOKEN=glpat-DDDD ACQ_SECRET_STORE_DIR="$_impdir/all" ACQ_BACKEND=sbx "$ACQ" secret import gitlab mybox --all >/dev/null 2>&1
+[ -e "$_impdir/all/acq.mybox.gitlab" ] && pass "secret import SANDBOX: wrote scoped key" \
+  || fail "secret import SANDBOX: no scoped key" "missing acq.mybox.gitlab"
+# No tokens detected -> exits 0 with a clear message, no backend call.
+: > "$CALLS"
+none_out=$(USAI_API_KEY='' GITHUB_TOKEN='' GH_TOKEN='' GITLAB_TOKEN='' \
+  ACQ_SECRET_STORE_DIR="$_impdir/none" ACQ_BACKEND=sbx "$ACQ" secret import --all 2>&1); none_rc=$?
+assert_eq "secret import (none found): exits 0" "0" "$none_rc"
+assert_contains "secret import (none found): says nothing found" "$none_out" "no known service tokens found"
+rm -rf "$_impdir"
 cleanup_stubs
 
-# 7c4. Same fail-closed behavior on msb (which has no `secret` CLI at all) — the
-#      handoff must never even reach `msb secret`.
+# 7c3b. `acq secret import` on msb ALSO never invokes the backend `secret` CLI
+#       (msb has none) — it writes only the acq store, same as sbx.
+make_stubs
+_impmdir=$(mktemp -d "${TMPDIR:-/tmp}/acq-importm.XXXXXX")
+: > "$CALLS"
+USAI_API_KEY=sk-usai-MMMM GITHUB_TOKEN='' GH_TOKEN='' GITLAB_TOKEN='' \
+  ACQ_SECRET_STORE_DIR="$_impmdir/store" ACQ_BACKEND=msb "$ACQ" secret import --all >/dev/null 2>&1; impm_rc=$?
+impm_log=$(cat "$CALLS")
+assert_eq "secret import(msb): exits 0" "0" "$impm_rc"
+assert_not_contains "secret import(msb): never invokes 'msb secret'" "$impm_log" "msb secret"
+[ "$(cat "$_impmdir/store/acq.usai" 2>/dev/null)" = "sk-usai-MMMM" ] && pass "secret import(msb): stored usai value" \
+  || fail "secret import(msb): usai value wrong" "$(cat "$_impmdir/store/acq.usai" 2>/dev/null)"
+rm -rf "$_impmdir"
+cleanup_stubs
+
+# 7c4. `acq secret set-custom` still FAILS CLOSED on msb (no `secret` CLI at all)
+#      — the handoff must never even reach `msb secret`.
 make_stubs
 : > "$CALLS"
 ACQ_BACKEND=msb "$ACQ" secret set-custom -g --host h --env E >/dev/null 2>&1; scm_rc=$?
@@ -1308,12 +1361,6 @@ scm_log=$(cat "$CALLS")
 [ "$scm_rc" -ne 0 ] && pass "secret set-custom(msb): exits non-zero" \
   || fail "secret set-custom(msb): must exit non-zero" "rc=$scm_rc"
 assert_not_contains "secret set-custom(msb): never invokes 'msb secret'" "$scm_log" "msb secret"
-: > "$CALLS"
-ACQ_BACKEND=msb "$ACQ" secret import usai >/dev/null 2>&1; impm_rc=$?
-impm_log=$(cat "$CALLS")
-[ "$impm_rc" -ne 0 ] && pass "secret import(msb): exits non-zero" \
-  || fail "secret import(msb): must exit non-zero" "rc=$impm_rc"
-assert_not_contains "secret import(msb): never invokes 'msb secret'" "$impm_log" "msb secret"
 cleanup_stubs
 
 # 7d. An unrecognized `secret` subverb is an acq-vocabulary mistake — acq owns

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1226,11 +1226,9 @@ assert_contains "help: --help after -- passes through to backend exec" "$afterdd
 assert_not_contains "help: --help after -- did NOT print acq help" "$afterdd_log" "agentic coding quickstart wrapper"
 cleanup_stubs
 
-# 7c. `acq secret ls|import|set-custom` pass through to the backend WITHOUT
-#     doubling the subcommand token (regression: `sbx secret ls ls`). The set/rm
-#     branches shift; this branch must too. import/set-custom additionally
-#     ANNOUNCE the handoff (they skip the acq secret store) while ls is a silent
-#     acq-store view (no notice).
+# 7c. `acq secret ls` is a silent acq-store view (delegates to the backend on
+#     sbx WITHOUT doubling the token and WITHOUT a passthrough notice — it is an
+#     acq-owned verb, not an escape hatch).
 make_stubs
 : > "$CALLS"
 ls_out=$(ACQ_BACKEND=sbx "$ACQ" secret ls -q 2>&1 || true)
@@ -1238,13 +1236,52 @@ ls_log=$(cat "$CALLS")
 assert_contains "secret ls: forwards a single ls token" "$ls_log" "sbx secret ls -q"
 assert_not_contains "secret ls: does NOT double the token" "$ls_log" "secret ls ls"
 assert_not_contains "secret ls: not announced as a passthrough" "$ls_out" "forwarding to"
+cleanup_stubs
+
+# 7c2. `acq secret set-custom` FAILS CLOSED — it would bypass the acq secret
+#      store (write only the backend's own table, expose the value on argv, and
+#      on msb error outright). acq must NOT forward it to the backend and must
+#      point the user at the acq-store-aware `acq secret set … --host … --env …`.
+make_stubs
 : > "$CALLS"
-sc_out=$(ACQ_BACKEND=sbx "$ACQ" secret set-custom -g --host h --env E 2>&1 || true)
+sc_out=$(ACQ_BACKEND=sbx "$ACQ" secret set-custom -g --host h --env E 2>&1); sc_rc=$?
 sc_log=$(cat "$CALLS")
-assert_contains "secret set-custom: single token" "$sc_log" "sbx secret set-custom -g --host h --env E"
-assert_not_contains "secret set-custom: not doubled" "$sc_log" "set-custom set-custom"
-assert_contains "secret set-custom: announces it skips the acq store" "$sc_out" "not wired through the acq secret store"
-assert_contains "secret set-custom: attributes output to backend" "$sc_out" "from 'sbx', not acq"
+[ "$sc_rc" -ne 0 ] && pass "secret set-custom: exits non-zero" \
+  || fail "secret set-custom: must exit non-zero" "rc=$sc_rc"
+assert_contains "secret set-custom: says it would bypass the acq store" "$sc_out" "bypass the acq secret store"
+assert_contains "secret set-custom: points at the managed equivalent" "$sc_out" "acq secret set [-g | SANDBOX] SERVICE --host HOST --env ENV"
+assert_not_contains "secret set-custom: never forwards to the backend" "$sc_log" "sbx secret"
+cleanup_stubs
+
+# 7c3. `acq secret import` FAILS CLOSED — not implemented. The forwarded backend
+#      `secret import` would bypass the acq store (and errors on msb); the
+#      intended acq import is the inverse (store-populating migration). acq must
+#      NOT forward it and must say it is not implemented yet.
+make_stubs
+: > "$CALLS"
+imp_out=$(ACQ_BACKEND=sbx "$ACQ" secret import usai 2>&1); imp_rc=$?
+imp_log=$(cat "$CALLS")
+[ "$imp_rc" -ne 0 ] && pass "secret import: exits non-zero" \
+  || fail "secret import: must exit non-zero" "rc=$imp_rc"
+assert_contains "secret import: says not implemented yet" "$imp_out" "not implemented yet"
+assert_not_contains "secret import: never forwards to the backend" "$imp_log" "sbx secret"
+cleanup_stubs
+
+# 7c4. Same fail-closed behavior on msb (which has no `secret` CLI at all) — the
+#      handoff must never even reach `msb secret`.
+make_stubs
+: > "$CALLS"
+ACQ_BACKEND=msb "$ACQ" secret set-custom -g --host h --env E >/dev/null 2>&1; scm_rc=$?
+scm_log=$(cat "$CALLS")
+[ "$scm_rc" -ne 0 ] && pass "secret set-custom(msb): exits non-zero" \
+  || fail "secret set-custom(msb): must exit non-zero" "rc=$scm_rc"
+assert_not_contains "secret set-custom(msb): never invokes 'msb secret'" "$scm_log" "msb secret"
+: > "$CALLS"
+ACQ_BACKEND=msb "$ACQ" secret import usai >/dev/null 2>&1; impm_rc=$?
+impm_log=$(cat "$CALLS")
+[ "$impm_rc" -ne 0 ] && pass "secret import(msb): exits non-zero" \
+  || fail "secret import(msb): must exit non-zero" "rc=$impm_rc"
+assert_not_contains "secret import(msb): never invokes 'msb secret'" "$impm_log" "msb secret"
 cleanup_stubs
 
 # 7d. An unrecognized `secret` subverb is an acq-vocabulary mistake — acq owns


### PR DESCRIPTION
## Context

Started from a bug report: `acq secret rm openchamber-setup` on the **msb** backend produced a confusing `error: unrecognized subcommand 'secret'` from `msb` itself, because acq forwarded a scopeless `secret rm` to a backend `secret` CLI that msb doesn't have. That surfaced a broader class of dispatch-hygiene issues: user mistakes on acq-**owned** verbs were falling through to the backend, escape-hatch passthroughs were silent, and two `secret` sub-subcommands (`set-custom`, `import`) bypassed acq's own secret store entirely.

This PR fixes the dispatch behavior end-to-end and implements a real `acq secret import`.

## Changes (by commit)

1. **`fix(acq): fail closed on scopeless 'secret rm'`** — On msb (no backend `secret` CLI), a non-managed `secret rm` token now errors with acq's own scope-required usage instead of leaking a raw `msb` error. sbx placeholder passthrough preserved.
2. **`feat(acq): announce backend passthrough and fail closed on owned verbs`** — Unknown top-level verbs still forward to the backend but print a stderr notice first (so the user knows the output/errors are the backend's, not acq's). Unrecognized `secret` subverbs fail closed with acq's own error.
3. **`fix(acq): stop store-bypassing 'secret set-custom' and 'secret import' passthrough`** — Both bypassed acq's backend-neutral secret store (invisible to `secret ls`, not re-fed on rotation, not removable via `secret rm`; errored on msb). `set-custom` now fails closed pointing at `acq secret set … --host … --env …`; `import` reserved for the real implementation below.
4. **`fix(acq): route per-subcommand --help to acq's own usage`** — `acq secret --help`, `acq kit --help`, `acq backend --help` (and sub-subcommand forms) now print acq's verb-specific usage instead of only the top banner. Backend delegation for non-owned verbs preserved.
5. **`feat(acq): implement 'secret import'`** — Store-populating importer: scans the host env for known acq-managed tokens (`usai←USAI_API_KEY`, `github←GITHUB_TOKEN`/`GH_TOKEN`, `gitlab←GITLAB_TOKEN`) and writes them to acq's own store (never the backend CLI; value never on argv). Global by default, SANDBOX-scopable; interactive with `--all`/`--force`/`--dry-run`, overwrite-protected.

## Security impact

Positive: closes two abstraction-breaking passthroughs that let secret values bypass the acq store (and land on argv via sbx `set-custom`). `secret import` reads values from the environment and stores them via stdin — never argv, never logged; previews show only a last-4 mask.

## Verification

- `./scripts/test-acq` → **667 passed / 0 failed** (added ~40 tests: fail-closed paths, announced passthrough, per-subcommand `--help`, and `secret import` dry-run/all/force/scope/none/msb).
- `shellcheck -S warning acq acq.backends/common.sh scripts/test-acq` → clean.
- `npm run lint:md` → 0 errors.

## Rollback

Revert the PR merge commit; no data migrations or state changes. The acq secret store format is unchanged.

## Notes

- No `BREAKING CHANGE`: the removed passthroughs were abstraction leaks, not a supported contract. `secret set-custom` users move to `acq secret set … --host … --env …`.
- AI-assisted (OpenCode); all commits reviewed by the author.
