### PR TITLE
docs: add SUPPORT.md (maintained by/for the federal community) (#275)

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,40 @@
+# Support
+
+The Agentic Coding Quickstart provides the `acq` sandbox tooling and setup
+guidance for running AI coding agents in isolated environments.
+
+## Documentation
+
+- [README](README.md) — overview and 5-minute quick start
+- [docs/QUICKSTART.md](docs/QUICKSTART.md) — start here
+- [docs/](docs/) — full documentation (backend guide, troubleshooting, ADRs)
+
+## Questions or help
+
+Open a [GitHub issue](https://github.com/GSA-TTS/agentic-coding-quickstart/issues)
+(or a Discussion, if enabled). Others benefit from the answer too.
+
+## Bugs and feature requests
+
+Open a [GitHub issue](https://github.com/GSA-TTS/agentic-coding-quickstart/issues)
+with steps to reproduce (for bugs) or a clear description of the request.
+See [docs/KNOWN_FAILURE_MODES.md](docs/KNOWN_FAILURE_MODES.md) first — your issue
+may already be documented.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Security vulnerabilities
+
+**Do not open a public issue for a security vulnerability.** See
+[SECURITY.md](SECURITY.md) for how to report one privately.
+
+## Code of conduct
+
+See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+---
+
+This project is maintained by and for the federal agentic-coding community, and provided as-is under
+[CC0 1.0](LICENSE), on a best-effort basis (no guaranteed response time).


### PR DESCRIPTION
## Summary

Public-readiness should-fix (epic #276, addresses the SUPPORT.md item of #275). Adds a minimal SUPPORT.md.

## Change (docs-only)

- **SUPPORT.md** (new) — short, link-based "how to get help": README + `docs/QUICKSTART.md` + `docs/` (incl. KNOWN_FAILURE_MODES); GitHub issues for questions/bugs; CONTRIBUTING for contributing; SECURITY.md for private vuln reports (not public issues); CODE_OF_CONDUCT link; best-effort/CC0. Framed as "maintained by and for the **federal** agentic-coding community." GitHub renders it as the Support link at issue-creation.

## Notes

- 3/3 consensus-approved the minimal SUPPORT.md; GOVERNANCE/MAINTAINERS skipped (matches TTS peers; ownership in CODEOWNERS).
- All relative links verified to resolve.
- The README-license and CONTRIBUTING-external-model items of #275 were already handled by the merged governance PR #280. Remaining on #275: housekeeping (node_modules/deleteme/CODEOWNERS/dependabot).

AI-assisted (OpenCode); consensus-reviewed. Requires human review.