### PR TITLE
fix(acq): store USAi key before sandbox create to end 200-vs-401 split

### DIFF
--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -408,6 +408,7 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -408,7 +408,6 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -10,7 +10,7 @@
     "markdownlint-cli2": "0.22.1"
   },
   "overrides": {
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "markdown-it": "14.2.0",
     "linkify-it": "5.0.2"
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,6 +567,21 @@ The agent MUST:
 
 **ADR location:** `docs/adr/`
 
+> **Running shellcheck locally (avoid the hang):** Do NOT run
+> `shellcheck acq.backends/*.sh scripts/test-acq` in a single invocation. ShellCheck's
+> dataflow analysis blows up pathologically when several large scripts (notably
+> `acq.backends/msb.sh` + `scripts/test-acq`) are analyzed together — it runs
+> effectively forever (CI would hit its timeout). Each file ALONE lints in 1–3s.
+> Match the pre-commit hook and lint **one file per invocation**:
+>
+> ```sh
+> printf '%s\n' acq acq.backends/common.sh acq.backends/msb.sh acq.backends/sbx.sh scripts/test-acq \
+>   | xargs -r -n1 shellcheck --severity=warning
+> ```
+>
+> This is exactly what `.pre-commit-config.yaml`'s `shellcheck` hook does
+> (`xargs -r -n1`); `--severity=warning` matches the hook.
+
 ---
 
 ## Approved Patterns

--- a/acq
+++ b/acq
@@ -622,6 +622,14 @@ case "$subcommand" in
     preflight_workspace_path "$ws" || exit 1
     local_name=$(derive_name "$@") || exit 1
     [ -n "$local_name" ] || { echo "acq: could not determine sandbox name" >&2; exit 1; }
+
+    # The USAi API key must be stored before provisioning: msb binds secrets only
+    # at create time, so a sandbox created before the key exists carries no USAi
+    # binding. Gate on key presence first (fail closed if declined) so create
+    # picks it up. `create` is otherwise detached and never attaches.
+    if ! ensure_key_present; then
+      exit 1
+    fi
     acq_backend_provision "$local_name" "$@"
 
     # Non-blocking USAi key advisory. `create` is detached and never attaches,
@@ -683,6 +691,15 @@ case "$subcommand" in
         # the offer is intentionally only on this path.
         maybe_offer_bundle_refresh "${ACQ_RESOLVED_BACKEND}" "$local_name" "$_pre_heal_status"
       else
+        # Fresh create: the USAi API key MUST be stored before we provision,
+        # because a backend (msb) binds secrets only at create time. Creating the
+        # sandbox first and setting the key after would leave the real sandbox
+        # with no USAi binding — the exact split that made validation report 200
+        # (in a throwaway sandbox) yet 401 (in the real one). Gate on key
+        # presence first; fail closed if the user declines.
+        if ! ensure_key_present; then
+          exit 1
+        fi
         acq_backend_provision "$local_name" "${create_args[@]}"
       fi
 

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -1676,6 +1676,23 @@ ensure_key_present() {
     return 0
   fi
 
+  # Backend mismatch: msb provision also accepts a host-exported USAI_API_KEY and
+  # binds it at create time (see _acq_msb_bind_secrets_into in msb.sh), so an empty
+  # acq store is NOT a blocker under msb when the env var is set (e.g. CI). Treat
+  # that as present to avoid prompting/aborting a create msb would have satisfied.
+  # sbx does NOT read host env at provision, so this short-circuit is msb-only.
+  if [ "${ACQ_RESOLVED_BACKEND:-}" = "msb" ] && [ -n "${USAI_API_KEY:-}" ]; then
+    return 0
+  fi
+
+  # Non-interactive (CI / piped stdin): no one can answer the prompt below, so
+  # emit a single terse line and fail closed rather than the full interactive
+  # help (mirrors the non-tty guard in the kit-update path above).
+  if [ ! -t 0 ]; then
+    echo "acq: no USAi API key stored; set one with 'acq secret set -g usai' (see $KEY_MGMT_URL). Aborting." >&2
+    return 1
+  fi
+
   echo >&2
   echo "No USAi API key is stored yet." >&2
   echo "USAi keys are created at $KEY_MGMT_URL and expire every 7 days." >&2

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -1658,6 +1658,63 @@ _report_usai_unreachable() {
   echo >&2
 }
 
+# ensure_key_present — pre-create gate: make sure a USAi API key is stored in the
+# acq secret store BEFORE the sandbox is created. This must run before
+# acq_backend_provision on a fresh run because msb binds secrets only at create
+# time (--secret ENV@HOST): a sandbox created with no stored key carries no USAi
+# binding, and no post-create re-feed can fix it (the binding is create-time).
+# Storing the key first means create picks it up for both backends.
+#
+# Returns 0 if a key is present (already, or after the user pastes one), 1 if the
+# user declines or setup fails. A no-op (returns 0) when the store helper isn't
+# loaded — the post-create ensure_valid_key gate still catches a bad key.
+ensure_key_present() {
+  if ! command -v acq_secret_has >/dev/null 2>&1; then
+    return 0
+  fi
+  if acq_secret_has usai; then
+    return 0
+  fi
+
+  echo >&2
+  echo "No USAi API key is stored yet." >&2
+  echo "USAi keys are created at $KEY_MGMT_URL and expire every 7 days." >&2
+  echo >&2
+  echo "To set one:" >&2
+  echo "  1. Open $KEY_MGMT_URL" >&2
+  echo "  2. Create a key (or copy an existing one) with the console copy button" >&2
+  echo >&2
+
+  if ! command -v acq_backend_secret_set >/dev/null 2>&1; then
+    echo "The '${ACQ_RESOLVED_BACKEND:-active}' backend does not implement key setup." >&2
+    echo "Set the key manually (acq secret set -g usai), then re-run." >&2
+    return 1
+  fi
+
+  local answer=""
+  printf 'Have your USAi API key ready to paste? Set it now? [y/N] ' >&2
+  read -r answer || true
+  case "$answer" in
+    [yY]|[yY][eE][sS])
+      # Store the key in the acq store (read from the TTY; never argv). This does
+      # NOT create a sandbox — the value just needs to be present before create.
+      acq_backend_secret_set -g usai || {
+        echo "Key setup did not complete. Aborting." >&2
+        return 1
+      }
+      if acq_secret_has usai; then
+        return 0
+      fi
+      echo "No USAi API key was stored. Aborting." >&2
+      return 1
+      ;;
+    *)
+      echo "Skipping. Aborting; re-run when your USAi API key is set." >&2
+      return 1
+      ;;
+  esac
+}
+
 ensure_valid_key() {
   local name="$1"
   shift
@@ -1682,32 +1739,18 @@ ensure_valid_key() {
     return 1
   fi
 
-  # Distinguish "no key stored yet" (first-time setup) from "key present but
-  # rejected" (expired/invalid), so the guidance and prompt match reality. If
-  # the store helper isn't loaded, assume a key is present so wording never
-  # regresses to the wrong direction.
-  local have_key=1
-  if command -v acq_secret_has >/dev/null 2>&1; then
-    acq_secret_has usai "$name" || have_key=0
-  fi
-
+  # A key IS stored (ensure_key_present gated create on that) but the models API
+  # rejected it: it is expired or invalid. Offer an in-place rotation, then
+  # re-validate THIS sandbox — the same one the agent will attach to, so a 200
+  # here is truthful (no throwaway-sandbox result stands in for the real one).
   echo >&2
-  if [ "$have_key" -eq 0 ]; then
-    echo "No USAi API key is set for '$name' (HTTP $status from the models API)." >&2
-    echo "USAi keys are created at $KEY_MGMT_URL and expire every 7 days." >&2
-    echo >&2
-    echo "To set one:" >&2
-    echo "  1. Open $KEY_MGMT_URL" >&2
-    echo "  2. Create a key (or copy an existing one) with the console copy button" >&2
-  else
-    echo "Your USAi API key looks invalid or expired (HTTP $status from the models API)." >&2
-    echo "USAi keys expire every 7 days." >&2
-    echo >&2
-    echo "To rotate it:" >&2
-    echo "  1. Open $KEY_MGMT_URL" >&2
-    echo "  2. Choose 'Rotate' from the Actions menu for your key" >&2
-    echo "  3. Copy the new key using the console copy button" >&2
-  fi
+  echo "Your USAi API key looks invalid or expired (HTTP $status from the models API)." >&2
+  echo "USAi keys expire every 7 days." >&2
+  echo >&2
+  echo "To rotate it:" >&2
+  echo "  1. Open $KEY_MGMT_URL" >&2
+  echo "  2. Choose 'Rotate' from the Actions menu for your key" >&2
+  echo "  3. Copy the new key using the console copy button" >&2
   echo >&2
 
   if ! command -v acq_backend_rotate_key >/dev/null 2>&1; then
@@ -1717,11 +1760,7 @@ ensure_valid_key() {
   fi
 
   local answer=""
-  if [ "$have_key" -eq 0 ]; then
-    printf 'Have your USAi key ready to paste? Set it now? [y/N] ' >&2
-  else
-    printf 'Have the new key ready to paste? Rotate now? [y/N] ' >&2
-  fi
+  printf 'Have the new API key ready to paste? Rotate now? [y/N] ' >&2
   read -r answer || true
   case "$answer" in
     [yY]|[yY][eE][sS])
@@ -1738,7 +1777,7 @@ ensure_valid_key() {
       return 1
       ;;
     *)
-      echo "Skipping. Aborting attach; re-run when your USAi key is set." >&2
+      echo "Skipping. Aborting attach; re-run when your USAi API key is set." >&2
       return 1
       ;;
   esac

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3084,19 +3084,24 @@ acq_backend_rotate_key() {
   }
 
   # Validate the new key in a fresh throwaway sandbox (backend-neutral helper).
+  # NOTE: on msb the throwaway sandbox is NOT the sandbox the agent attaches to.
+  # The real running sandbox is re-fed via `msb modify --secret`, which can apply
+  # to 0 sandboxes if the real one is still booting. So a throwaway "HTTP 200"
+  # here does NOT prove the real sandbox will authenticate — printing it would
+  # reproduce the exact 200-then-401 split this change set out to kill. We only
+  # use the throwaway to surface a hard-negative early (invalid key / network),
+  # and leave the authoritative "validated" verdict to ensure_valid_key's
+  # real-sandbox check_key on next attach.
   echo "Validating new key in a temporary sandbox..." >&2
   local status=""
   if command -v check_fresh_sandbox_key >/dev/null 2>&1; then
     status=$(check_fresh_sandbox_key)
   fi
 
-  if [ -z "$status" ]; then
-    echo "Could not run a validation sandbox; skipping check." >&2
-    echo "The key was rotated. Re-run 'acq run' to validate on next attach." >&2
-    return 0
-  fi
-  if [ "$status" = "200" ]; then
-    echo "Key validated (HTTP 200). You're good to go." >&2
+  if [ -z "$status" ] || [ "$status" = "200" ]; then
+    # No throwaway result, or the throwaway accepted the key. Do NOT claim the
+    # real sandbox is validated — the re-feed may not have reached it yet.
+    echo "Key stored. It will be validated against the running sandbox on next attach." >&2
     return 0
   fi
   if [ "$status" = "unreachable" ]; then

--- a/acq.backends/secret-store.sh
+++ b/acq.backends/secret-store.sh
@@ -704,7 +704,14 @@ acq_secret_set_interactive() {
   elif [ ! -t 0 ]; then
     IFS= read -r value || true
   else
-    printf 'Enter %s secret: ' "$service" >&2
+    # "usai" is the service KEY, but users think of it as their "API key", not a
+    # "secret" (which in this project means the sbx/msb credential-injection
+    # concept). Prompt with the friendlier term for the well-known services.
+    case "$service" in
+      usai)   printf 'Enter USAi API key: ' >&2 ;;
+      github) printf 'Enter GitHub token: ' >&2 ;;
+      *)      printf 'Enter %s API key: ' "$service" >&2 ;;
+    esac
     value=$(_acq_read_secret_masked)
     printf '\n' >&2
   fi

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -728,14 +728,17 @@ cleanup_stubs
 # decline by feeding an empty line on stdin. Bare workspace (no git remote) keeps
 # the github advisory quiet.
 
