### PR TITLE
fix(acq): secret rm can remove any stored entry, not just built-ins (#300)

### DIFF
--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -443,8 +443,15 @@ acq_secret_import() {
 # _acq_is_managed_secret_rm ARGS... -> 0 if the `acq secret rm` args name an
 # acq-managed secret (scope + known service), else 1 (pass through to backend).
 # Recognizes:  -g SERVICE  |  --global SERVICE  |  SANDBOX SERVICE
+#
+# "Managed" is EITHER a built-in service (usai/github/gitlab) OR any entry that
+# actually exists in the acq store under the resolved scope. The store check
+# means an entry `acq secret ls` shows can always be removed by `acq secret rm`,
+# even if it was created with an arbitrary (e.g. sandbox-shaped) service name —
+# otherwise such entries become un-removable orphans. A lone token with no scope
+# is still NOT managed (it is a raw placeholder for a backend that has one).
 _acq_is_managed_secret_rm() {
-  local a1="${1:-}" a2="${2:-}" svc=""
+  local a1="${1:-}" a2="${2:-}" svc="" sandbox=""
   case "$a1" in
     -g|--global) svc="$a2" ;;
     -*)          return 1 ;;              # some other flag/placeholder
@@ -453,14 +460,21 @@ _acq_is_managed_secret_rm() {
       # placeholder for the backend to handle.
       [ -n "$a2" ] || return 1
       case "$a2" in -*) return 1 ;; esac
-      svc="$a2"
+      svc="$a2"; sandbox="$a1"
       ;;
   esac
   [ -n "$svc" ] || return 1
   case "$ACQ_MANAGED_SECRET_SERVICES" in
     *" $svc "*) return 0 ;;
-    *) return 1 ;;
   esac
+  # Not a built-in: managed iff the entry exists in the acq store at this scope.
+  # (Only checkable when the neutral store is loaded — the native-store backends.)
+  if command -v _acq_secret_key >/dev/null 2>&1 && command -v acq_secret_get >/dev/null 2>&1; then
+    local key
+    key=$(_acq_secret_key "$svc" "$sandbox") || return 1
+    acq_secret_get "$key" >/dev/null 2>&1 && return 0
+  fi
+  return 1
 }
 
 # Word-split a whitespace-separated env value into the named array WITHOUT

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1409,6 +1409,35 @@ assert_contains "classify: lone placeholder is passthrough" "$classify_out" "lon
 assert_contains "classify: unknown service is passthrough" "$classify_out" "g-unknown=passthru"
 cleanup_stubs
 
+# 5h3a. Regression (GSA-TTS/agentic-coding-quickstart#300): a NON-built-in secret
+#       that actually EXISTS in the acq store (e.g. an orphan created with a
+#       sandbox-shaped service name) must be removable — the classifier treats a
+#       stored entry as managed, and `acq secret rm` deletes it. Otherwise such
+#       entries become un-removable orphans (`ls` shows them, `rm` refuses).
+make_stubs
+_orphan_store=$(mktemp -d "${TMPDIR:-/tmp}/acq-orphan.XXXXXX")
+orphan_out=$(
+  export ACQ_SECRET_STORE_DIR="$_orphan_store/secrets"   # force the file store
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/common.sh"
+  _k=$(_acq_secret_key opencode-pic-blm-cxworks)
+  printf 'orphan-value' | acq_secret_store "$_k" >/dev/null 2>&1
+  # before removal: stored + classified managed
+  acq_secret_get "$_k" >/dev/null 2>&1 && printf 'stored=yes\n'
+  _acq_is_managed_secret_rm -g opencode-pic-blm-cxworks && printf 'orphan=managed\n' || printf 'orphan=passthru\n'
+  # an absent non-built-in is still NOT managed (must not swallow a real placeholder)
+  _acq_is_managed_secret_rm -g never-stored-svc && printf 'absent=managed\n' || printf 'absent=passthru\n'
+  # remove it, then confirm gone
+  acq_secret_delete "$_k" >/dev/null 2>&1
+  acq_secret_get "$_k" >/dev/null 2>&1 && printf 'after=present\n' || printf 'after=gone\n'
+)
+rm -rf "$_orphan_store"
+assert_contains "orphan(#300): stored" "$orphan_out" "stored=yes"
+assert_contains "orphan(#300): stored entry is managed (removable)" "$orphan_out" "orphan=managed"
+assert_contains "orphan(#300): absent non-builtin stays passthrough" "$orphan_out" "absent=passthru"
+assert_contains "orphan(#300): removed" "$orphan_out" "after=gone"
+cleanup_stubs
+
 # 5h3b. Regression: on msb, `acq secret rm SERVICE` with NO scope (a lone token)
 #       must NOT be passed through to a nonexistent `msb secret` CLI (which
 #       produced a confusing "unrecognized subcommand 'secret'" from msb). Since


### PR DESCRIPTION
## Summary
Closes GSA-TTS/agentic-coding-quickstart#300 (user-reported by Tyler Burton). An acq secret store entry created with a non-built-in (sandbox-shaped) service name — e.g. `opencode-pic-blm-cxworks` — shows in `acq secret ls` but `acq secret rm` **refuses to delete it**, leaving an un-removable orphan.

**Root cause:** `_acq_is_managed_secret_rm` (`acq.backends/common.sh`) only recognized the hard-coded `usai/github/gitlab` allowlist, so on the msb/native store a non-allowlisted name hit the fail-closed 'scope required' branch instead of being deleted.

**Fix (neutral store only):** a name is 'managed' if it is a built-in **OR the entry actually exists in the acq store** at the resolved scope (via `_acq_secret_key` + `acq_secret_get`). So any entry `acq secret ls` lists is removable; an absent non-built-in still passes through (never swallows a real backend placeholder); a lone token with no scope stays passthrough.

## Scope / coordination
Touches **only** the backend-neutral classifier in `common.sh`. The SBX CLI's separate experimental secret-flag changes (`--sandbox` / removed `-g` / `--placeholder`) are handled independently on **`feat/msb-oci-podman`** (Bret) — this fix is orthogonal and unblocks the reported **msb** case now. No `sbx.sh` changes here.

## Verification
- Regression test (test-acq 5h3a): store an arbitrary-named secret → classifies managed → removes; absent non-built-in stays passthrough.
- Verified live against the file store: orphan → managed+removed; absent/lone → passthrough; `usai` built-in still managed.
- shellcheck + syntax pass.

## Manual workaround (for users blocked now)
The value is keyed `acq.<service>` (global) / `acq.<sandbox>.<service>`:
- Linux keyring: `secret-tool clear acq_key acq.<service>`
- macOS keychain: `security delete-generic-password -s acq-secret-store -a acq.<service>`
- file fallback: `rm -f "${XDG_STATE_HOME:-$HOME/.local/state}/acq/secrets/acq.<service>"`

AI-assisted (OpenCode). User-reported. Requires human review.