### PR TITLE
fix(sbx): correct lifecycle verbs — sbx has no 'start'/'restart' (closes #265)

### DIFF
--- a/acq
+++ b/acq
@@ -83,9 +83,10 @@ Subcommands:
   ls                                       List sandboxes.
   stop NAME                                Stop a sandbox (without removing).
   start NAME                               Start a stopped sandbox and re-run its
-                                           kit startup services.
+                                           kit startup services (msb only; on sbx
+                                           a sandbox resumes automatically on 'acq run').
   restart NAME                             Stop then start a sandbox, re-running
-                                           kit startup services.
+                                           kit startup services (msb only; see 'start').
   rm NAME                                  Remove a sandbox.
   exec NAME -- CMD...                      Run a command inside a sandbox.
   cp SRC DST                               Copy files in/out (NAME:path syntax).
@@ -675,18 +676,23 @@ case "$subcommand" in
 
   start)
     # Resume a stopped sandbox and re-run its kit startup services deterministically
-    # (ADR-0017). `msb start`/`sbx start` alone do NOT reliably replay kit
+    # (ADR-0017). On msb, `msb start` alone does NOT reliably replay kit
     # `startup`/`background` commands (a bare create-time `--script-path` is not
     # enrolled in microsandbox's persisted startup), so after the backend resume we
     # re-drive acq_backend_ensure_kits_applied: it re-applies the pinned kits
     # idempotently and RE-RUNS the startup phase via the exec path — the actual,
-    # deterministic mechanism that brings supervised services back up.
+    # deterministic mechanism that brings supervised services back up. sbx has no
+    # 'start' verb (acq_backend_start is undefined there); this arm is
+    # capability-gated below to point sbx users at `acq run`, which auto-resumes.
     shift
     local_name="${1:-}"
     [ -n "$local_name" ] || { echo "acq: start: missing sandbox name" >&2; exit 1; }
     if ! command -v acq_backend_start >/dev/null 2>&1; then
-      echo "acq: the '${ACQ_RESOLVED_BACKEND}' backend does not support start" >&2
-      echo "     (acq_backend_start). Start the sandbox manually, then re-run." >&2
+      # e.g. sbx: no 'start' verb, and no detached-resume model — a stopped
+      # sandbox is auto-resumed by the next attach, so 'acq run' is the path.
+      echo "acq: the '${ACQ_RESOLVED_BACKEND}' backend has no separate 'start' verb." >&2
+      echo "     A stopped sandbox resumes automatically on attach — just run:" >&2
+      echo "       acq run $local_name" >&2
       exit 1
     fi
     acq_backend_start "$local_name"
@@ -710,8 +716,11 @@ case "$subcommand" in
     local_name="${1:-}"
     [ -n "$local_name" ] || { echo "acq: restart: missing sandbox name" >&2; exit 1; }
     if ! command -v acq_backend_start >/dev/null 2>&1; then
-      echo "acq: the '${ACQ_RESOLVED_BACKEND}' backend does not support restart" >&2
-      echo "     (acq_backend_start). Restart the sandbox manually, then re-run." >&2
+      # e.g. sbx: no 'restart' verb. Attach auto-resumes a stopped sandbox, so
+      # bouncing it is just 'acq run' (optionally 'acq stop' first).
+      echo "acq: the '${ACQ_RESOLVED_BACKEND}' backend has no separate 'restart' verb." >&2
+      echo "     A stopped sandbox resumes automatically on attach — just run:" >&2
+      echo "       acq run $local_name        # (optionally 'acq stop $local_name' first)" >&2
       exit 1
     fi
     acq_backend_stop "$local_name" \

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -385,22 +385,22 @@ acq_backend_stop() {
   sbx stop "$1"
 }
 
-# acq_backend_start NAME — start (resume) a stopped sandbox (ADR-0017).
-# sbx exposes `sbx start` and preserves state on stop (ACQ_BACKEND_CAN_RESUME=1),
-# so this mirrors the msb verb: a thin resume primitive. The acq `start`/`restart`
-# dispatcher re-drives acq_backend_ensure_kits_applied after this to re-run the
-# idempotent kit apply (which restores startup services), same as the msb path.
+# NO acq_backend_start on sbx — DELIBERATELY.
 #
