### PR TITLE
chore(gitleaks): add .gitleaks.toml allowlist for example/test secrets (#277)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,32 @@
+# Gitleaks Configuration for agentic-coding-quickstart
+# https://github.com/gitleaks/gitleaks
+#
+# Named .gitleaks.toml so the pre-commit gitleaks hook auto-loads it.
+# Extends the default ruleset and allowlists intentional example/test secrets.
+
+title = "Agentic Coding Quickstart Gitleaks Config"
+
+minVersion = "v8.25.0"
+
+[extend]
+# Use the default gitleaks rules as the base configuration
+useDefault = true
+
+[allowlist]
+description = "Allow documented example secrets and deliberate test fixtures"
+
+# Documentation + test paths that contain intentional, non-sensitive example
+# secrets. A full-history scan (public-readiness) flagged these; all are fake by
+# design — doc illustrations and sample-vulnerable-code the security tooling
+# scans for. Notably docs/explorations/downscoping-...md quotes GitHub's own
+# example client_id/client_secret and the gh CLI's PUBLIC OAuth client secret
+# (documented upstream as "safe to be embedded in version control").
+paths = [
+  '''docs/explorations/downscoping-github-credentials-for-local-agents\.md''',
+  '''docs/getting-started\.md''',
+  '''docs/safety-guidance\.md''',
+  '''docs/test-cases-schema\.md''',
+  '''\.agents/skills/secure-code-review/tests/.*''',
+  '''scripts/tests/test_validate_sensitive_terms\.py''',
+  '''test/sandbox-unit\.sh''',
+]


### PR DESCRIPTION
## Summary

Public-readiness (epic #276, part of #277). A full-history `gitleaks detect --log-opts=--all` (393 commits) found **12 findings, all NON-sensitive**: doc examples (incl. GitHub's own example client_id/client_secret and the `gh` CLI's publicly-embedded OAuth client secret) and deliberate test fixtures (sample-vulnerable-code the secure-code-review skill scans for, the sensitive-terms validator's test key, sandbox-unit test data). No real secret; no history rewrite needed.

The repo runs the gitleaks pre-commit hook but had **no config**, so it flagged all 12 on every scan (default ruleset). Add `.gitleaks.toml` extending the default rules with a path allowlist for these known-safe doc/test paths.

## Verification

`gitleaks detect --log-opts=--all` → **0 leaks** (was 12).

Relates to #277 (the issue also tracks the human issue/PR-history review).

AI-assisted (OpenCode); requires human review.