-# 3k1. No usai key stored -> PRE-create gate names the setup case + prompts to
-#      set; declining aborts the run (non-zero) BEFORE the sandbox is created.
+# 3k1. No usai key stored, non-interactive stdin (piped) -> PRE-create gate emits
+#      the TERSE non-tty line (no full interactive help) and aborts the run
+#      (non-zero) BEFORE the sandbox is created. Piped stdin makes `[ ! -t 0 ]`
+#      true, so ensure_key_present takes the terse branch — the full "Set it now"
+#      prompt is TTY-only (see 3k1b).
 make_stubs
 _keyrun=$(mktemp -d "${TMPDIR:-/tmp}/acq-keyrun.XXXXXX")
 rm -f "$STUBDIR/.created"
 out=$(printf '\n' | STUB_KEY_STATUS=401 ACQ_BACKEND=sbx "$ACQ" run opencode "$_keyrun" 2>&1); rc=$?
-assert_contains "run: never-set key names the setup case" "$out" "No USAi API key is stored yet"
-assert_contains "run: never-set key prompts to set" "$out" "Set it now"
+assert_contains "run: never-set key (non-tty) names the setup case" "$out" "no USAi API key stored"
+assert_not_contains "run: never-set key (non-tty) omits full interactive help" "$out" "Set it now"
 assert_not_contains "run: never-set key does NOT say expired" "$out" "invalid or expired"
 assert_eq "run: never-set + decline aborts run" "1" "$rc"
 if [ -f "$STUBDIR/.created" ]; then
