### PR TITLE
docs(acq): remove hardcoded 'four kits' count + guard against drift (#278)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ review_cycle: "quarterly"
 
 This repository is a thin **wrapper** (`acq`) that stands up a working,
 federally-configured agent sandbox by composing existing tools: a **sandboxing
-backend** — the `sbx` CLI (SBX) or `msb` (MSB / microsandbox) — plus four
+backend** — the `sbx` CLI (SBX) or `msb` (MSB / microsandbox) — plus its
+built-in
 **mixin kits** hosted in the community
 [agentic-coding-patterns](https://github.com/GSA-TTS/agentic-coding-patterns)
 repo (`integrations/isolation/acq-kits/`). It carries **no** kit code of its own
@@ -43,7 +44,7 @@ my-workspace/                       # Parent folder (user creates this)
 └── my-app/                         # User's project(s)
 ```
 
-When `acq` creates a sandbox it applies four kits by pinned remote reference
+When `acq` creates a sandbox it applies its built-in kits by pinned remote reference
 (`--kit git+https://github.com/GSA-TTS/agentic-coding-patterns.git#ref=<sha>&dir=…`).
 The same neutral kits apply to both backends; per-backend translation is the
 adapter's job (see [ADR-0010](docs/adr/0010-acq-pluggable-backends.md) /

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ quickstart for when you want to customize or troubleshoot.
 
 ### What `acq` applies
 
-`acq` applies **four mixin kits** (by pinned remote reference from the
+`acq` applies its **built-in mixin kits** (by pinned remote reference from the
 community [agentic-coding-patterns](https://github.com/GSA-TTS/agentic-coding-patterns)
 repo) when it creates a sandbox:
 
@@ -345,7 +345,7 @@ current baseline. See the kit definition in the agentic-coding-patterns reposito
 ---
 ## Customizing your setup
 
-`acq` applies a fixed set of four kits, pinned to a commit of the patterns
+`acq` applies a fixed set of built-in kits, pinned to a commit of the patterns
 repo. To customize:
 
 - **Add your own kits on every run:** see [Advanced: extra kits](#advanced-extra-kits).
@@ -360,7 +360,7 @@ repo. To customize:
 
 ## Advanced: extra kits
 
-`acq` always applies its four built-in kits. To apply **additional** kits on
+`acq` always applies its built-in kits. To apply **additional** kits on
 every invocation without repeating `--kit` flags, set `ACQ_EXTRA_KITS` to a
 whitespace-separated list of kit references (local paths or remote refs):
 

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1426,7 +1426,7 @@ assert_not_contains "secret rm(msb): lone token never invokes 'msb secret'" "$lo
 cleanup_stubs
 
 # ===========================================================================
-# 6. Kit list completeness (the four built-in kits)
+# 6. Kit list completeness (the built-in kits) + doc count-drift guard
 # ===========================================================================
 
 make_stubs; load_acq
@@ -1439,6 +1439,17 @@ assert_contains "kits: git-ssh-sign" "$kits_joined" "acq-kits/git-ssh-sign"
 # any later kit makes a network request (matters on sbx, whose kits apply
 # sequentially; harmless on msb, where trust is a create-time flag).
 assert_contains "kits: zscaler applied first" "${KITS[0]}" "acq-kits/zscaler-ca-certificate"
+# Count-drift guard (#278): the authority is ACQ_KIT_NAMES in common.sh. If a
+# doc still spells out a hardcoded English count ("four kits"), it will silently
+# lie the moment the built-in set changes size. Prefer countless prose ("its
+# built-in kits"); this asserts no such stale English-number count survives in
+# the user-facing docs.
+_kit_count="${#ACQ_KIT_NAMES[@]}"
+assert_eq "kit count is the documented set" "4" "$_kit_count"
+for _doc in "$REPO_ROOT/README.md" "$REPO_ROOT/AGENTS.md"; do
+  _bad=$(grep -Eic "\b(four|five|three|six|two) (built-in |mixin )?kits\b" "$_doc" || true)
+  assert_eq "no hardcoded English kit count in $(basename "$_doc")" "0" "$_bad"
+done
 cleanup_stubs
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
Closes GSA-TTS/agentic-coding-quickstart#278 (count-centralization epic playbook#183, approach A). The built-in kit set's authority is `ACQ_KIT_NAMES` in `acq.backends/common.sh`, but **'four kits'** was hardcoded in README (×3) and AGENTS.md (×2) — silently wrong the moment the set changes size.

- **Reworded** the user-facing prose to be countless ('its built-in kits', 'a fixed set of built-in kits').
- **Extended `test-acq` test 6** (Kit list completeness — already anchored on `ACQ_KIT_NAMES`) with a count-drift guard: asserts README.md/AGENTS.md contain **no hardcoded English kit count** (`(four|five|three|six|two) kits`). Reintroducing a spelled-out count fails the suite. Verified: injecting 'four mixin kits' back into README trips the assertion.

Left legitimately-numeric **code comments** (kit-translate/msb/verify-backends) untouched — those describe the current set in-code, not user docs.

## Verification
0 residual 'four kits' in docs; test-acq syntax + guard logic verified; pre-commit (secrets, markdownlint, shellcheck) pass.

## Rollback
Revert. Doc wording + one test assertion.

AI-assisted (OpenCode). Requires human review.