-# READINESS (S1): the msb adapter blocks on _acq_msb_wait_for_exec_ready inside
-# acq_backend_start because `msb exec` races the async guest boot after a resume.
-# sbx is left as a bare `sbx start` here: sbx has no post-resume readiness
-# primitive in use — _acq_sbx_wait_for_exec_ready exists but is not invoked after
-# provision/start today, and sbx's own `sbx exec` waits for the sandbox to become
-# ready — so there is no analogous mirror to add. If a live race is later observed
-# on sbx resume, mirror the msb approach here (add the wait after `sbx start`).
-acq_backend_start() {
-  sbx start "$1"
-}
+# The sbx CLI has no `start` (or `restart`) subcommand (`sbx --help`: create,
+# exec, run, stop, rm, … — no start). sbx also has no equivalent of msb's
+# "start but stay detached": with no attached session, sbx auto-idles a sandbox
+# to the stopped state, and it is transparently resumed by the next `sbx run` /
+# `sbx exec` (verified by hand). So there is nothing for a standalone resume
+# primitive to do, and an earlier `sbx start "$1"` here was calling a
+# non-existent subcommand (would fail with an unknown-command error).
+#
+# Because this function is intentionally undefined, the acq `start`/`restart`
+# dispatcher's `command -v acq_backend_start` guard capability-gates those verbs
+# on sbx with a clear message. The resume-on-attach path (`acq run <stopped>`)
+# still works: acq_backend_ensure_kits_applied heals via `sbx kit add`/`sbx exec`
+# and attach via `sbx run`, all of which auto-start a stopped sandbox — no
+# explicit start needed. See ADR-0017 for the reconciled sbx lifecycle model.
 
 acq_backend_terminate() {
   sbx rm --force "$1"

--- a/docs/adr/0017-msb-create-time-startup-script-staging.md
+++ b/docs/adr/0017-msb-create-time-startup-script-staging.md
@@ -30,18 +30,30 @@ serde-skipped).
 
 **Chosen resolution (this increment ships it):**
 
- - **The acq `start`/`restart` verb — the sole, deterministic mechanism.** Add an
-   acq `start`/`restart` verb backed by `acq_backend_start` (`msb start` /
-   `sbx start`). After the backend resume, re-drive
+ - **The acq `start`/`restart` verb — the sole, deterministic mechanism (msb).** Add an
+   acq `start`/`restart` verb backed by `acq_backend_start` (`msb start` on the
+   msb backend). After the backend resume, re-drive
    `acq_backend_ensure_kits_applied`, which re-applies the pinned kits
    idempotently and **re-runs the startup phase via the exec path** — the actual
    mechanism that brings kit `startup`/`background` services back up. On the
    **msb** backend, a **stopped** sandbox is also started automatically at the top
    of `acq_backend_ensure_kits_applied`, so `acq run <stopped-sandbox>` works
    end-to-end on msb (start → heal/startup → attach) — this closes the stated gap
-   without any native-persistence uncertainty. The **sbx** backend does not yet
-   have this start-if-stopped guard in its `acq_backend_ensure_kits_applied`; the
-   sbx `acq run <stopped-sandbox>` path is tracked as a follow-up (see Links).
+   without any native-persistence uncertainty.
+
+ - **sbx has no `start`/`restart` verb — resume is automatic on attach.** The sbx
+   CLI exposes no `start` (or `restart`) subcommand (`sbx --help`: create, exec,
+   run, stop, rm, …), and sbx has no analogue of msb's "start but stay detached":
+   with no attached session sbx auto-idles a sandbox to the stopped state, and the
+   next `sbx run` / `sbx exec` transparently resumes it (verified by hand). So on
+   sbx there is nothing for a standalone resume primitive to do:
+   `acq_backend_start` is **deliberately not defined** on the sbx adapter, and the
+   acq `start`/`restart` verbs are **capability-gated** — they exit with an
+   actionable message pointing at `acq run <name>` rather than shelling out to a
+   non-existent `sbx start`. `acq run <stopped-sbx-sandbox>` already works because
+   the heal (`sbx kit add`/`sbx exec`) and attach (`sbx run`) auto-start the
+   sandbox. (An earlier revision of this ADR wrongly listed `sbx start` as the sbx
+   resume primitive; no such subcommand exists — corrected here.)
 
 **Native restart OUTSIDE acq is out of scope (found in live testing).** An
 earlier revision of this increment also, behind an opt-in flag
@@ -165,8 +177,11 @@ testing proved native restart outside acq is infeasible — see the Update note.
 ### Positive Consequences
 
 - Kit `startup`/`background` services are restored on resume deterministically