@@ -744,6 +747,49 @@ else
   pass "run: never-set + decline does not create a sandbox"
 fi
 rm -rf "$_keyrun"
+cleanup_stubs
+
+# 3k1a. `acq create` with an EMPTY key store + non-interactive stdin: the
+#       PRE-create key gate (ensure_key_present) must abort the create WITHOUT
+#       provisioning a sandbox — no `.created` marker and no `sbx create` in the
+#       call log. This is the create-side mirror of 3k1: create binds the key at
+#       provision time, so a create with no key must not proceed.
+make_stubs
+_kc=$(mktemp -d "${TMPDIR:-/tmp}/acq-keycreate-decline.XXXXXX")
+rm -f "$STUBDIR/.created"
+out=$(printf '\n' | ACQ_BACKEND=sbx "$ACQ" create opencode "$_kc" 2>&1); rc=$?
+log=$(cat "$CALLS")
+assert_contains "create: empty store (non-tty) aborts with terse gate" "$out" "no USAi API key stored"
+assert_eq "create: empty store aborts (non-zero)" "1" "$rc"
+assert_not_contains "create: empty store does NOT call sbx create" "$log" "sbx create"
+if [ -f "$STUBDIR/.created" ]; then
+  fail "create: empty store must NOT create a sandbox" "sandbox was created before key was set"
+else
+  pass "create: empty store does not create a sandbox"
+fi
+rm -rf "$_kc"
+cleanup_stubs
+
+# 3k1b. CI host-env scenario (SHOULD-FIX): msb backend, EMPTY acq store, but a
+#       host-exported USAI_API_KEY (as in CI), non-interactive stdin. msb binds
+#       the host env var at provision (_acq_msb_bind_secrets_into), so the key
+#       gate must treat it as PRESENT and NOT abort the create — provision must
+#       proceed (`msb create` appears in the call log). This guards the
+#       false-negative that would otherwise abort a create provision could
+#       satisfy. sbx does NOT read host env, so the short-circuit is msb-only.
+make_stubs
+_kc=$(mktemp -d "${TMPDIR:-/tmp}/acq-keycreate-ci.XXXXXX")
+rm -f "$STUBDIR/.msb_created"
+out=$(printf '' | USAI_API_KEY="sk-ci-host" ACQ_BACKEND=msb "$ACQ" create opencode "$_kc" 2>&1); rc=$?
+log=$(cat "$CALLS")
+assert_not_contains "create(msb): host env key not aborted by gate" "$out" "no USAi API key stored"
+assert_contains "create(msb): host env key -> provision proceeds (msb create)" "$log" "msb create"
+if [ -f "$STUBDIR/.msb_created" ]; then
+  pass "create(msb): host env key provisions a sandbox"
+else
+  fail "create(msb): host env key must provision a sandbox" "no .msb_created marker"
+fi
+rm -rf "$_kc"
 cleanup_stubs
 
 # 3k2. usai key PRESENT + bad status -> post-create gate says "invalid or

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -678,6 +678,7 @@ cleanup_stubs
 # Verify `acq create opencode /proj` calls sbx create with --name and --kit flags.
 make_stubs
 _projdir=$(mktemp -d "${TMPDIR:-/tmp}/acq-proj.XXXXXX")
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 out=$(ACQ_BACKEND=sbx "$ACQ" create opencode "$_projdir" 2>/dev/null)
 log=$(cat "$CALLS")
 assert_contains "dispatch: create -> sbx create --name" "$log" "sbx create --name"
