### PR TITLE
chore: public-readiness housekeeping — CODEOWNERS + dependabot (#275)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,5 @@
 
 # Security-sensitive files require additional review
 /.github/workflows/ @GSA-TTS/agentic-coding-team
-/opencode.jsonc @GSA-TTS/agentic-coding-team
 /AGENTS.md @GSA-TTS/agentic-coding-team
 /SECURITY.md @GSA-TTS/agentic-coding-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,39 @@ updates:
       actions:
         patterns:
           - "*"
+
+  # npm (repo tooling — e.g. markdown lint deps)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      npm:
+        patterns:
+          - "*"
+
+  # npm (linter toolchain)
+  - package-ecosystem: "npm"
+    directory: "/.github/linters"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      linters:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Public-readiness should-fix housekeeping (epic #276, the housekeeping items of #275).

## Changes (config-only)

- **`.github/CODEOWNERS`** — remove the stale `/opencode.jsonc` rule. No `opencode.jsonc` is tracked in this repo (the usai opencode.jsonc lives in the patterns kit), so the rule matched nothing.
- **`.github/dependabot.yml`** — add npm ecosystems for `/` (root `package.json`) and `/.github/linters` (the markdownlint toolchain — the one that carried the recent js-yaml CVE), so updates are covered beyond github-actions.
  - **pip intentionally omitted:** the repo has no Python manifest (no `requirements.txt` / `pyproject.toml`), so a pip ecosystem would be a dead no-op.

`node_modules/` and `deleteme/` were verified already **gitignored and untracked** — no change needed.

## Verification

`dependabot.yml` parses; ecosystems = `github-actions:/`, `npm:/`, `npm:/.github/linters`. pre-commit clean.

Closes the housekeeping items of #275.

AI-assisted (OpenCode); requires human review.