-  via `acq start` / `acq restart` (both backends) and, on the msb backend, via
-  `acq run <stopped-sandbox>` (start-if-stopped heal).
+  via `acq start` / `acq restart` on **msb**, and, on **both** backends, via
+  `acq run <stopped-sandbox>` — on msb through the start-if-stopped heal, on sbx
+  through `sbx run`/`sbx exec` auto-resuming the sandbox. On sbx, `acq start`/
+  `acq restart` are capability-gated (no such verb exists) and direct the user to
+  `acq run`.
 - Command bodies are staged as files, not interpolated shell strings (SI-10).
 - No change to the neutral kit vocabulary or to install/idempotency semantics.
 - Safe-by-default: no image-entrypoint override; resume never changes the guest
@@ -209,6 +224,9 @@ testing proved native restart outside acq is infeasible — see the Update note.
   that startup re-runs on `acq run`/`acq start`/`acq restart` (acq re-drives the
   idempotent apply), and that a raw `msb start` outside acq is not a supported
   resume path.
-- Follow-up: the sbx adapter has no start-if-stopped guard in
-  `acq_backend_ensure_kits_applied`, so `acq run <stopped-sandbox>` on sbx heals
-  against a stopped guest — tracked in GSA-TTS/agentic-coding-quickstart#265.
+- Resolved: the sbx lifecycle model was reconciled with the real `sbx` CLI —
+  there is no `sbx start`/`restart` subcommand, and a stopped sbx sandbox is
+  auto-resumed by the next `sbx run`/`sbx exec`. `acq_backend_start` is therefore
+  intentionally undefined on sbx, `acq start`/`restart` are capability-gated to
+  point at `acq run`, and `acq run <stopped-sbx-sandbox>` works via that
+  auto-resume (GSA-TTS/agentic-coding-quickstart#265).

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -2777,18 +2777,22 @@ cleanup_stubs
 # acq_backend_start, start-if-stopped-on-attach, and startup staging.
 # ---------------------------------------------------------------------------
 
-# 8o1L. acq_backend_start exists for BOTH backends and calls the right CLI.
+# 8o1L. acq_backend_start exists for msb and calls the right CLI. On sbx it is
+#        DELIBERATELY absent (sbx has no 'start' verb; a stopped sandbox resumes
+#        on the next `sbx run`/`sbx exec`), so acq must NOT define it or emit
+#        `sbx start` (which is not a real subcommand).
 make_stubs; load_acq
 : > "$CALLS"
 ( . "${REPO_ROOT}/acq.backends/msb.sh"; acq_backend_start msbstartbox >/dev/null 2>&1 )
 msb_start_log=$(cat "$CALLS")
 assert_contains "0017: msb acq_backend_start calls 'msb start NAME'" "$msb_start_log" "msb start msbstartbox"
 cleanup_stubs
-make_stubs; load_acq
-: > "$CALLS"
-( acq_backend_start sbxstartbox >/dev/null 2>&1 )   # sbx adapter already loaded by load_acq
-sbx_start_log=$(cat "$CALLS")
-assert_contains "0017: sbx acq_backend_start calls 'sbx start NAME'" "$sbx_start_log" "sbx start sbxstartbox"
+make_stubs; load_acq   # load_acq sources the sbx adapter
+if command -v acq_backend_start >/dev/null 2>&1; then
+  fail "sbx: acq_backend_start is NOT defined (sbx has no 'start' verb)" "it is defined"
+else
+  pass "sbx: acq_backend_start is NOT defined (sbx has no 'start' verb)"
+fi
 cleanup_stubs
 
 # 8o1M. `acq start NAME` (msb): calls `msb start NAME` AND re-drives the kit heal
@@ -2857,6 +2861,29 @@ make_stubs; load_acq
 out=$(ACQ_BACKEND=msb "$ACQ" restart 2>&1); rc=$?
 assert_contains "0017: acq restart missing name errors" "$out" "restart: missing sandbox name"
 if [ "$rc" -ne 0 ]; then pass "0017: acq restart missing name exits nonzero"; else fail "0017: acq restart missing name exits nonzero" "rc=$rc"; fi
+cleanup_stubs
+
+# 8o1O2. sbx capability-gating: `acq start`/`acq restart` on sbx (which has no
+#         'start'/'restart' verb and auto-resumes on attach) must fail cleanly
+#         with an actionable message pointing at `acq run`, and must NEVER emit a
+#         (non-existent) `sbx start`/`sbx restart` subcommand.
+make_stubs; load_acq
+: > "$CALLS"
+out=$(ACQ_BACKEND=sbx "$ACQ" start sbxbox 2>&1); rc=$?
+log=$(cat "$CALLS")
+assert_contains "sbx: acq start explains no 'start' verb" "$out" "no separate 'start' verb"
+assert_contains "sbx: acq start points at 'acq run'" "$out" "acq run sbxbox"
+assert_not_contains "sbx: acq start never calls 'sbx start'" "$log" "sbx start"
+if [ "$rc" -ne 0 ]; then pass "sbx: acq start exits nonzero (capability-gated)"; else fail "sbx: acq start exits nonzero (capability-gated)" "rc=$rc"; fi
+cleanup_stubs
+make_stubs; load_acq
+: > "$CALLS"
+out=$(ACQ_BACKEND=sbx "$ACQ" restart sbxbox 2>&1); rc=$?
+log=$(cat "$CALLS")
+assert_contains "sbx: acq restart explains no 'restart' verb" "$out" "no separate 'restart' verb"
+assert_not_contains "sbx: acq restart never calls 'sbx start'" "$log" "sbx start"
+assert_not_contains "sbx: acq restart never calls 'sbx restart'" "$log" "sbx restart"
+if [ "$rc" -ne 0 ]; then pass "sbx: acq restart exits nonzero (capability-gated)"; else fail "sbx: acq restart exits nonzero (capability-gated)" "rc=$rc"; fi
 cleanup_stubs
 
 # 8o1P. START-IF-STOPPED (the `acq run <stopped-sandbox>` path). A sandbox that


### PR DESCRIPTION
## Context

The sbx adapter's `acq_backend_start` shelled out to **`sbx start`**, which is
not a real sbx subcommand. `sbx --help` lists `create, exec, run, stop, rm, …`
— there is **no `start`** (and no `restart`). So on the sbx backend,
`acq start <name>` / `acq restart <name>`, and the `acq_backend_start` call in
the stopped-resume path, would fail with an unknown-command error. The comment
in ADR-0017 / `acq.backends/sbx.sh` asserting "sbx exposes `sbx start`" was an
unverified assumption carried over from the msb design.

Resolves GSA-TTS/agentic-coding-quickstart#265.

AI-assisted (OpenCode). Human-reviewed before merge.

## Root cause

`sbx start` shipped in ADR-0017 / #260 as an **unverified CLI assumption** (the
msb path has a real `msb start`, and the sbx adapter mirrored it without
checking). Verified against the real `sbx --help` here.