@@ -693,6 +694,7 @@ cleanup_stubs
 make_stubs
 _ghproj=$(mktemp -d "${TMPDIR:-/tmp}/acq-ghcreate.XXXXXX")
 ( cd "$_ghproj" && git init -q && git remote add origin https://github.com/GSA-TTS/quickstart.git )
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 out=$(ACQ_BACKEND=sbx ACQ_SECRET_FORCE_FILE=1 ACQ_SECRET_FILE_DIR="$_ghproj/.secrets" \
   "$ACQ" create opencode "$_ghproj" </dev/null 2>&1)
 assert_contains "dispatch: create runs github-scope advisory" "$out" "no repo-scoped GitHub token"
@@ -700,11 +702,14 @@ rm -rf "$_ghproj"
 cleanup_stubs
 
 # `acq create` runs a NON-BLOCKING USAi key advisory: it warns on a definitively
-# invalid key but never aborts (create is detached). Drive the stub's key status
-# via STUB_KEY_STATUS. Use a bare temp workspace (no git remote) so the github
-# advisory stays quiet and doesn't confuse the assertion.
+# invalid key but never aborts (create is detached). A key must be stored first
+# (create now gates on key PRESENCE pre-provision, since msb binds at create);
+# the advisory then reflects the models-API status of the stored key. Drive the
+# stub's key status via STUB_KEY_STATUS. Use a bare temp workspace (no git
+# remote) so the github advisory stays quiet and doesn't confuse the assertion.
 make_stubs
 _keyproj=$(mktemp -d "${TMPDIR:-/tmp}/acq-keycreate.XXXXXX")
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 # Bad key -> advisory fires, but create still succeeds (exit 0).
 out=$(STUB_KEY_STATUS=401 ACQ_BACKEND=sbx "$ACQ" create opencode "$_keyproj" 2>&1); rc=$?
 assert_contains "dispatch: create warns on invalid USAi key" "$out" "invalid or expired (HTTP 401)"
@@ -715,34 +720,41 @@ assert_not_contains "dispatch: create silent on valid USAi key" "$out" "invalid 
 rm -rf "$_keyproj"
 cleanup_stubs
 
-# `acq run` GATES on the USAi key (ensure_valid_key): a non-200 aborts attach
-# unless the user sets/rotates. The message distinguishes "never set" from
-# "expired", and declining (empty answer on the [y/N] prompt) aborts in both
-# cases. Drive the stub's key status via STUB_KEY_STATUS and decline by feeding
-# an empty line on stdin. Bare workspace (no git remote) keeps the github
-# advisory quiet.
+# `acq run` GATES on the USAi key: on a fresh create it FIRST requires a key to
+# be stored (ensure_key_present, PRE-create, because msb binds secrets only at
+# create), then post-create validates that same real sandbox (ensure_valid_key).
+# A non-200 aborts unless the user sets/rotates; declining (empty answer on the
+# [y/N] prompt) aborts. Drive the stub's key status via STUB_KEY_STATUS and
+# decline by feeding an empty line on stdin. Bare workspace (no git remote) keeps
+# the github advisory quiet.
 
-# 3k1. No usai secret stored + bad status -> "no USAi API key is set" + "Set it
-#      now"; declining aborts the run (non-zero).
+# 3k1. No usai key stored -> PRE-create gate names the setup case + prompts to
+#      set; declining aborts the run (non-zero) BEFORE the sandbox is created.
 make_stubs
 _keyrun=$(mktemp -d "${TMPDIR:-/tmp}/acq-keyrun.XXXXXX")
+rm -f "$STUBDIR/.created"
 out=$(printf '\n' | STUB_KEY_STATUS=401 ACQ_BACKEND=sbx "$ACQ" run opencode "$_keyrun" 2>&1); rc=$?
-assert_contains "run: never-set key names the setup case" "$out" "No USAi API key is set"
+assert_contains "run: never-set key names the setup case" "$out" "No USAi API key is stored yet"
 assert_contains "run: never-set key prompts to set" "$out" "Set it now"
 assert_not_contains "run: never-set key does NOT say expired" "$out" "invalid or expired"
-assert_eq "run: never-set + decline aborts attach" "1" "$rc"
+assert_eq "run: never-set + decline aborts run" "1" "$rc"
+if [ -f "$STUBDIR/.created" ]; then
+  fail "run: never-set + decline must NOT create a sandbox" "sandbox was created before key was set"
+else
+  pass "run: never-set + decline does not create a sandbox"
+fi
 rm -rf "$_keyrun"
 cleanup_stubs
 
-# 3k2. usai secret PRESENT + bad status -> "invalid or expired" + "Rotate now"
-#      (regression: the set-but-rejected wording is unchanged); declining aborts.
+# 3k2. usai key PRESENT + bad status -> post-create gate says "invalid or
+#      expired" + "Rotate now"; declining aborts.
 make_stubs
 _keyrun=$(mktemp -d "${TMPDIR:-/tmp}/acq-keyrun.XXXXXX")
 printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 out=$(printf '\n' | STUB_KEY_STATUS=401 ACQ_BACKEND=sbx "$ACQ" run opencode "$_keyrun" 2>&1); rc=$?
 assert_contains "run: expired key names the rotate case" "$out" "invalid or expired"
 assert_contains "run: expired key prompts to rotate" "$out" "Rotate now"
-assert_not_contains "run: expired key does NOT say 'no USAi API key'" "$out" "No USAi API key is set"
+assert_not_contains "run: expired key does NOT say 'no USAi API key'" "$out" "No USAi API key is stored"
 assert_eq "run: expired + decline aborts attach" "1" "$rc"
 rm -rf "$_keyrun"
 cleanup_stubs
@@ -750,6 +762,7 @@ cleanup_stubs
 # 3k3. Healthy status attaches regardless of store state (no gate message).
 make_stubs
 _keyrun=$(mktemp -d "${TMPDIR:-/tmp}/acq-keyrun.XXXXXX")
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 out=$(STUB_OPENCODE_OK=1 STUB_KEY_STATUS=200 ACQ_BACKEND=sbx "$ACQ" run opencode "$_keyrun" 2>&1); rc=$?
 assert_not_contains "run: healthy key -> no gate message" "$out" "Aborting attach"
 assert_eq "run: healthy key attaches" "0" "$rc"
@@ -761,6 +774,7 @@ cleanup_stubs
 #       The stub reports opencode broken until postinstall.mjs runs.
 make_stubs
 _ocrun=$(mktemp -d "${TMPDIR:-/tmp}/acq-ocrun.XXXXXX")
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 out=$(STUB_KEY_STATUS=200 ACQ_BACKEND=sbx "$ACQ" run opencode "$_ocrun" 2>&1); rc=$?
 log=$(cat "$CALLS")
 assert_contains "run(opencode): runs postinstall.mjs when binary not functional" "$log" "postinstall.mjs"
@@ -776,6 +790,7 @@ cleanup_stubs
 # 3k5. When opencode is ALREADY functional, acq does NOT re-run postinstall.
 make_stubs
 _ocrun=$(mktemp -d "${TMPDIR:-/tmp}/acq-ocok.XXXXXX")
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 out=$(STUB_OPENCODE_OK=1 STUB_KEY_STATUS=200 ACQ_BACKEND=sbx "$ACQ" run opencode "$_ocrun" 2>&1)
 log=$(cat "$CALLS")
 assert_not_contains "run(opencode): skips postinstall when already runnable" "$log" "postinstall.mjs"
@@ -864,6 +879,7 @@ cleanup_stubs
 # reaches `sbx create`. Use a throwaway temp dir as the workspace.
 _kitproj=$(mktemp -d "${TMPDIR:-/tmp}/acq-kitproj.XXXXXX")
 make_stubs
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit /tmp/mykit "$_kitproj" 2>/dev/null)
 log=$(cat "$CALLS")
 create_line=$(printf '%s\n' "$log" | grep '^sbx create')
