### PR TITLE
docs: clarify novice onboarding in README and quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,16 @@ You will run the commands in this guide from a terminal. Open one now...
 
 </details>
 
-Then make sure you have each of these ready:
+Good news: there's very little to gather in advance. You need a supported
+computer and a way to run these commands — `acq` walks you through the USAi key
+and GitHub access interactively on first run (see [Step 3](#step-3-create-and-run-a-sandbox)).
 
 | Requirement     | Notes                                                      |
 | --------------- | ---------------------------------------------------------- |
 | A supported host for microVMs | msb uses hardware virtualization. You need one of:<ul><li>**macOS** — Apple Silicon (Intel Macs are not supported)</li><li>**Windows 11** — with the Windows Hypervisor Platform enabled (preview)</li><li>**Linux** — glibc-based, with KVM enabled (`/dev/kvm` present)</li></ul>If you need more detail than this, see [msb host setup](docs/QUICKSTART.md#msb-host-setup) for per-platform particulars. |
-| USAi API key    | [Create one](https://console.gsa.usai.gov/key-management), record it safely, and keep it handy            |
-| GitHub token | <p>(recommended) Allows the agent authenticate to GitHub, work with private repositories, and act on your behalf (open PRs, push to branches, etc).</p><p>**`acq` can walk you through creating a repo-scoped token on first run.**</p> |
+| `git`           | Already installed on macOS and on the supported Linux hosts — **nothing to do**. (On macOS, the first time you run a `git` command the system may offer to install the Command Line Tools; accept it.) Check with `git --version`. |
+| USAi API key    | **Nothing to get in advance** — `acq` prompts you for a key and validates it on first run. <p>(Optional) If you'd rather set it up ahead of time, [create one](https://console.gsa.usai.gov/key-management) and keep it handy; note that USAi keys expire every 7 days.</p> |
+| GitHub token | **Nothing to get in advance** — `acq` offers to walk you through creating a repo-scoped token on first run, when your project contains GitHub repos. You can decline and add one later. <p>(A token lets the agent authenticate to GitHub, work with private repositories, and act on your behalf — open PRs, push to branches, etc.)</p> |
 
 ### Step 1: Install microsandbox (msb)
 
@@ -58,6 +61,9 @@ msb is a standalone, open-source (Apache-2.0) microVM runtime (a host-level tool
 # With Homebrew, our preference at GSA TTS:
 brew install superradcompany/tap/microsandbox
 ```
+
+> Don't have Homebrew? Install it from [brew.sh](https://brew.sh), or use the
+> `curl` installer below (which needs no Homebrew).
 
 or
 
@@ -75,15 +81,51 @@ cd agentic-coding-quickstart
 
 The `acq` command in Step 3 is run from inside this cloned folder.
 
+<details>
+<summary>Testing a specific tagged release? (click to expand)</summary>
+
+To try a specific tagged version, check it out after cloning:
+
+```bash
+git checkout v3.0.0-rc1
+```
+
+Git will print a message about being in a **"detached HEAD" state**. That is
+**normal — it is not an error.** It just means you're looking at a specific
+tagged snapshot rather than a branch. You can run `acq` exactly as described
+below. To go back to the latest development version, run `git switch main`.
+
+</details>
+
 ### Step 3: Create and run a sandbox
 
 ```bash
 ./acq run opencode /path/to/your/project
 ```
 
+`/path/to/your/project` is the folder you want the agent to work in. It can be
+an **existing project** or a **new, empty folder** you just made for this — your
+choice. If the folder is (or will be) a software project, initialize git in it
+first so the agent can track its changes:
+
+```bash
+mkdir -p ~/my-project        # a new folder, if you don't have one yet
+cd ~/my-project
+git init .                   # recommended if this is for software development
+```
+
+Then point `acq` at it (e.g. `./acq run opencode ~/my-project`).
+
 That's it. You're now running an AI coding agent with USAi access and restricted
 filesystem and network access. Repeat this to create sandboxes for each project
 you want to work on.
+
+> [!NOTE]
+> **The first run does real work and may pause quietly for a minute or two.**
+> `acq` boots a microVM, installs the coding agent, and fetches its
+> configuration kits — all with little output while it happens. A quiet terminal
+> here is expected; it is not stuck. Later runs against the same project are much
+> faster.
 
 On first run, `acq` sets you up interactively — nothing to configure beforehand:
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -3,7 +3,7 @@ title: "acq Backend Quickstart"
 description: "Get running with acq, the pluggable-backend wrapper for agentic-coding-quickstart"
 status: canonical
 tier: 2
-last_updated: "2026-08-03"
+last_updated: "2026-08-06"
 audience: "developers"
 keywords: ["acq", "backend", "sbx", "msb", "quickstart", "sandbox"]
 related_files: ["docs/BACKEND_GUIDE.md", "docs/QUICKSTART_SBX.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
@@ -49,7 +49,12 @@ Complete the standard setup in [README.md](../README.md#5-minute-quickstart):
 
 - Install the `sbx` CLI (>= 0.35.0)
 - Run `sbx login`
-- Set your network policy and secrets (USAi key, GitHub token)
+- Set your network policy
+
+You do **not** need to gather a USAi key or GitHub token in advance — `acq`
+prompts you for the USAi key on first run and offers to scope a GitHub token
+when your workspace has GitHub repos. Set them ahead of time only when
+pre-seeding a machine or scripting setup (see [Secrets](#secrets) below).
 
 ### Step 2: Run a sandbox
 
@@ -57,8 +62,17 @@ Complete the standard setup in [README.md](../README.md#5-minute-quickstart):
 ./acq run opencode /path/to/your/project
 ```
 
+`/path/to/your/project` is the folder the agent works in — an **existing
+project** or a **new, empty folder** you just created. If it's a software
+project, run `git init .` in it first so the agent can track its changes.
+
 That's it. `acq run` creates the sandbox if it doesn't exist, heals any missing
 kits, validates your USAi key, and attaches the agent.
+
+> [!NOTE]
+> The **first** run boots a microVM, installs the agent, and fetches kits — it
+> may pause quietly for a minute or two with little output. That is expected,
+> not a hang; later runs are much faster.
 
 ### Step 3: Common commands
 

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -33,8 +33,8 @@ For federal compliance and automation, sbx CLI is the recommended approach.
 |-------------|--------------|-------|
 | sbx CLI | `sbx version` | Standalone tool, Docker Desktop not required |
 | Docker account | `sbx login` succeeds | Your org may require a paid Docker subscription seat |
-| USAi API key | From your GSA account | For Anthropic/Claude access |
-| GitHub token | `gh auth token` | Optional, for code access |
+| USAi API key | — | **Nothing to get in advance** — `acq` prompts you and validates it on first run. Set ahead of time only when pre-seeding/scripting. |
+| GitHub token | — | **Nothing to get in advance** — `acq` offers to scope one on first run when your workspace has GitHub repos. Optional, for code access. |
 
 > [!NOTE]
 > Docker Desktop is **not required** to use sbx. The sbx CLI is a standalone tool.
@@ -52,7 +52,11 @@ For federal compliance and automation, sbx CLI is the recommended approach.
 ```bash
 # macOS
 brew install docker/tap/sbx && sbx login
+```
 
+> Don't have Homebrew? Install it from [brew.sh](https://brew.sh) first.
+
+```bash
 # Windows
 winget install -h Docker.sbx && sbx login
 


### PR DESCRIPTION
## Context

Notes from watching a novice, non-technical user work through `README.md` on first run surfaced several onboarding friction points. This PR fixes the wording; a follow-up issue tracks the one code change (progress feedback).

> **Note:** based on `fix/usai-key-before-sandbox-create` (PR #286), not `main`, since this branch was cut from it. Retarget to `main` once #286 merges.

## Changes (docs only)

- **Prerequisites lead with "little to gather in advance"** and defer the USAi key + GitHub token to `acq`'s interactive first-run flow:
  - USAi key reframed from an imperative to an **optional aside** (link kept for users who want to pre-stage).
  - GitHub token wording now **leads** with "acq walks you through it on first run."
- **Added a `git` prerequisite note** — it's already present on macOS/supported Linux (with the macOS Command Line Tools prompt), so users aren't unsure whether to install it.
- **Homebrew link** ([brew.sh](https://brew.sh)) for users who prefer brew but don't have it.
- **Optional tagged-release checkout** with an explicit reassurance that the **"detached HEAD" message is normal, not an error**.
- **Clarified the project path** can be existing or new, with `git init .` guidance.
- **First-run quiet-pause note** — interim mitigation for the missing progress feedback (spinner tracked in GSA-TTS/agentic-coding-quickstart#287).
- Propagated the same clarifications into `docs/QUICKSTART.md` and `docs/QUICKSTART_SBX.md`.

## AI assistance

AI-assisted (OpenCode). Human-reviewed before submission.

## Verification

- \`npm run lint:md\` → **0 errors** (34 files).
- Docs-only change; no code paths touched.

## Rollback

Revert the single commit on this branch; no runtime impact.

## Security impact

None — documentation only. No auth, secret-handling, or attack-surface changes.

Refs: GSA-TTS/agentic-coding-quickstart#287