## What changed

sbx has no analogue of msb's "start but stay detached": with no attached
session sbx auto-idles a sandbox to the **stopped** state, and the next
`sbx run` / `sbx exec` transparently resumes it (verified by hand).

- **Removed `acq_backend_start` from the sbx adapter** — left deliberately
  undefined, with a comment documenting the model. `acq_backend_stop` →
  `sbx stop` is real and kept.
- The acq `start`/`restart` dispatcher's existing `command -v acq_backend_start`
  guard now **capability-gates** those verbs on sbx with an actionable message
  pointing at `acq run <name>` (which auto-resumes), instead of emitting a
  non-existent `sbx start`.
- **`acq run <stopped-sbx-sandbox>` still works** — the heal (`sbx kit add` /
  `sbx exec`) and attach (`sbx run`) auto-start the sandbox.
- Reconciled **ADR-0017** (which wrongly listed `sbx start` as the sbx resume
  primitive) and the `acq` help text.

msb is unaffected (`msb start` is real there; `acq start`/`restart` and the
start-if-stopped heal continue to work).

## Verification

- `./scripts/test-acq` — **631 passed, 0 failed** (plain + PTY). New/updated
  coverage: `acq_backend_start` is undefined on sbx; `acq start`/`acq restart`
  on sbx exit nonzero with the `acq run` guidance and never emit `sbx start`/
  `sbx restart`; msb start/restart paths unchanged.
- `shellcheck -S warning` clean on `acq` + adapters + `scripts/test-acq`;
  `npm run lint:md` clean.
- Live `scripts/verify-backends` on a real sbx host is still recommended before
  the 3.0.0 tag (can't run sbx in the dev sandbox).

## Rollback

Revert the commit; sbx `acq start`/`restart` return to calling the (broken)
`sbx start`. No data/config is persisted.

## Security impact

None. Removes a call to a non-existent subcommand; NAME args stay quoted argv
(no `sh -c`); no auth/secret surface touched.