@@ -880,6 +896,7 @@ cleanup_stubs
 
 # --kit=<ref> (equals form) is also intercepted.
 make_stubs
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit=/tmp/eqkit "$_kitproj" 2>/dev/null)
 log=$(cat "$CALLS")
 create_line=$(printf '%s\n' "$log" | grep '^sbx create')
@@ -889,6 +906,7 @@ cleanup_stubs
 
 # Multiple --kit flags are all intercepted.
 make_stubs
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 out=$(ACQ_BACKEND=sbx "$ACQ" create opencode --kit /tmp/k1 --kit /tmp/k2 "$_kitproj" 2>/dev/null)
 log=$(cat "$CALLS")
 create_line=$(printf '%s\n' "$log" | grep '^sbx create')
@@ -899,6 +917,7 @@ cleanup_stubs
 
 # run form also intercepts --kit (routes through provision -> sbx create).
 make_stubs
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 out=$(ACQ_BACKEND=sbx "$ACQ" run opencode --kit /tmp/runkit "$_kitproj" 2>/dev/null)
 log=$(cat "$CALLS")
 create_line=$(printf '%s\n' "$log" | grep '^sbx create')
@@ -909,6 +928,7 @@ cleanup_stubs
 # A `--kit` AFTER the `--` separator belongs to the AGENT, not acq: it MUST NOT
 # be hijacked into the kit list, and it MUST survive intact in the agent args.
 make_stubs
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
 out=$(ACQ_BACKEND=sbx "$ACQ" run opencode "$_kitproj" -- --kit evil-agent-arg 2>/dev/null)
 log=$(cat "$CALLS")
 create_line=$(printf '%s\n' "$log" | grep '^sbx create')


