### PR TITLE
docs(failure-modes): note git-ssh-sign msb parity gap tracked in #303

### DIFF
--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -3,7 +3,7 @@ title: "Known Failure Modes"
 description: "Real-world failure patterns when using Docker SBX + USAi + agent frameworks"
 status: canonical
 tier: 2
-last_updated: "2026-08-10"
+last_updated: "2026-08-12"
 audience: "developers"
 keywords: ["debugging", "troubleshooting", "sbx", "usai", "failures"]
 ---
@@ -770,6 +770,15 @@ failure modes, see the kit's
 > [agentic-coding-patterns#211](https://github.com/GSA-TTS/agentic-coding-patterns/issues/211);
 > the quickstart-side decision (docs + advisory) is recorded in
 > [ADR-0007](adr/0007-commit-verification-identity-guidance.md).
+>
+> **Backend note (`msb`):** the `git-ssh-sign` kit currently works on the `sbx`
+> backend but **not** on `msb`. `sbx` forwards the host ssh-agent into the
+> sandbox by default, so in-guest signing "just works"; `msb` has no equivalent
+> host-socket forwarding, so a guest cannot reach the host agent. This parity gap
+> is blocked on a tagged `msb` release that ships the upstream vsock/unix-socket
+> forwarding work (microsandbox `--vsock`), and is tracked — with the upstream
+> watch-list and our follow-on `acq`/kit checklist — in
+> [quickstart#303](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/303).
 
 ---
 


### PR DESCRIPTION
## Context

The `git-ssh-sign` kit works on the `sbx` backend (host ssh-agent is forwarded
into the sandbox by default) but not on `msb`, which has no equivalent
host-socket forwarding — an sbx↔msb parity gap. That gap is now tracked in
GSA-TTS/agentic-coding-quickstart#303, blocked on a tagged `msb` release shipping
the upstream vsock/unix-socket forwarding work (microsandbox `--vsock`, landed on
`main` via superradcompany/microsandbox#1297).

## Plan

- Add a **backend note** under §22 ("Signed Commits Show Unverified") of
  `docs/KNOWN_FAILURE_MODES.md` pointing readers at #303 so someone who hits
  non-working signing on `msb` finds the tracked explanation and trigger.
- Bump the doc's `last_updated` frontmatter.

Docs-only; one file changed.

## Verification

- `npx markdownlint-cli2 docs/KNOWN_FAILURE_MODES.md` — no errors on this file
  (the only remaining lint output is for an unrelated untracked file not part of
  this branch/PR).

## Rollback

Revert this commit; the note is additive and self-contained.

## Security impact

None — documentation only. (The gap it describes is itself a trust-boundary
consideration, addressed in the design tracked by #303.)

## Note on signing

This commit was made **unsigned** because it was authored inside an `msb`
sandbox with no forwarded ssh-agent — i.e. the exact parity gap #303 tracks.

AI-assisted.

Refs: GSA-TTS/agentic-coding-quickstart#303