### PR DESCRIPTION
## Context

Bug report against `v3.0.0-rc1`: on a fresh `acq run opencode <proj>` (msb backend), the user is told their brand-new key is valid (HTTP 200) **and** immediately that it is not (HTTP 401), even though the key is confirmed valid elsewhere:

```
acq: usai secret stored (acq.usai).
acq: stored 'usai' in the acq secret store.
Validating new key in a temporary sandbox...
Key validated (HTTP 200). You're good to go.
Key still not working (HTTP 401). Aborting attach.
```

### Root cause

The sandbox was created **before** any USAi key was stored. msb binds secrets only at **create time** (`--secret ENV@HOST`), so the real sandbox carried no USAi binding. The key-rotate path then validated a **throwaway** sandbox created *after* the key was stored — that returned 200 — while the post-store re-check ran against the **real** sandbox — still unbound → 401. The two messages came from two different sandboxes.

Separately, the key-entry prompt said "secret", which in this project is a distinct credential-injection concept; users think of it as their "API key".

## Fix

Reorder so the key is stored **before** the sandbox is created, so both backends bind it at create:

- **`acq`** — pre-create `ensure_key_present` gate on the `run` fresh-create branch and on `create`. Fails closed if the user declines (no sandbox is created).
- **`acq.backends/common.sh`** — add `ensure_key_present`; `ensure_valid_key` now only handles the post-create expired/invalid case and validates the **real** sandbox, so 200/401 can no longer come from different sandboxes.
- **`acq.backends/secret-store.sh`** — prompts now say "USAi API key" / "GitHub token" / "`<svc>` API key" instead of "secret".

No `KNOWN_FAILURE_MODES.md` entry — this eliminates the failure mode rather than documenting it. No back-compat concerns (`v3.0.0-rc1`).

## Dependency fix (Dependabot high, alert #3)

While pushing, the remote surfaced a high-severity **js-yaml** advisory (CVE-2026-59870, quadratic CPU consumption in `!!omap` resolution) reaching the linter toolchain transitively via `markdownlint-cli2`. The existing override pinned the still-vulnerable `4.3.0`; bumped it to `4.3.1` (the fixed 4.x release) so the fix applies **without** the semver-major `markdownlint-cli2` upgrade that `npm audit fix` would otherwise force. `.github/linters/package-lock.json` regenerated (`--package-lock-only`).

## Verification

- `./scripts/test-acq` — **694 passed / 0 failed** (added: declining pre-create does **not** create a sandbox; seeded a stored key in create/kit-flag tests that now require one pre-create).
- `npm audit` in `.github/linters` — **0 vulnerabilities** (was 1 high).
- `npm ci --prefix .github/linters` — clean; `npm run lint:md` — 0 errors.
- `shellcheck -S warning` on `acq`, `common.sh`, `secret-store.sh` — clean.
- `bash -n` — clean.

## Rollback

Revert the two commits; no data migration or state change involved. The js-yaml bump is an override-only change (revert restores `4.3.0`).

## Security impact

- Credential-entry **ordering** change only. The key is still read from the TTY (never argv), stored in the acq secret store, and injected by the backend — the real value never enters the guest. No change to the injection mechanism or attack surface.
- Clears a high-severity transitive CVE in the CI linter toolchain.

AI-assisted (OpenCode).