### PR TITLE
feat(msb): diagnose+disambiguate msb egress failures (three signatures)

### DIFF
--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -1451,6 +1451,8 @@ ensure_opencode_postinstall() {
 
 # Probe the USAi API from inside the sandbox. Emits ONE clean token on stdout:
 #   - a 3-digit HTTP status (e.g. 200, 401) on a real HTTP response,
+#   - "unresolved" when the guest resolver returned no answer for the name
+#     (curl exit 6 / NXDOMAIN) — the split-horizon-DNS tell,
 #   - the literal "unreachable" when curl could not complete a request at all
 #     (TLS reset, DNS failure, proxy/Zscaler interception, offline — curl exits
 #     non-zero and writes http_code 000), or
@@ -1473,8 +1475,18 @@ check_key() {
 }
 
 # Reduce a raw `<http_code>|<curl_exit>` probe result (possibly polluted with
-# curl error text) to a clean status token: a 3-digit HTTP code, "unreachable",
-# or "". Shared by check_key and check_fresh_sandbox_key.
+# curl error text) to a clean status token: a 3-digit HTTP code, "unresolved"
+# (DNS did not resolve the name — curl exit 6), "unreachable" (resolved but the
+# connection never completed — TLS reset / connect refused / HTTP 000), or "".
+# Shared by check_key and check_fresh_sandbox_key.
+#
+# WHY "unresolved" is split out from "unreachable": a curl exit 6 means the guest
+# resolver returned NXDOMAIN for the name. For a split-horizon host like
+# api.gsa.usai.gov (whose real address lives in an internal, tunnel-only zone the
+# guest's public resolver can't see), that is the diagnostic tell — a distinct
+# remedy (a resolver that can reach the internal zone) from a broad TLS/egress
+# cut. Keeping them separate lets the caller give the right advice instead of a
+# generic "network problem". See docs/KNOWN_FAILURE_MODES.md §30.
 _classify_key_status() {
   local raw="$1" code exit_code
   # The curl exit code is the last field after the final '|'. Keep only digits.
@@ -1489,6 +1501,13 @@ _classify_key_status() {
   # curl succeeded (exit 0) AND returned a plausible non-000 HTTP code.
   if [ "$exit_code" = "0" ] && [ -n "$code" ] && [ "$code" != "000" ]; then
     printf '%s\n' "$code"
+    return 0
+  fi
+  # curl exit 6 = "couldn't resolve host": DNS returned no answer for the name.
+  # This is the split-horizon-DNS signature (the public guest resolver can't see
+  # an internal-only zone), NOT a broad connection cut — report it distinctly.
+  if [ "$exit_code" = "6" ]; then
+    printf 'unresolved\n'
     return 0
   fi
   # curl failed to get any response (nonzero exit, or http_code 000): the request
@@ -2000,6 +2019,11 @@ advise_valid_key() {
     return 0
   fi
 
+  if [ "$status" = "unresolved" ]; then
+    _report_usai_unresolved
+    return 0
+  fi
+
   echo "acq: note — your USAi API key looks invalid or expired (HTTP $status)." >&2
   echo "      USAi keys expire every 7 days. This sandbox was created, but the" >&2
   echo "      key must be valid before an agent can use it." >&2
@@ -2024,6 +2048,31 @@ _report_usai_unreachable() {
   echo "      both outbound connections are being cut — a strong sign of a network" >&2
   echo "      or TLS-interception (e.g. corporate proxy) issue rather than USAi." >&2
   echo "      See docs/KNOWN_FAILURE_MODES.md for diagnosis steps." >&2
+  echo >&2
+}
+
+# Print a DNS-oriented diagnosis when the USAi models API name did not RESOLVE
+# from the sandbox (curl exit 6 / NXDOMAIN). This is distinct from the broad
+# "unreachable" cut: the tell is that the name has no answer for the guest
+# resolver, while other public hosts (GitHub, npm) resolve and connect fine.
+#
+# The usual cause on GFE is split-horizon DNS — the USAi host resolves to an
+# INTERNAL address that only exists in the corporate/tunnel zone, which the
+# guest's default public resolver (ACQ_MSB_DNS_NAMESERVER, 1.1.1.1) cannot see.
+# A key rotation cannot fix this, and neither can a msb data wipe; the remedy is
+# a resolver that can reach the internal USAi zone. State the signal and point
+# at the docs rather than guessing the user's network fix.
+_report_usai_unresolved() {
+  echo >&2
+  echo "acq: the USAi API host in $USAI_MODELS_URL did not RESOLVE from the sandbox" >&2
+  echo "      (DNS returned no address). This is a name-resolution problem, NOT an" >&2
+  echo "      invalid or expired key, so rotating the key will not help." >&2
+  echo "      If other public hosts (GitHub, npm) work from the sandbox but only" >&2
+  echo "      USAi fails to resolve, USAi is likely a split-horizon name whose" >&2
+  echo "      address lives in an internal/tunnel-only zone the guest's default" >&2
+  echo "      resolver cannot see. Point the guest at a resolver that can reach the" >&2
+  echo "      internal USAi zone via ACQ_MSB_DNS_NAMESERVER." >&2
+  echo "      See docs/KNOWN_FAILURE_MODES.md §30 (USAi-only NXDOMAIN)." >&2
   echo >&2
 }
 
@@ -2149,6 +2198,14 @@ ensure_valid_key() {
   # the first USAi call) with a network-oriented diagnosis.
   if [ "$status" = "unreachable" ]; then
     _report_usai_unreachable
+    return 1
+  fi
+
+  # DNS returned no address for the USAi host (curl exit 6). Distinct from a
+  # broad cut: the split-horizon-DNS case, where only USAi fails to resolve. A
+  # rotation cannot fix it, so fail closed with a resolver-oriented diagnosis.
+  if [ "$status" = "unresolved" ]; then
+    _report_usai_unresolved
     return 1
   fi
 

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -197,6 +197,68 @@ ACQ_MSB_CPUS="${ACQ_MSB_CPUS-2}"
 # so an explicitly-empty value disables the flag rather than re-defaulting.
 ACQ_MSB_DNS_NAMESERVER="${ACQ_MSB_DNS_NAMESERVER-1.1.1.1}"
 
+# ---------------------------------------------------------------------------
+# TLS-interception UPSTREAM trust (corporate MITM proxy, e.g. Zscaler)
+# ---------------------------------------------------------------------------
+# SCOPE: this block is defense-in-depth for the case where a corporate
+# TLS-intercepting proxy GENUINELY TERMINATES an outbound endpoint (presents its
+# own corporate-signed leaf). It is NOT a cure-all for "the guest can't reach the
+# network"; see docs/KNOWN_FAILURE_MODES.md §30, which separates that broad-egress
+# failure (stale msb state; fixed by a data wipe + reinstall) and the USAi
+# split-horizon DNS failure (needs a resolver that can see the internal zone) from
+# this genuine-interception case.
+#
+# acq enables msb `--tls-intercept` so msb can substitute injected secrets on the
+# wire (see the --tls-intercept block in acq_backend_provision). That runs a
+# HOST-SIDE TLS proxy which re-originates an outbound TLS connection to the real
+# server. Behind a terminating corporate proxy that "real server" is the proxy
+# itself, presenting a corporate-signed leaf, so msb's proxy must trust the
+# CORPORATE ROOT on its UPSTREAM leg.
+#
+# msb verifies that upstream leg against the host's native trust store. Crucially,
+# `--trust-host-cas` does NOT help here — it only ships host CAs into the GUEST,
+# not into the proxy's upstream verifier. When the host's native-cert enumeration
+# does not surface the corporate root (uneven on macOS: it depends on which
+# keychain / trust-settings domain the root lives in), the upstream handshake
+# fails AFTER the guest-facing TLS already completed, and the guest client sees
+# `curl: (56) … unexpected eof` for every terminated host — not a 401.
+#
+# FIX: pass the corporate root explicitly to msb's UPSTREAM verifier via
+# `--tls-upstream-ca-cert <PEM>` (msb ADDS it to the native roots; the flag is
+# repeatable / a file may bundle multiple certs). Two ways to supply it:
+#
+#   1. ACQ_MSB_UPSTREAM_CA_CERT — explicit path(s) to PEM file(s) (colon- or
+#      space-separated). Highest precedence; passed through verbatim. Use this
+#      when you already have the corporate root on disk, or on non-macOS hosts.
+#
+#   2. Auto-detect (macOS default, on). When no explicit path is set, acq exports
+#      the host's search-list root CAs to a PEM under its state dir and passes
+#      THAT. This captures the corporate root exactly as the host trusts it,
+#      sidestepping the native-cert loader's keychain/trust-settings gaps. Toggle
+#      off with ACQ_MSB_UPSTREAM_CA_AUTODETECT=0.
+#
+# Normalized like the other on/off toggles. Auto-detect only runs on macOS (it
+# uses the `security` tool); elsewhere it is a no-op and only the explicit path
+# (option 1) applies.
+ACQ_MSB_UPSTREAM_CA_CERT="${ACQ_MSB_UPSTREAM_CA_CERT:-}"
+ACQ_MSB_UPSTREAM_CA_AUTODETECT="${ACQ_MSB_UPSTREAM_CA_AUTODETECT-1}"
+case "$(printf '%s' "$ACQ_MSB_UPSTREAM_CA_AUTODETECT" | tr '[:upper:]' '[:lower:]')" in
+  ""|0|false|no|off) ACQ_MSB_UPSTREAM_CA_AUTODETECT="" ;;
+  *)                 ACQ_MSB_UPSTREAM_CA_AUTODETECT="1" ;;
+esac
+
+# Where the auto-detected host CA bundle is written for the upstream verifier.
+ACQ_MSB_UPSTREAM_CA_FILE="${ACQ_MSB_UPSTREAM_CA_FILE:-${ACQ_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/acq}/msb/host-upstream-cas.pem}"
+
+# REPRODUCTION / TESTING toggle. A host whose corporate proxy does NOT intercept
+# api.gsa.usai.gov / github.com (e.g. those domains are on a proxy bypass list)
+# cannot locally reproduce the upstream-trust failure, because the msb proxy talks
+# straight to the real endpoints. Setting ACQ_MSB_NO_UPSTREAM_CA=1 SUPPRESSES the
+# fix (emits no --tls-upstream-ca-cert even when one is available), so the sandbox
+# behaves as an environment where native-cert loading misses the corporate root.
+# Use it to confirm the failure and that the fix resolves it. Off by default.
+ACQ_MSB_NO_UPSTREAM_CA="${ACQ_MSB_NO_UPSTREAM_CA:-}"
+
 # Agents recognized by acq's run dispatch (mirrors sbx.sh KNOWN_AGENTS).
 # shellcheck disable=SC2034
 KNOWN_AGENTS=" claude codex copilot cursor docker-agent droid gemini kiro opencode shell "
@@ -1875,8 +1937,111 @@ _acq_msb_stage_startup_script() {
     acq_debug "msb startup-script staged: --script-path ${ACQ_MSB_STARTUP_SCRIPT_NAME}:${_file}"
   else
     # No startup commands in this kit — remove the empty temp file.
-    rm -f "$_file" 2>/dev/null || true
+     rm -f "$_file" 2>/dev/null || true
+   fi
+ }
+
+# ---------------------------------------------------------------------------
+# _acq_msb_upstream_ca_flags_into ARRVAR — TLS-intercept upstream CA trust
+# ---------------------------------------------------------------------------
+# Emit `--tls-upstream-ca-cert <PEM>` create flags (one per resolved PEM) into
+# the named array so msb's host-side interception proxy trusts a corporate MITM
+# proxy's root on its UPSTREAM leg. See the ACQ_MSB_UPSTREAM_CA_* block near the
+# top of this file for the full rationale.
+#
+# Scope: this helps ONLY the genuinely-terminated-endpoint case (a corporate
+# proxy terminates the domain and presents its own leaf). It is defense-in-depth;
+# it does not help a broad-egress failure (stale msb state) or USAi split-horizon
+# DNS. See docs/KNOWN_FAILURE_MODES.md §30.
+#
+# Precedence:
+#   0. ACQ_MSB_NO_UPSTREAM_CA — suppress entirely (reproduction/testing toggle).
+#   1. ACQ_MSB_UPSTREAM_CA_CERT — explicit path(s), colon- or space-separated;
+#      each existing, non-empty, readable file is passed through verbatim.
+#   2. Auto-detect (macOS only, on unless ACQ_MSB_UPSTREAM_CA_AUTODETECT=0): export
+#      the host search-list root CAs to a single PEM and pass THAT one file.
+#
+# Non-fatal throughout: any failure warns and emits nothing (the sandbox still
+# creates; msb falls back to its own native-cert loading, i.e. today's behavior).
+_acq_msb_upstream_ca_flags_into() {
+  local _arr="$1"
+  eval "$_arr=()"
+
+  # (0) Reproduction/testing override: behave as if no upstream CA is available.
+  if [ -n "${ACQ_MSB_NO_UPSTREAM_CA:-}" ]; then
+    acq_debug "msb upstream-CA: suppressed via ACQ_MSB_NO_UPSTREAM_CA (reproduction mode)"
+    return 0
   fi
+
+  # (1) Explicit path(s) win. Split on ':' and whitespace; keep only readable,
+  # non-empty files. A configured-but-missing path is a warning, not silent.
+  if [ -n "${ACQ_MSB_UPSTREAM_CA_CERT:-}" ]; then
+    local _p _added=0 _oldifs="$IFS" _nl
+    # Split on ':' plus every whitespace char (space, tab, newline). Build the
+    # separator set with printf into a variable so no literal trailing space/tab
+    # sits on a source line (the trailing-whitespace pre-commit hook would strip
+    # it and silently break the split). $(...) drops trailing newlines, so append
+    # the newline separately via a dedicated _nl.
+    _nl=$(printf '\n_')   # capture a real newline (the trailing _ survives $(...) )
+    _nl=${_nl%_}          # ... then strip the guard char, leaving just "\n"
+    IFS=":$(printf ' \t')${_nl}"
+    # shellcheck disable=SC2086  # deliberate split of the path list on IFS
+    set -- $ACQ_MSB_UPSTREAM_CA_CERT
+    IFS="$_oldifs"
+    for _p in "$@"; do
+      [ -n "$_p" ] || continue
+      if [ -r "$_p" ] && [ -s "$_p" ]; then
+        eval "$_arr+=(--tls-upstream-ca-cert \"\$_p\")"
+        _added=$((_added + 1))
+        acq_debug "msb upstream-CA: trusting explicit PEM ${_p}"
+      else
+        echo "acq(msb): warning: ACQ_MSB_UPSTREAM_CA_CERT path not readable, skipping: ${_p}" >&2
+      fi
+    done
+    [ "$_added" -gt 0 ] && return 0
+    # Fall through to auto-detect if every explicit path was unusable.
+  fi
+
+  # (2) Auto-detect the host trust store (macOS only). Exports every root CA on
+  # the default keychain search list to one PEM and trusts that on the upstream
+  # leg — capturing the corporate root exactly as the host trusts it, whether or
+  # not msb's own native-cert loader would have surfaced it. This covers the
+  # genuine-interception case only (see docs/KNOWN_FAILURE_MODES.md §30), not a
+  # broad-egress or split-horizon-DNS failure. Unprivileged (roots are readable
+  # without sudo, which would otherwise trigger a PIV-PIN loop on managed Macs).
+  [ -n "${ACQ_MSB_UPSTREAM_CA_AUTODETECT:-}" ] || return 0
+  [ "$(uname -s 2>/dev/null)" = "Darwin" ] || return 0
+  command -v security >/dev/null 2>&1 || return 0
+
+  local _out="$ACQ_MSB_UPSTREAM_CA_FILE" _dir
+  _dir=$(dirname -- "$_out")
+  if ! mkdir -p "$_dir" 2>/dev/null; then
+    echo "acq(msb): warning: cannot create upstream-CA dir ${_dir}; skipping auto-detect" >&2
+    return 0
+  fi
+
+  # `security find-certificate -a -p` emits every search-list cert as PEM. Write
+  # to a temp file first, then atomically move into place, and only keep it if it
+  # actually contains a certificate (an empty/garbled dump must not be trusted).
+  local _tmp
+  _tmp=$(mktemp "${_out}.XXXXXX" 2>/dev/null) || {
+    echo "acq(msb): warning: cannot create temp file for upstream-CA bundle; skipping auto-detect" >&2
+    return 0
+  }
+  if security find-certificate -a -p >"$_tmp" 2>/dev/null && grep -q 'BEGIN CERTIFICATE' "$_tmp"; then
+    chmod 0644 "$_tmp" 2>/dev/null || true
+    mv -f "$_tmp" "$_out" 2>/dev/null || { rm -f "$_tmp" 2>/dev/null; return 0; }
+    eval "$_arr+=(--tls-upstream-ca-cert \"\$_out\")"
+    acq_debug "msb upstream-CA: exported host search-list roots to ${_out} and trusting them upstream"
+  else
+    rm -f "$_tmp" 2>/dev/null
+    echo "acq(msb): note: could not export host CAs for the TLS-intercept upstream verifier;" >&2
+    echo "acq(msb):   msb will fall back to its own native-cert loading. If egress fails with" >&2
+    echo "acq(msb):   a TLS 'unexpected eof' behind a corporate proxy that terminates the" >&2
+    echo "acq(msb):   endpoint, set ACQ_MSB_UPSTREAM_CA_CERT to your proxy's root CA PEM." >&2
+    echo "acq(msb):   See docs/KNOWN_FAILURE_MODES.md §30." >&2
+  fi
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -2097,6 +2262,15 @@ acq_backend_provision() {
   # cannot use interception (secrets then won't substitute).
   if [ -z "${ACQ_MSB_NO_TLS_INTERCEPT:-}" ]; then
     create_flags+=(--tls-intercept)
+
+    # When interception is on and a corporate proxy genuinely terminates an
+    # endpoint, msb's host-side proxy must trust the corporate root on its
+    # UPSTREAM leg (defense-in-depth; see _acq_msb_upstream_ca_flags_into and
+    # docs/KNOWN_FAILURE_MODES.md §30). Emitted only alongside --tls-intercept:
+    # with interception off there is no upstream leg to verify.
+    local _upstream_ca=()
+    _acq_msb_upstream_ca_flags_into _upstream_ca
+    [ "${#_upstream_ca[@]}" -gt 0 ] && create_flags+=("${_upstream_ca[@]}")
   fi
 
   # Guest DNS: use a resolver reachable from the microVM. The host's resolvers
@@ -2444,6 +2618,76 @@ _acq_msb_safe_agent_token() {
 }
 
 # ---------------------------------------------------------------------------
+# _acq_msb_report_npm_install_failure NAME — diagnose a failed in-guest npm
+# install, distinguishing a genuinely-missing npm from an UNREACHABLE registry.
+# ---------------------------------------------------------------------------
+# A network-cut install (corporate TLS interception → curl (56) unexpected eof /
+# HTTP 000, or a resolver that can't see the registry → NXDOMAIN) otherwise reads
+# identically to "node/npm isn't installed", which sends users down the wrong
+# path (reinstalling node on the HOST, which never touches the guest). Probe the
+# actual cause in-guest and print the message that matches it.
+#
+# Branches:
+#   - npm binary absent in-guest      → genuinely-missing message.
+#   - npm present + registry probe:
+#       unresolved (curl exit 6)       → registry name did not resolve; DNS.
+#       unreachable (curl exit / 000)  → TLS/network cut; point at KFM §30.
+#       responded / inconclusive       → registry rejected it or a real npm error.
+# Reuses the shared _classify_key_status fingerprint so the npm path and the
+# USAi path classify curl results identically.
+_acq_msb_report_npm_install_failure() {
+  local name="$1"
+  echo "acq(msb): warning: 'npm install -g $ACQ_MSB_OPENCODE_PKG' failed in '$name'." >&2
+  echo "acq(msb):   opencode will not be available on attach." >&2
+
+  # Is npm actually present in the guest? If not, that is the cause outright.
+  if ! msb exec "$name" -u 0 -- sh -c 'command -v npm' >/dev/null 2>&1; then
+    echo "acq(msb):   Cause: npm is not present in the guest. Use a base image that" >&2
+    echo "acq(msb):   ships node/npm, or bake opencode into ACQ_MSB_IMAGE." >&2
+    return 0
+  fi
+
+  # npm exists — classify reachability of the registry from INSIDE the guest,
+  # using the same curl `<http_code>|<exit>` fingerprint as the USAi key probe.
+  # Probe the first configured registry host over HTTPS; any HTTP response (even
+  # a 404) proves the connection completed, i.e. NOT a network cut.
+  local _reg _first_host _raw _status
+  _first_host=""
+  for _reg in $ACQ_MSB_NPM_HOSTS; do _first_host="$_reg"; break; done
+  if [ -n "$_first_host" ] && command -v _classify_key_status >/dev/null 2>&1; then
+    _raw=$(msb exec "$name" -u 0 -- sh -c \
+      "curl -sS -o /dev/null -w '%{http_code}' https://${_first_host}/; printf '|%s' \"\$?\"" \
+      2>/dev/null || true)
+    _status=$(_classify_key_status "$_raw")
+    case "$_status" in
+      unresolved)
+        echo "acq(msb):   Cause: the npm registry host (${_first_host}) did not RESOLVE from" >&2
+        echo "acq(msb):   the guest. This is DNS, not a missing npm. Point the guest at a" >&2
+        echo "acq(msb):   usable resolver via ACQ_MSB_DNS_NAMESERVER, or set ACQ_MSB_NPM_HOSTS" >&2
+        echo "acq(msb):   to a mirror the guest can resolve. See docs/KNOWN_FAILURE_MODES.md §30." >&2
+        return 0
+        ;;
+      unreachable)
+        echo "acq(msb):   Cause: the npm registry host (${_first_host}) is NOT REACHABLE from" >&2
+        echo "acq(msb):   the guest — the connection was cut (TLS 'unexpected eof' / HTTP 000)," >&2
+        echo "acq(msb):   NOT a missing npm. This is a network / TLS-interception problem." >&2
+        echo "acq(msb):   See docs/KNOWN_FAILURE_MODES.md §30 for diagnosis." >&2
+        return 0
+        ;;
+    esac
+  fi
+
+  # npm present and the registry either responded (an HTTP error) or the probe
+  # was inconclusive: give neutral guidance without implying node is missing.
+  echo "acq(msb):   npm is present and the registry appears reachable, so the install" >&2
+  echo "acq(msb):   itself failed (registry rejected the request, disk, or a package" >&2
+  echo "acq(msb):   error). Re-run with ACQ_DEBUG=1 to see npm's output, set" >&2
+  echo "acq(msb):   ACQ_MSB_NPM_HOSTS for an internal mirror, or bake opencode into" >&2
+  echo "acq(msb):   ACQ_MSB_IMAGE." >&2
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # _acq_msb_install_agent NAME AGENT — install the agent binary into the guest
 # ---------------------------------------------------------------------------
 # sbx's agent templates ship the binary; msb runs a plain base, so acq installs
@@ -2501,11 +2745,7 @@ _acq_msb_install_agent() {
       # controlled tunable. `npm` is present (node prerequisite). npm needs the
       # registry host, allow-listed at create.
       if ! msb exec "$name" -u 0 -- npm install -g --no-fund --no-audit "$ACQ_MSB_OPENCODE_PKG" >/dev/null 2>&1; then
-        echo "acq(msb): warning: 'npm install -g $ACQ_MSB_OPENCODE_PKG' failed in '$name'." >&2
-        echo "acq(msb):   opencode will not be available on attach. Common causes: the npm" >&2
-        echo "acq(msb):   registry host (${ACQ_MSB_NPM_HOSTS}) is not reachable/allow-listed," >&2
-        echo "acq(msb):   or npm is missing. Set ACQ_MSB_NPM_HOSTS for an internal mirror," >&2
-        echo "acq(msb):   or bake opencode into ACQ_MSB_IMAGE." >&2
+        _acq_msb_report_npm_install_failure "$name"
         return 0
       fi
       ;;

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -3,7 +3,7 @@ title: "acq Backend Guide"
 description: "Per-backend strengths, tradeoffs, and configuration for acq"
 status: canonical
 tier: 2
-last_updated: "2026-08-04"
+last_updated: "2026-08-17"
 audience: "developers"
 keywords: ["acq", "backend", "sbx", "msb", "microsandbox", "tradeoffs"]
 related_files: ["docs/QUICKSTART.md", "docs/QUICKSTART_SBX.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md", "docs/adr/0014-neutral-port-publish-and-background-vocab.md", "docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md"]
@@ -706,6 +706,23 @@ A `WARN` line marks a known, tracked limitation — it is surfaced every run but
 does **not** count as a failure, so a clean run still exits 0. (The former msb
 private-repo playbook `WARN` is gone: the playbook kit now fetches via the REST
 API and is a hard-required `pass` on both backends, given a stored github token.)
+
+**msb: broad egress failure on an established setup.** If an msb sandbox that
+used to work starts failing *every* outbound call at once (USAi, GitHub, and npm
+all cut with `curl (56) unexpected eof` / HTTP `000`), the likeliest cause is
+corrupted local msb state, not a network or certificate change. Wipe msb's data
+and reinstall, then confirm host readiness:
+
+```bash
+curl -fsSL https://install.microsandbox.dev | sh   # reinstall (re-lays runtime state)
+msb doctor                                          # verify virtualization + prerequisites
+msb doctor --fix                                    # apply supported setup fixes
+```
+
+If a broad cut persists on a clean reinstall — or if only USAi fails (a
+split-horizon-DNS symptom) — see
+[`docs/KNOWN_FAILURE_MODES.md` §30](KNOWN_FAILURE_MODES.md) for the three-signature
+triage and the `scripts/diagnose-*` probes.
 
 ---
 

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1311,7 +1311,7 @@ which one you have before acting.
 | Signature (from inside the guest) | Cause | Fix |
 |---|---|---|
 | **Broad** `curl (56) unexpected eof` / HTTP `000` on **multiple** hosts at once (USAi *and* GitHub *and* npm) | Corrupted / stale **msb state** (not a clean-install behavior) | **Wipe msb data + reinstall, then `msb doctor`** (below) |
-| **USAi only** fails with `NXDOMAIN` / `curl rc=6` (or `rc=35` if a public address is pinned), while GitHub + npm work fine | **Split-horizon DNS** — the USAi host resolves to an internal, tunnel-only address the guest's public resolver can't see | Point the guest at a resolver that can reach the internal USAi zone (`ACQ_MSB_DNS_NAMESERVER`) |
+| **USAi only** fails with `NXDOMAIN` / `curl rc=6` (or `rc=35` if a public address is pinned), while GitHub + npm work fine | **Split-horizon DNS** — the USAi host resolves to an internal, tunnel-only address the guest's public resolver can't see | Try pointing the guest at a resolver that can reach the internal USAi zone (`ACQ_MSB_DNS_NAMESERVER`) — but the internal resolver may itself not be routable from the guest; verify guest→resolver reachability and coordinate with your network team if it isn't |
 | A **genuinely intercepted** endpoint fails its TLS handshake behind a corporate proxy that terminates it | The proxy's **root CA** isn't trusted on msb's upstream (proxy→server) leg | acq passes it via `--tls-upstream-ca-cert` (defense-in-depth; below) |
 
 Probe from inside the sandbox to read the signature — the curl exit code is the
@@ -1372,11 +1372,22 @@ fix this; a key rotation does not fix this.
 `acq` now reports this distinctly ("did not RESOLVE … likely a split-horizon
 name") rather than as a generic network cut or a bad key.
 
-**Fix:** give the guest a resolver that can reach the internal USAi zone:
+**Try this — but it is not a guaranteed fix:** point the guest at a resolver that
+can reach the internal USAi zone:
 
 ```bash
 export ACQ_MSB_DNS_NAMESERVER=<a-resolver-that-can-reach-the-internal-USAi-zone>
 ```
+
+**Important:** the internal resolver may not itself be routable from the guest.
+Measured on GFE, the internal resolver was not reachable from the guest, and even
+pinning USAi's public address still failed to connect (`rc=35`) — the endpoint
+appeared reachable only via the corporate tunnel. So setting
+`ACQ_MSB_DNS_NAMESERVER` is worth trying, but it is not a "set this and it works"
+fix. **Verify guest→resolver reachability first** (e.g. with
+`./scripts/diagnose-host-egress-diff`), and if the resolver (or USAi itself) is
+not routable from the guest, **coordinate with your network team** — the guest
+may need tunnel access it does not currently have.
 
 (See the `ACQ_MSB_DNS_NAMESERVER` notes in `docs/BACKEND_GUIDE.md` and the
 README's msb DNS section.)

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1286,13 +1286,13 @@ If `sbx exec` reports the sandbox is not running, start it first
 
 ---
 
-## 30. USAi/kit fetch fails with TLS `unexpected eof` / HTTP 000 (network, not the key)
+## 30. Sandbox can't reach USAi / GitHub / npm — three signatures, three fixes
 
 ### Symptoms
 
-Early in `acq run`, the kit fetch and the USAi key check both fail with a TLS
-connection error, and (before this was fixed) acq mis-reported it as an expired
-key and prompted to rotate:
+Early in `acq run`, an outbound request from inside the sandbox fails and (before
+this was disambiguated) acq could mis-report it as an expired key and prompt to
+rotate:
 
 ```
 agentic-coding-playbook: fetch of GSA-TTS/agentic-coding-playbook@… tarball failed
@@ -1301,29 +1301,22 @@ agentic-coding-playbook: fetch of GSA-TTS/agentic-coding-playbook@… tarball fa
 Your USAi API key looks invalid or expired (HTTP …000 from the models API).
 ```
 
-Rotating the key does not help: the freshly-pasted key fails validation the same
-way (`HTTP 000`).
+Rotating the key never helps here — the failure is in the network path, not the
+key. But "the sandbox can't reach the network" is not one problem: three distinct
+failures share overlapping symptoms and need **different** remedies. Identify
+which one you have before acting.
 
-### Root Cause
+### Triage — which signature is it?
 
-This is a **network reachability / TLS-interception problem, not a key problem.**
-`curl (56) unexpected eof` and an HTTP status of `000` mean the outbound TLS
-connection was cut before any HTTP response came back. That **two independent
-hosts** (`api.github.com` for the kit tarball and `api.gsa.usai.gov` for the key
-check) fail identically is the tell: the failure is in the network path out of
-the sandbox, not in USAi or your key.
+| Signature (from inside the guest) | Cause | Fix |
+|---|---|---|
+| **Broad** `curl (56) unexpected eof` / HTTP `000` on **multiple** hosts at once (USAi *and* GitHub *and* npm) | Corrupted / stale **msb state** (not a clean-install behavior) | **Wipe msb data + reinstall, then `msb doctor`** (below) |
+| **USAi only** fails with `NXDOMAIN` / `curl rc=6` (or `rc=35` if a public address is pinned), while GitHub + npm work fine | **Split-horizon DNS** — the USAi host resolves to an internal, tunnel-only address the guest's public resolver can't see | Point the guest at a resolver that can reach the internal USAi zone (`ACQ_MSB_DNS_NAMESERVER`) |
+| A **genuinely intercepted** endpoint fails its TLS handshake behind a corporate proxy that terminates it | The proxy's **root CA** isn't trusted on msb's upstream (proxy→server) leg | acq passes it via `--tls-upstream-ca-cert` (defense-in-depth; below) |
 
-The common trigger is a **corporate TLS-intercepting proxy (e.g. Zscaler)**: the
-sandbox's outbound HTTPS is intercepted, and if the intercepting proxy's root CA
-is not trusted for the sandbox's own outbound connection, the handshake is
-terminated and curl reports `unexpected eof`.
-
-### Diagnosis
-
-`acq` now detects this and reports it as a network problem instead of an expired
-key (it does not prompt to rotate). To confirm what is failing, probe the two
-hosts from inside the sandbox — a `curl (35)/(56)` or `000` here (rather than a
-`200`/`401`) confirms the connection is being cut, not rejected by USAi:
+Probe from inside the sandbox to read the signature — the curl exit code is the
+discriminator (`6` = didn't resolve; `35`/`56` or `000` = resolved but the
+connection was cut):
 
 ```bash
 # msb
@@ -1333,24 +1326,105 @@ msb exec <sandbox> -- curl -sS -o /dev/null -w '%{http_code}\n' -v https://api.g
 sbx exec <sandbox> -- curl -sS -o /dev/null -w '%{http_code}\n' -v https://api.gsa.usai.gov/api/v1/models
 ```
 
-A machine on the **same corporate network where these connections are NOT
-intercepted (or where the intercepting CA is trusted) succeeds**, which is why
-the same command can work on one host and fail on another. The remedy depends on
-your environment's proxy/CA configuration and is outside acq's control; resolve
-it with your network/endpoint administrators.
+For a deeper host-side characterization (interception vs egress path, DNS,
+host-vs-host comparison), run the bundled read-only probes:
+
+```bash
+./scripts/diagnose-tls-intercept        # classify interception / cert-trust / egress path
+./scripts/diagnose-host-egress-diff      # compare a failing host to a working one
+```
+
+### Signature 1 — broad `unexpected eof` on multiple hosts (stale msb state)
+
+Observed in the field on a Zscaler-enrolled macOS host: **every** outbound HTTPS
+call from the guest failed at once with `curl (56) unexpected eof`. It did **not**
+reproduce on a clean install — a machine with the same Zscaler configuration
+worked fine — and it was cleared by a **full msb data wipe + reinstall**. The
+matching upstream report ([superradcompany/microsandbox#1344](https://github.com/superradcompany/microsandbox/issues/1344))
+was **closed as non-reproducible**: something in the local msb state was corrupt,
+not a defect in a clean msb.
+
+**Fix:** wipe msb's data/state and reinstall, then confirm host readiness:
+
+```bash
+# Reinstall msb (removes and re-lays its runtime state)
+curl -fsSL https://install.microsandbox.dev | sh
+
+# Verify host virtualization + runtime prerequisites; --fix applies supported setup
+msb doctor
+msb doctor --fix
+```
+
+If a broad `unexpected eof` **recurs on a clean install**, that would be new
+evidence of an msb bug — capture the `diagnose-*` output and reopen
+[superradcompany/microsandbox#1344](https://github.com/superradcompany/microsandbox/issues/1344).
+
+### Signature 2 — USAi-only NXDOMAIN (split-horizon DNS)
+
+On a clean msb install on a GFE/Zscaler host, GitHub and npm resolve and return
+`200` from the guest, but `api.gsa.usai.gov` fails to **resolve** (`curl rc=6` /
+NXDOMAIN); pinning its public address instead fails to connect (`rc=35`). USAi is
+a **split-horizon** name — the host resolves it to an *internal* address reachable
+only over the corporate tunnel, and the guest's default public resolver
+(`ACQ_MSB_DNS_NAMESERVER=1.1.1.1`) cannot see that zone. A msb data wipe does not
+fix this; a key rotation does not fix this.
+
+`acq` now reports this distinctly ("did not RESOLVE … likely a split-horizon
+name") rather than as a generic network cut or a bad key.
+
+**Fix:** give the guest a resolver that can reach the internal USAi zone:
+
+```bash
+export ACQ_MSB_DNS_NAMESERVER=<a-resolver-that-can-reach-the-internal-USAi-zone>
+```
+
+(See the `ACQ_MSB_DNS_NAMESERVER` notes in `docs/BACKEND_GUIDE.md` and the
+README's msb DNS section.)
+
+### Signature 3 — genuine TLS interception (upstream CA trust, defense-in-depth)
+
+When a corporate proxy (Zscaler, Netskope, …) **genuinely terminates** an
+endpoint, acq's `--tls-intercept` (which msb needs to substitute injected secrets
+on the wire) makes msb's host-side proxy re-originate an *upstream* TLS connection
+to that proxy — which presents a corporate-signed leaf. That upstream leg must
+trust the **corporate root**. `--trust-host-cas` does not help (it only ships CAs
+into the guest, not into the proxy's upstream verifier), and msb's native-cert
+loader surfaces enterprise roots unevenly on macOS. When the root isn't surfaced,
+the upstream handshake fails *after* the guest-facing TLS completed and the guest
+sees `unexpected eof`.
+
+acq passes the host's root CAs to that upstream verifier via
+`--tls-upstream-ca-cert` whenever interception is on, so a genuinely-terminated
+endpoint verifies even when native-cert loading would miss the root. Controls:
+
+- `ACQ_MSB_UPSTREAM_CA_CERT=/path/to/root.pem` — trust an explicit PEM
+  (colon- or space-separated for several). Highest precedence; use it on
+  non-macOS hosts or when you already have the root on disk.
+- `ACQ_MSB_UPSTREAM_CA_AUTODETECT=0` — disable the macOS auto-export of the host
+  search-list roots (on by default).
+- `ACQ_MSB_NO_UPSTREAM_CA=1` — reproduction/testing only: withhold the upstream CA
+  even when available.
+
+This is **defense-in-depth for the interception case only** — it does not address
+Signature 1 (stale state) or Signature 2 (split-horizon DNS).
 
 ### Prevention / Status
 
-- `acq` classifies a connection failure (curl nonzero exit / HTTP 000) as
-  `unreachable` and reports a network diagnosis, never "invalid or expired," and
-  does not prompt to rotate a good key. It fails closed (aborts the run) rather
-  than attach a session that cannot reach USAi.
+- `acq` classifies an in-guest curl result and reports the matching diagnosis:
+  `unresolved` (DNS/split-horizon) vs `unreachable` (connection cut) vs a real
+  HTTP status — never "invalid or expired" for a network failure, and it does not
+  prompt to rotate a good key. It fails closed (aborts the run) rather than attach
+  a session that cannot reach USAi.
+- The in-guest `npm install` failure message is likewise disambiguated: it
+  distinguishes a genuinely-missing npm from an unreachable / unresolvable
+  registry, so a network cut is not misread as "node isn't installed."
 - The built-in kits are ordered so `zscaler-ca-certificate` is applied first, so
-  CA trust is established before the other kits make network requests (this
-  matters on the sbx backend, whose kits apply sequentially).
-- Making the sandbox's outbound TLS traverse a corporate proxy is a
-  host/network-configuration matter (trusting the corporate root CA, proxy
-  settings), not something acq can set for you.
+  guest-side CA trust is established before the other kits make network requests
+  (this matters on the sbx backend, whose kits apply sequentially).
+- Making the sandbox's outbound TLS traverse a corporate proxy, and giving the
+  guest a resolver that can see internal zones, are host/network-configuration
+  matters — resolve them with your network/endpoint administrators where acq's
+  tunables don't cover your environment.
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -3,7 +3,7 @@ title: "acq Backend Quickstart"
 description: "Get running with acq, the pluggable-backend wrapper for agentic-coding-quickstart"
 status: canonical
 tier: 2
-last_updated: "2026-08-06"
+last_updated: "2026-08-17"
 audience: "developers"
 keywords: ["acq", "backend", "sbx", "msb", "quickstart", "sandbox"]
 related_files: ["docs/BACKEND_GUIDE.md", "docs/QUICKSTART_SBX.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
@@ -51,6 +51,12 @@ Complete the standard setup in [README.md](../README.md#5-minute-quickstart):
 - Install the `msb` CLI: `curl -fsSL https://install.microsandbox.dev | sh`
 - Run `msb doctor` (add `--fix` to set up KVM/HVF/WHP virtualization)
 - Set your network policy
+
+Re-run `msb doctor` once more after setup — a clean `doctor` pass is the quickest
+way to confirm the host is ready before your first `acq run` (and, if an
+established setup later starts failing every outbound call at once, a wipe +
+reinstall then `msb doctor` is the first thing to try; see
+[Troubleshooting](BACKEND_GUIDE.md#troubleshooting)).
 
 You do **not** need to gather a USAi key or GitHub token in advance — `acq`
 prompts you for the USAi key on first run and offers to scope a GitHub token

--- a/scripts/diagnose-host-egress-diff
+++ b/scripts/diagnose-host-egress-diff
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+#
+# diagnose-host-egress-diff - HOST-SIDE comparison probe for a broad msb microVM
+# egress failure.
+#
+# WHY THIS EXISTS
+#   One shape of msb network failure is a broad cut: `curl: (56) ... unexpected
+#   eof` from inside every msb guest, while the host process (and often a
+#   same-host podman-machine VM) reach the same endpoints. In the field this has
+#   turned out to be corrupted/stale msb state on the affected host - it did not
+#   reproduce on a clean install, and a full msb data wipe + reinstall cleared it
+#   (see docs/KNOWN_FAILURE_MODES.md section 30, Signature 1). When a reinstall
+#   does NOT clear it and the guest's egress still differs from a working host's,
+#   the open question is:
+#
+#       what is DIFFERENT about the failing host's network/VM plumbing?
+#
+#   This probe captures a paste-friendly snapshot of the host's routing,
+#   interfaces/MTU, DNS, system network-extensions/content-filters, and (if a
+#   sandbox is up) the libkrun/vmnet NIC - so a FAILING host and a WORKING host
+#   can be diffed side by side. It is NOT the cert/TLS probe: for the interception
+#   / split-horizon-DNS / IPv6-first discriminators use
+#   scripts/diagnose-tls-intercept. This one assumes a broad cut that survived a
+#   reinstall and hunts the host-to-host delta.
+#
+# SAFETY
+#   * The default run is FULLY UNPRIVILEGED and read-only - routes, interfaces,
+#     DNS config, extension inventory, version strings. No `sudo`, no prompts.
+#     Anyone (including users without sudo) can run and paste it.
+#   * An OPT-IN privileged block (pfctl ruleset + a short header-only tcpdump
+#     during a live guest curl) runs ONLY if you pass ACQ_DIFF_SUDO=1. It calls
+#     `sudo` AT MOST ONCE (a single `sudo -v` up front, then reuses the cached
+#     credential) to minimize PIV/admin prompts. Omit it (the default) and the
+#     probe never touches sudo - so a user without admin can still contribute
+#     the unprivileged snapshot.
+#   * Output is config METADATA and packet HEADERS only (tcpdump runs with no
+#     payload capture: interface, addresses, ports, TCP flags). No secrets, no
+#     packet bodies, no environment dump. Review before sharing.
+#
+# PLATFORM: macOS (the failing/working hosts are all macOS). On other OSes it
+#   prints what it can and skips the macOS-specific tools.
+#
+# USAGE
+#   ./scripts/diagnose-host-egress-diff [HOST ...]
+#       HOST ...  Extra hostnames to probe routing for (added to the built-in
+#                 USAi + GitHub + npm set). Override the set with
+#                 ACQ_DIFF_HOSTS="h1 h2 ...".
+#
+#   ACQ_DIFF_SUDO=1   Opt in to the single privileged block (pfctl + tcpdump).
+#                     Prompts for sudo ONCE. Leave unset to stay unprivileged.
+#   ACQ_DIFF_SANDBOX=<name>   msb sandbox name to use for the live-capture curl
+#                     in the privileged block (default: the first running msb
+#                     sandbox, else the acq default 'opencode-*' name is tried).
+#   ACQ_DIFF_CAPTURE_HOST=<host>  endpoint the guest curls during the tcpdump
+#                     (default: api.github.com).
+#
+# Run this on BOTH a failing and a working host and diff the two outputs.
+set -u
+
+# ---------------------------------------------------------------------------
+# Hosts to characterize routing for. Default = what acq depends on.
+# ---------------------------------------------------------------------------
+DEFAULT_HOSTS="api.gsa.usai.gov api.github.com registry.npmjs.org"
+if [ -n "${ACQ_DIFF_HOSTS:-}" ]; then
+  # shellcheck disable=SC2206  # intentional word-split of a space-separated list
+  HOSTS=(${ACQ_DIFF_HOSTS})
+else
+  # shellcheck disable=SC2206
+  HOSTS=(${DEFAULT_HOSTS} "$@")
+fi
+
+CAPTURE_HOST="${ACQ_DIFF_CAPTURE_HOST:-api.github.com}"
+
+is_macos() { [ "$(uname -s 2>/dev/null)" = "Darwin" ]; }
+have() { command -v "$1" >/dev/null 2>&1; }
+hr() { printf '\n===== %s =====\n' "$1"; }
+sub() { printf '\n--- %s ---\n' "$1"; }
+indent() { sed 's/^/  /'; }
+
+# ---------------------------------------------------------------------------
+hr "host / OS / tooling"
+# ---------------------------------------------------------------------------
+if is_macos; then sw_vers 2>/dev/null || true; fi
+uname -a 2>/dev/null || true
+echo "msb:      $(command -v msb || echo 'not on PATH')"
+have msb && { msb --version 2>/dev/null || true; }
+echo "podman:   $(command -v podman || echo 'not on PATH')"
+have podman && { podman --version 2>/dev/null || true; }
+echo "curl:     $(command -v curl || echo 'not on PATH')"
+
+# ---------------------------------------------------------------------------
+hr "1. Default routes (split-tunnel tell: which iface is the default gateway?)"
+# ---------------------------------------------------------------------------
+echo "  A Zscaler/ZTNA force-tunnel installs a utun* default route. If the"
+echo "  FAILING host routes its default via utun but a WORKING host does not"
+echo "  (or vice-versa), that difference is the prime suspect for why the"
+echo "  microVM's non-tunneled egress is treated differently."
+if have netstat; then
+  sub "netstat -rn (IPv4 + IPv6 default entries)"
+  netstat -rn 2>/dev/null | grep -iE '^(default|Destination|Internet|::)' | indent
+elif have ip; then
+  sub "ip route (default) / ip -6 route (default)"
+  { ip route show default 2>/dev/null; ip -6 route show default 2>/dev/null; } | indent \
+    || echo "  (no default route reported)"
+else
+  echo "  (neither netstat nor ip available; skipped)"
+fi
+if is_macos && have route; then
+  sub "route -n get default (IPv4)"
+  route -n get default 2>/dev/null | grep -iE 'gateway|interface' | indent || echo "  (none)"
+  sub "route -n get -inet6 default (IPv6)"
+  route -n get -inet6 default 2>/dev/null | grep -iE 'gateway|interface' | indent || echo "  (no IPv6 default)"
+fi
+
+# ---------------------------------------------------------------------------
+hr "2. Per-host route (does each endpoint egress via utun/tunnel or physical?)"
+# ---------------------------------------------------------------------------
+echo "  If the endpoints route out a DIFFERENT interface on the failing host,"
+echo "  that pins the split-tunnel difference to specific destinations."
+if is_macos && have route; then
+  for h in "${HOSTS[@]}"; do
+    [ -n "$h" ] || continue
+    line=$(route -n get "$h" 2>/dev/null | grep -iE 'interface:' | head -1 | awk '{print $2}')
+    printf '  %-24s -> iface %s\n' "$h" "${line:-<unresolved>}"
+  done
+else
+  echo "  (route lookup is macOS-specific; skipped)"
+fi
+
+# ---------------------------------------------------------------------------
+hr "3. Interfaces + MTU (utun*, vmnet*, bridge*, en*)"
+# ---------------------------------------------------------------------------
+echo "  An MTU mismatch on the VM NIC / tunnel is a classic cause of a TLS"
+echo "  handshake that connects then dies mid-read ('unexpected eof'). Compare"
+echo "  the utun/vmnet MTUs between hosts."
+if is_macos && have ifconfig; then
+  for pfx in utun vmnet bridge en feth; do
+    for i in $(ifconfig -l 2>/dev/null | tr ' ' '\n' | grep -E "^${pfx}[0-9]" 2>/dev/null); do
+      mtu=$(ifconfig "$i" 2>/dev/null | grep -oE 'mtu [0-9]+' | awk '{print $2}')
+      inet=$(ifconfig "$i" 2>/dev/null | grep -E 'inet ' | awk '{print $2}' | tr '\n' ',' | sed 's/,$//')
+      stat=$(ifconfig "$i" 2>/dev/null | grep -oE 'status: [a-z]+' | awk '{print $2}')
+      printf '  %-9s mtu=%-5s status=%-8s inet=%s\n' "$i" "${mtu:-?}" "${stat:-?}" "${inet:-none}"
+    done
+  done
+else
+  echo "  (macOS ifconfig-specific; skipped)"
+fi
+
+# ---------------------------------------------------------------------------
+hr "4. DNS configuration (resolver order / scoped resolvers)"
+# ---------------------------------------------------------------------------
+if is_macos && have scutil; then
+  scutil --dns 2>/dev/null \
+    | grep -iE 'nameserver|domain|if_index|flags|reach' \
+    | head -40 | indent || echo "  (scutil --dns returned nothing)"
+else
+  echo "  (macOS scutil-specific; skipped)"
+fi
+
+# ---------------------------------------------------------------------------
+hr "5. System network extensions / content filters (Zscaler installs one)"
+# ---------------------------------------------------------------------------
+echo "  A version or activation-state difference in the Zscaler network"
+echo "  extension / socket filter between hosts is a strong candidate."
+if is_macos && have systemextensionsctl; then
+  sub "systemextensionsctl list"
+  systemextensionsctl list 2>/dev/null \
+    | grep -iE 'zscaler|netskope|palo|crowdstrike|filter|proxy|\[activated|enabled\]|teamID' \
+    | indent || echo "  (no matching system extensions listed)"
+fi
+if is_macos; then
+  sub "Zscaler app + version (if installed)"
+  if [ -d "/Applications/Zscaler/Zscaler.app" ]; then
+    /usr/bin/defaults read /Applications/Zscaler/Zscaler.app/Contents/Info.plist CFBundleShortVersionString 2>/dev/null \
+      | sed 's/^/  Zscaler.app version: /' || echo "  (version unreadable)"
+  else
+    echo "  (/Applications/Zscaler/Zscaler.app not present)"
+  fi
+  sub "loaded network kexts/daemons matching zscaler/netskope"
+  # pgrep is unprivileged.
+  pgrep -fl -i 'zscaler|netskope|ZSATunnel|ZSAService' 2>/dev/null | indent \
+    || echo "  (no matching processes)"
+fi
+
+# ---------------------------------------------------------------------------
+hr "6. libkrun / vmnet NIC (present only while a sandbox is running)"
+# ---------------------------------------------------------------------------
+echo "  If an msb sandbox is up, this shows the NIC msb created (subnet, MTU)."
+echo "  Compare its MTU/subnet to the working host's."
+if is_macos && have ifconfig; then
+  # vmnet-backed interfaces on macOS commonly appear as bridge*/vmenet*/feth*.
+  found_vm=0
+  for i in $(ifconfig -l 2>/dev/null | tr ' ' '\n' | grep -E '^(vmenet|bridge|feth)[0-9]' 2>/dev/null); do
+    found_vm=1
+    sub "ifconfig $i"
+    ifconfig "$i" 2>/dev/null | grep -iE 'flags|inet |member|mtu' | indent
+  done
+  [ "$found_vm" -eq 0 ] && echo "  (no vmenet/bridge/feth interfaces up right now - start a sandbox to capture)"
+fi
+if have msb; then
+  sub "running msb sandboxes"
+  msb list 2>/dev/null | indent || echo "  (msb list returned nothing)"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. OPT-IN PRIVILEGED BLOCK - pfctl ruleset + short header-only tcpdump during
+#    a live guest curl. Single sudo, only if ACQ_DIFF_SUDO=1.
+# ---------------------------------------------------------------------------
+hr "7. OPTIONAL privileged capture (pf rules + guest-egress packet path)"
+if [ "${ACQ_DIFF_SUDO:-0}" != "1" ]; then
+  echo "  SKIPPED (unprivileged mode). This block needs one sudo, so it is OFF by"
+  echo "  default - users without admin can still paste everything above."
+  echo
+  echo "  To include it (captures pf rules + whether the guest's SYN leaves the"
+  echo "  host and what comes back - the decisive packet-path evidence),"
+  echo "  re-run with:"
+  echo
+  echo "    ACQ_DIFF_SUDO=1 ./scripts/diagnose-host-egress-diff"
+  echo
+  echo "  It calls sudo AT MOST ONCE and captures packet HEADERS only (no"
+  echo "  payloads, no secrets)."
+elif ! is_macos; then
+  echo "  (privileged capture is macOS-specific; skipped)"
+elif ! have sudo; then
+  echo "  ACQ_DIFF_SUDO=1 was set but 'sudo' is not available; skipping."
+else
+  echo "  ACQ_DIFF_SUDO=1: acquiring sudo ONCE (cached for this block only)..."
+  if ! sudo -v 2>/dev/null; then
+    echo "  sudo authentication was declined/failed; skipping the privileged block."
+    echo "  (Everything above is still valid unprivileged output.)"
+  else
+    sub "pfctl -s info (packet-filter state)"
+    sudo -n pfctl -s info 2>/dev/null | grep -iE 'status|Debug' | indent \
+      || echo "  (pfctl -s info returned nothing)"
+
+    sub "pfctl -s rules (NAT/filter rules; Zscaler/ZTNA rules that reset VM egress show here)"
+    # Rules only - no state table (which could list active connection tuples).
+    sudo -n pfctl -s rules 2>/dev/null | indent \
+      || echo "  (no readable pf rules, or pf disabled)"
+    sudo -n pfctl -s nat 2>/dev/null | indent || true
+
+    # Determine the sandbox to curl from.
+    sandbox="${ACQ_DIFF_SANDBOX:-}"
+    if [ -z "$sandbox" ] && have msb; then
+      sandbox=$(msb list 2>/dev/null | awk 'NR>1 {print $1; exit}')
+    fi
+
+    sub "live guest-egress packet path (header-only tcpdump during a guest curl)"
+    if [ -z "$sandbox" ] || ! have msb; then
+      echo "  (no running msb sandbox found and none given via ACQ_DIFF_SANDBOX;"
+      echo "   start one - e.g. 'acq run opencode .' - and re-run to capture this.)"
+    else
+      echo "  sandbox: $sandbox   endpoint: https://${CAPTURE_HOST}/"
+      echo "  Capturing TCP SYN/RST/FIN headers on all interfaces for ~8s while the"
+      echo "  guest curls the endpoint. This shows whether the guest's SYN leaves"
+      echo "  the host, and whether it is RST/unanswered - the VM-egress"
+      echo "  discriminator. (No payload is captured: -s on headers, flags only.)"
+      cap=$(mktemp -t acqdiff.XXXXXX) || cap=/tmp/acqdiff.$$
+      # tcpdump on 'any', restricted to TCP control packets to the target port,
+      # header snaplen, printing the interface (-e) so we can see which NIC each
+      # packet crosses. No -w (no pcap file) and a tiny snaplen -> headers only,
+      # no payload. Pipe root tcpdump's stdout through `sudo tee` rather than a
+      # plain redirect (the redirect would run as the unprivileged shell; see
+      # ShellCheck SC2024).
+      sudo -n tcpdump -l -n -e -i any -c 200 -s 96 \
+        "tcp and port 443 and (tcp[tcpflags] & (tcp-syn|tcp-rst|tcp-fin) != 0)" \
+        2>/dev/null | sudo -n tee "$cap" >/dev/null &
+      tdpid=$!
+      sleep 1
+      # Fire the guest curl (best-effort; the point is the packets, not the body).
+      msb exec "$sandbox" -- curl -sS -o /dev/null --max-time 8 \
+        -w 'guest curl -> %{http_code} exit=%{exitcode}\n' \
+        "https://${CAPTURE_HOST}/" 2>&1 | indent || true
+      sleep 6
+      # Stop the capture. tcpdump runs as root, so kill it via sudo (by pid and,
+      # as a belt-and-suspenders for the piped-through-tee case, by name). The
+      # local pipeline head is reaped by `wait`.
+      sudo -n pkill -f 'tcpdump .* port 443' 2>/dev/null || true
+      kill "$tdpid" 2>/dev/null || true
+      wait "$tdpid" 2>/dev/null || true
+      sub "captured TCP control packets (SYN/RST/FIN) to :443"
+      if [ -s "$cap" ]; then
+        indent <"$cap"
+        echo
+        echo "  READ: a guest SYN that appears on the vmnet/bridge iface but NEVER"
+        echo "  on utun/en (the real egress), or that is met by an immediate RST,"
+        echo "  localizes where the microVM's egress dies. Compare to a working host"
+        echo "  (its SYN should traverse to the physical/tunnel iface and get a"
+        echo "  SYN-ACK back)."
+      else
+        echo "  (no matching control packets captured - the guest curl may have"
+        echo "   failed before emitting a SYN, or tcpdump could not attach)"
+      fi
+      rm -f "$cap" 2>/dev/null || true
+    fi
+  fi
+fi
+
+hr "DONE - config metadata + packet headers only, no secrets. Diff a failing vs working host."

--- a/scripts/diagnose-tls-intercept
+++ b/scripts/diagnose-tls-intercept
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+#
+# diagnose-tls-intercept - HOST-SIDE, READ-ONLY diagnostic for an msb sandbox
+# that cannot reach USAi / GitHub / npm.
+#
+# WHY THIS EXISTS
+#   "The sandbox can't reach the network" is not one problem. This probe helps
+#   sort a failure into one of the three signatures documented in
+#   docs/KNOWN_FAILURE_MODES.md section 30, because each has a different fix:
+#
+#   SIGNATURE 1 - broad connection cut (curl (56) unexpected eof / HTTP 000) on
+#     MULTIPLE hosts at once. In the field this has been corrupted/stale msb
+#     state: it did not reproduce on a clean install, and a full msb data wipe +
+#     reinstall (then `msb doctor`) cleared it. Steps 4-7 help confirm the "broad
+#     cut" shape; the fix is a reinstall, not a certificate change.
+#
+#   SIGNATURE 2 - USAi ONLY fails to RESOLVE (curl exit 6 / NXDOMAIN) while
+#     GitHub and npm work. USAi is a split-horizon name whose real address lives
+#     in an internal, tunnel-only zone the guest's public resolver cannot see.
+#     Step 4 reads this directly (an "exit=6" for USAi but 200/301 for the
+#     others). The fix is a resolver that can reach the internal zone
+#     (ACQ_MSB_DNS_NAMESERVER), not a reinstall and not a cert change.
+#
+#   SIGNATURE 3 - a genuinely TLS-intercepted endpoint (a corporate proxy
+#     terminates the domain and presents its own leaf). msb's `--tls-intercept`
+#     (which acq enables to substitute secrets on the wire) runs a HOST-SIDE MITM
+#     proxy whose UPSTREAM leg verifies the real server against the HOST trust
+#     store - NOT the guest bundle, and NOT `--trust-host-cas`. If step 5 shows
+#     the corporate proxy as the served-leaf issuer AND the host's native-cert
+#     enumeration does not surface that root, the upstream handshake fails after
+#     the guest-facing TLS completed -> `unexpected eof`. Fix: pass the root
+#     explicitly via `--tls-upstream-ca-cert` (acq does this by default; override
+#     with ACQ_MSB_UPSTREAM_CA_CERT). Steps 1-5 characterize this case.
+#
+#   Step 6 is the DECISIVE discriminator between Signature 3 (cert trust) and a
+#   below-TLS egress cut (Signature 1 shape): if egress still fails with msb
+#   interception fully DISABLED, no certificate change can help. Step 7 then
+#   LOCALIZES a broad cut - it compares msb's VM egress against another VM
+#   runtime (podman machine) on the same host: if podman's VM reaches an endpoint
+#   msb cannot, msb's libkrun/vmnet path is being singled out (evidence for an
+#   msb-specific bug worth an upstream report) versus a blanket network block of
+#   all non-tunneled VM egress. Step 8 checks a cheap IPv6-first variant of that
+#   msb bug (a guest with no usable IPv6 egress that never falls back to IPv4);
+#   steps 6 and 7 probe each host both default (dual-stack) and IPv4-forced
+#   (curl -4) so step 8 can read whether forcing IPv4 fixes it.
+#
+# SAFETY: read-only. Prints cert identity METADATA only (labels, subject/issuer
+#   CN, SHA-1 fingerprints) and HTTP status codes. No private keys, no secrets,
+#   no environment dump. Review before running/sharing the output.
+#
+# PLATFORM: macOS (uses the `security` keychain tool). On other OSes it prints
+#   what it can (reachability + interception check) and skips the keychain steps.
+#
+# USAGE:
+#   ./scripts/diagnose-tls-intercept [HOST ...]
+#     HOST ...  Optional extra hostnames to test for reachability + interception
+#               (in addition to the built-in USAi + GitHub set). Override the
+#               whole set with ACQ_DIAGNOSE_HOSTS="h1 h2 ...".
+#     ACQ_DIAGNOSE_CA_NAMES="Zscaler Netskope ..."  Override the CA-name scan list.
+#     ACQ_DIAGNOSE_RUN_STEP6=1  Opt in to an AUTOMATED step-6 reproduction: create
+#               a throwaway `ACQ_MSB_NO_TLS_INTERCEPT=1` sandbox, curl the key
+#               hosts from INSIDE the guest, then remove it. Off by default (the
+#               printed manual command is the primary, always-safe path).
+#
+#   Fully UNPRIVILEGED - it never calls `sudo`. On GSA-managed Macs `sudo`
+#   triggers a PIV/SSH askpass that loops on the smart-card PIN, and it is
+#   unnecessary here: root CAs are readable over the default keychain search
+#   list (only private keys need privilege, which this probe never touches).
+set -u
+
+# Hosts to test. Default = the endpoints acq actually depends on. Callers can
+# add more as positional args, or replace the whole set via ACQ_DIAGNOSE_HOSTS.
+DEFAULT_HOSTS="api.gsa.usai.gov api.github.com codeload.github.com github.com"
+if [ -n "${ACQ_DIAGNOSE_HOSTS:-}" ]; then
+  # shellcheck disable=SC2206  # intentional word-split of a space-separated list
+  HOSTS=(${ACQ_DIAGNOSE_HOSTS})
+else
+  # shellcheck disable=SC2206
+  HOSTS=(${DEFAULT_HOSTS} "$@")
+fi
+
+# CA display names to scan for in the keychains / trust-settings domains.
+# Broadened beyond Zscaler so this stays useful for other intercepting proxies.
+DEFAULT_CA_NAMES="Zscaler Netskope Palo Cloudflare Forcepoint Corporate GSA Federal Root CA"
+# shellcheck disable=SC2206
+CA_NAMES=(${ACQ_DIAGNOSE_CA_NAMES:-$DEFAULT_CA_NAMES})
+
+is_macos() { [ "$(uname -s 2>/dev/null)" = "Darwin" ]; }
+have() { command -v "$1" >/dev/null 2>&1; }
+hr() { printf '\n===== %s =====\n' "$1"; }
+
+hr "host / OS"
+if is_macos; then sw_vers 2>/dev/null || true; fi
+uname -a 2>/dev/null || true
+echo "msb:      $(command -v msb || echo 'not on PATH')"
+have msb && { msb --version 2>/dev/null || true; }
+echo "openssl:  $(command -v openssl || echo 'not on PATH')"
+echo "curl:     $(command -v curl || echo 'not on PATH')"
+
+# All keychain queries run UNPRIVILEGED. We deliberately do NOT `sudo` here:
+# on GSA-managed Macs `sudo` invokes a PIV/SSH askpass and loops on the smart-
+# card PIN, and it buys nothing - `security find-certificate` over the default
+# search list already enumerates the System keychain (roots are world-readable;
+# it is private KEYS that need privilege, and this probe never touches those).
+if is_macos && have security; then
+  hr "1. Corporate/intercepting-proxy roots by name (all search-list keychains)"
+  echo "  (the default search list already includes the System keychain; roots"
+  echo "   are readable without sudo - only private keys would need privilege)"
+  found_any=0
+  for n in "${CA_NAMES[@]}"; do
+    out=$(security find-certificate -a -c "$n" -Z 2>/dev/null | grep -E 'SHA-1|"labl"')
+    [ -n "$out" ] && { found_any=1; printf '%s\n' "$out" | sed "s/^/  [$n] /"; }
+  done
+  [ "$found_any" -eq 0 ] && echo "  (nothing matched those names in the search-list keychains)"
+
+  hr "2. User (login) trust-settings domain"
+  security dump-trust-settings 2>/dev/null \
+    | grep -iE 'zscaler|netskope|palo|cloudflare|forcepoint|root|corp|gsa|federal' \
+    || echo "  (no user-domain trust-settings entries matched those names)"
+  echo "  (admin/System trust-settings would need sudo - deliberately skipped to"
+  echo "   avoid the PIV-PIN prompt; step 1 + step 3 already establish presence)"
+
+  hr "3. Cert COUNT visible to a native-certs-style enumeration"
+  echo "  This is the closest unprivileged proxy for what rustls_native_certs"
+  echo "  load_native_certs() sees - it reads the same search-list keychains."
+  security find-certificate -a -p 2>/dev/null | grep -c 'BEGIN CERTIFICATE' \
+    | sed 's/^/  search-list roots+intermediates (incl. System): /'
+else
+  hr "keychain steps skipped"
+  echo "  Not macOS (or 'security' unavailable): the load_native_certs() source"
+  echo "  differs per OS. Reachability + interception checks below still apply."
+fi
+
+hr "4. HOST reachability (does the host itself trust the intercepted chain?)"
+if have curl; then
+  for h in "${HOSTS[@]}"; do
+    url="https://${h}/"
+    code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "$url" 2>/dev/null; printf '|exit=%s' "$?")
+    echo "  $url -> ${code}"
+  done
+  echo
+  echo "  Interpretation: 'exit=6' means the NAME did not resolve (NXDOMAIN). If"
+  echo "  ONLY api.gsa.usai.gov shows exit=6 while GitHub/npm return 200/301, that"
+  echo "  is SIGNATURE 2 (split-horizon DNS): USAi resolves to an internal,"
+  echo "  tunnel-only zone the guest's public resolver cannot see. Fix with a"
+  echo "  resolver that can reach it (ACQ_MSB_DNS_NAMESERVER) - not a reinstall or"
+  echo "  a cert change. exit=35/56 (or code 000) instead means the name resolved"
+  echo "  but the connection was cut - continue to steps 5-8."
+else
+  echo "  (curl not available; skipped)"
+fi
+
+hr "5. Is egress actually being TLS-intercepted right now? (issuer of served leaf)"
+if have openssl; then
+  for h in "${HOSTS[@]}"; do
+    echo "  --- $h ---"
+    echo | openssl s_client -connect "${h}:443" -servername "$h" 2>/dev/null \
+      | openssl x509 -noout -issuer -subject 2>/dev/null | sed 's/^/    /' \
+      || echo "    (openssl probe failed)"
+  done
+  echo
+  echo "  Interpretation: if 'issuer' names the corporate proxy (e.g. Zscaler),"
+  echo "  egress IS being intercepted at the HOST level - this points at SIGNATURE 3"
+  echo "  (msb's upstream verifier must trust that root; acq passes host roots via"
+  echo "  --tls-upstream-ca-cert by default, override with ACQ_MSB_UPSTREAM_CA_CERT)."
+  echo "  If instead 'issuer' names the REAL public CA (Amazon/Sectigo/etc.) AND"
+  echo "  step 4 reached every host, then the host's own egress is fine and NOT"
+  echo "  intercepted for these domains - so a sandbox that still fails is a"
+  echo "  below-TLS egress cut (the SIGNATURE 1 shape). Step 6 decides it."
+else
+  echo "  (openssl not available; skipped)"
+fi
+
+hr "6. DECISIVE: does egress fail even with msb interception DISABLED?"
+echo "  This is the discriminator between SIGNATURE 3 (cert trust) and a below-TLS"
+echo "  egress cut. With ACQ_MSB_NO_TLS_INTERCEPT=1 msb adds no --tls-intercept and"
+echo "  no --tls-upstream-ca-cert: its proxy is entirely out of the path and the"
+echo "  guest's TLS goes straight out. If egress STILL fails identically, the"
+echo "  failure is below msb's TLS layer and no certificate change can help - most"
+echo "  often corrupted/stale msb state (SIGNATURE 1: wipe msb data + reinstall,"
+echo "  then 'msb doctor')."
+echo
+# Locate the acq wrapper next to this script so the printed commands are copy-paste
+# ready regardless of the caller's CWD.
+acq_bin=""
+if [ -x "${ACQ_SCRIPT_DIR:-}/acq" ]; then
+  acq_bin="${ACQ_SCRIPT_DIR}/acq"
+elif [ -x "$(dirname "$0")/../acq" ]; then
+  acq_bin="$(cd "$(dirname "$0")/.." && pwd)/acq"
+fi
+[ -n "$acq_bin" ] && acq_show="$acq_bin" || acq_show="./acq"
+
+if [ "${ACQ_DIAGNOSE_RUN_STEP6:-0}" = "1" ] && have msb && [ -n "$acq_bin" ]; then
+  # Opt-in automated reproduction. Off by default: it creates and removes a
+  # throwaway sandbox and, on a first run, msb secret binding / key prompts can
+  # interfere. The manual command below is the primary, always-safe path.
+  probe_name="acq-diagnose-noicept-$$"
+  echo "  ACQ_DIAGNOSE_RUN_STEP6=1: running an interception-DISABLED in-guest probe"
+  echo "  in a throwaway sandbox (name: ${probe_name}). It does NOT touch your"
+  echo "  normal 'opencode-*' sandbox."
+  echo
+  # For each host, probe default (dual-stack) AND IPv4-forced. If default fails
+  # but -4 succeeds, the guest is going out IPv6-first and stalling - the guest
+  # gets a v6 address / AAAA answers on a host with no usable v6 egress, the
+  # gateway answers the v6 SYN locally, so Happy Eyeballs never falls back to v4.
+  # See step 8.
+  probe_cmd='for h in api.gsa.usai.gov api.github.com registry.npmjs.org; do printf "  in-guest https://%s/ default -> " "$h"; curl -sS -o /dev/null -w "%{http_code}|exit=%{exitcode}\n" --max-time 15 "https://$h/" 2>&1 || echo "exit=$?"; printf "  in-guest https://%s/ -4      -> " "$h"; curl -4 -sS -o /dev/null -w "%{http_code}|exit=%{exitcode}\n" --max-time 15 "https://$h/" 2>&1 || echo "exit=$?"; done'
+  if ACQ_MSB_NO_TLS_INTERCEPT=1 "$acq_bin" create --name "$probe_name" opencode . >/dev/null 2>&1; then
+    # NOTE the `--` before the command: `acq exec` forwards to `msb exec [OPTS]
+    # <NAME> -- <CMD…>`, which REQUIRES the `--` separator. Without it msb rejects
+    # the first word of the command ("error: unexpected argument 'sh' found").
+    ACQ_MSB_NO_TLS_INTERCEPT=1 "$acq_bin" exec "$probe_name" -- sh -c "$probe_cmd" 2>&1 \
+      | sed 's/^/  /' || echo "  (in-guest probe could not run)"
+    "$acq_bin" rm "$probe_name" >/dev/null 2>&1 || \
+      echo "  (note: could not auto-remove ${probe_name}; remove with: ${acq_show} rm ${probe_name})"
+  else
+    echo "  Could not create the throwaway sandbox automatically (a key/secret"
+    echo "  prompt may be required on a first run). Use the manual command below."
+  fi
+  echo
+else
+  echo "  Run this reproduction from the repo root and paste the last ~15 lines of"
+  echo "  its output here (set ACQ_DIAGNOSE_RUN_STEP6=1 to have this script attempt"
+  echo "  it automatically in a throwaway sandbox instead):"
+  echo
+  echo "    ACQ_MSB_NO_TLS_INTERCEPT=1 ${acq_show} run opencode ."
+  echo
+fi
+echo "  READ THE RESULT: if that startup (or the in-guest curls) still FAIL with"
+echo "  'curl: (56) ... unexpected eof' / an npm registry.npmjs.org error while"
+echo "  step 4 (host-side) SUCCEEDED, the microVM's egress is being cut below"
+echo "  msb's TLS/cert handling. If it fails on MULTIPLE hosts at once, that is the"
+echo "  SIGNATURE 1 shape - most often stale msb state (wipe + reinstall). Use"
+echo "  step 7 to localize whether it is a network block or an msb-specific"
+echo "  VM-networking issue, and step 8 for the IPv6-first discriminator."
+
+hr "7. LOCALIZE a broad cut: network block, or an msb VM-networking issue?"
+echo "  A broad egress cut splits into two sub-cases. The distinguishing test:"
+echo "  does ANOTHER VM runtime on THIS host reach the same endpoint msb cannot?"
+echo
+echo "  If a podman-machine (or Docker/Lima/etc.) VM CAN curl an endpoint msb"
+echo "  CANNOT, then this host's Zero-Trust tunnel IS carrying VM egress in"
+echo "  general - and msb's libkrun/vmnet path is being singled out. That points"
+echo "  at an msb-specific VM-networking issue (worth an upstream report), not a"
+echo "  blanket network-policy block. If NO VM runtime can reach it, the network"
+echo "  is blocking all non-tunneled VM egress (a host/security-admin matter)."
+echo
+if have podman; then
+  echo "  podman detected - comparison probe (in-VM curl via podman machine):"
+  # Best-effort: only meaningful if a podman machine is already running. We do
+  # NOT start/stop machines or pull images beyond a tiny one; keep it read-only-ish.
+  pm_cmd='for h in api.gsa.usai.gov api.github.com registry.npmjs.org; do printf "    podman-VM https://%s/ default -> " "$h"; curl -sS -o /dev/null -w "%{http_code}|exit=%{exitcode}\n" --max-time 15 "https://$h/" 2>&1 || echo "exit=$?"; printf "    podman-VM https://%s/ -4      -> " "$h"; curl -4 -sS -o /dev/null -w "%{http_code}|exit=%{exitcode}\n" --max-time 15 "https://$h/" 2>&1 || echo "exit=$?"; done'
+  if podman machine inspect >/dev/null 2>&1; then
+    # Run curl INSIDE the podman machine VM (not a container) to mirror msb's
+    # VM-NIC egress path as closely as possible.
+    podman machine ssh "sh -c '$pm_cmd'" 2>&1 | sed 's/^/  /' \
+      || echo "    (podman machine ssh probe could not run; try manually - see below)"
+  else
+    echo "    (no running podman machine detected; start one and re-run, or probe"
+    echo "     manually - see below)"
+  fi
+  echo
+fi
+echo "  Manual comparison (run whichever VM runtime you have and compare to the"
+echo "  msb step-6 result above):"
+echo
+echo "    # podman machine (VM-level, closest analog to msb's libkrun VM):"
+echo "    podman machine ssh 'curl -sS -o /dev/null -w \"%{http_code}\\n\" -v https://api.github.com'"
+echo
+echo "  If the podman VM returns 200/301 for hosts msb cannot reach, capture that"
+echo "  side by side with step 6 - it is the strongest signal of an msb VM-"
+echo "  networking issue and belongs in an upstream microsandbox report."
+echo
+echo "  NOTE on Zscaler: what a host-vs-host difference ESTABLISHES is only that"
+echo "  this host's msb egress differs from a working host's (and, per step 7,"
+echo "  possibly from another VM runtime on THIS host). WHY they differ is a"
+echo "  hypothesis, not a measured fact: a password-gated 'Exit Zscaler' is at"
+echo "  most a correlated symptom, and a working host reproduces the good case"
+echo "  with Zscaler fully active and never exited - so do NOT treat exiting"
+echo "  Zscaler as the mechanism. To actually confirm a policy difference, compare"
+echo "  the two hosts' Zscaler status/policy + routes (netstat -rn, route get, the"
+echo "  Zscaler app's About/Status). See docs/KNOWN_FAILURE_MODES.md section 30."
+
+hr "8. IPv6-FIRST discriminator: does forcing IPv4 fix it?"
+echo "  A cheap-to-confirm variant of the msb VM-networking case: on a host with"
+echo "  no usable IPv6 egress (common under Zscaler/ZTNA force-tunneling), the msb"
+echo "  guest can still get an IPv6 address and AAAA DNS answers. The microVM"
+echo "  gateway then answers the guest's IPv6 SYN LOCALLY (connect returns success"
+echo "  instantly), so Happy Eyeballs never falls back to IPv4 - and every"
+echo "  dual-stack host stalls to timeout / 'unexpected eof'. (This matches a"
+echo "  known upstream microsandbox IPv6-first report.)"
+echo
+echo "  DECISIVE TEST: steps 6 and 7 above already probe each host BOTH ways -"
+echo "  default (dual-stack) and IPv4-forced (curl -4). Compare the two lines"
+echo "  per host in the step-6 (msb) output:"
+echo
+echo "    - default FAILS (56/000) but '-4' SUCCEEDS (200/301) -> IPv6-first stall."
+echo "      In-guest workaround: force IPv4 (curl -4) or disable guest IPv6, and"
+echo "      report it to the upstream microsandbox IPv6-first issue rather than"
+echo "      filing a new one."
+echo "    - BOTH default and '-4' fail -> NOT the IPv6-first case; egress is cut"
+echo "      regardless of address family (stay with the step-7 split)."
+echo "    - both succeed -> egress is actually fine for these hosts right now."
+echo
+echo "  (If your msb has no ACQ_MSB_NO_TLS_INTERCEPT auto-run, run step 6 manually"
+echo "   and read the default-vs--4 pair; the podman step-7 output pairs them too,"
+echo "   so you can confirm whether podman's VM also needs -4 or not.)"
+
+hr "DONE - review output; cert metadata + status codes only, no secrets"

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -137,11 +137,19 @@ case "${1:-}" in
         # real probe emits `<http_code>|<curl_exit>`. Model that shape.
         # STUB_KEY_UNREACHABLE=1 models curl failing to connect (TLS reset /
         # HTTP 000 / nonzero exit) — the network-unreachable case.
+        # STUB_KEY_UNREACHABLE=35 models the Sig 2 "pinned public address"
+        # variant (KFM §30): DNS was bypassed by pinning USAi's public IP, so the
+        # name resolved but the TLS/connect handshake still failed (curl exit 35)
+        # because the endpoint is reachable only via the corporate tunnel. Like
+        # any other connect failure it must classify as "unreachable", NOT a bad
+        # key and NOT a DNS-resolver hint.
         # STUB_KEY_UNRESOLVED=1 models DNS NXDOMAIN (curl exit 6) — the
         # split-horizon-DNS case.
         if [ "${STUB_KEY_UNRESOLVED:-0}" = "1" ]; then
           printf '000|6'
-        elif [ "${STUB_KEY_UNREACHABLE:-0}" = "1" ]; then
+        elif [ "${STUB_KEY_UNREACHABLE:-0}" = "35" ]; then
+          printf '000|35'
+        elif [ "${STUB_KEY_UNREACHABLE:-0}" != "0" ]; then
           printf '000|56'
         else
           printf '%s|0' "${STUB_KEY_STATUS:-200}"
@@ -246,14 +254,18 @@ case "$_msb_sub" in
       # #321: the registry reachability probe curls `https://<host>/` and prints
       # the `<http_code>|<curl_exit>` shape _classify_key_status reads. Default
       # models a reachable registry (200). STUB_NPM_REGISTRY=unreachable models a
-      # TLS/connection cut (000|56); =unresolved models NXDOMAIN (000|6). Match
-      # BEFORE the generic `%{http_code}` arm below (that one is the USAi key
-      # probe with an Authorization header; this one has neither header nor USAi
-      # host). Must precede the generic arm because both contain `%{http_code}`.
+      # TLS/connection cut (000|56); =unresolved models NXDOMAIN (000|6);
+      # =responded models the registry answering with an HTTP ERROR (500|0) —
+      # the connection completed, so it is NOT a DNS/TLS problem and MUST fall
+      # through to the neutral "registry rejected it / real npm error" branch.
+      # Match BEFORE the generic `%{http_code}` arm below (that one is the USAi
+      # key probe with an Authorization header; this one has neither header nor
+      # USAi host). Must precede the generic arm because both contain `%{http_code}`.
       *"registry.npmjs.org"*'%{http_code}'*|*'%{http_code}'*"registry.npmjs.org"*)
         case "${STUB_NPM_REGISTRY:-reachable}" in
           unreachable) printf '000|56' ;;
           unresolved)  printf '000|6'  ;;
+          responded)   printf '500|0'  ;;
           *)           printf '200|0'  ;;
         esac ;;
       *'%{http_code}'*)
@@ -997,6 +1009,28 @@ assert_eq "run: unreachable aborts the run (fail closed)" "1" "$rc"
 rm -rf "$_keyrun"
 cleanup_stubs
 
+# 3k6a. Sig 2 "pinned public address" variant (KFM §30): the split-horizon name
+#        was bypassed by pinning USAi's PUBLIC IP, so DNS resolved but the
+#        TLS/connect handshake still failed (curl exit 35) — the endpoint is only
+#        reachable via the corporate tunnel. This must be treated exactly like the
+#        broad unreachable case (network problem, fail closed, no rotate prompt),
+#        and must NOT emit the DNS "did not RESOLVE" / ACQ_MSB_DNS_NAMESERVER hint,
+#        which belongs only to the NXDOMAIN (exit 6) branch. Guards against a
+#        pinned-public failure being misfiled as a resolver problem.
+make_stubs
+_keyrun35=$(mktemp -d "${TMPDIR:-/tmp}/acq-pinned35.XXXXXX")
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
+seed_sbx_usai_proxy_fixture
+out35=$(STUB_KEY_UNREACHABLE=35 ACQ_BACKEND=sbx "$ACQ" run opencode "$_keyrun35" 2>&1); rc35=$?
+assert_contains "run(rc=35): pinned-public names a network problem" "$out35" "could not reach the USAi API"
+assert_contains "run(rc=35): pinned-public says not a key problem" "$out35" "NOT an invalid or expired key"
+assert_not_contains "run(rc=35): pinned-public does NOT prompt to rotate" "$out35" "Rotate now"
+assert_not_contains "run(rc=35): pinned-public does NOT emit a DNS resolver hint" "$out35" "ACQ_MSB_DNS_NAMESERVER"
+assert_not_contains "run(rc=35): pinned-public does NOT say 'did not RESOLVE'" "$out35" "did not RESOLVE"
+assert_eq "run(rc=35): pinned-public aborts the run (fail closed)" "1" "$rc35"
+rm -rf "$_keyrun35"
+cleanup_stubs
+
 # 3k7. check_key returns a CLEAN token even when curl output is polluted: a real
 #       HTTP status classifies as that status; a connection failure classifies as
 #       "unreachable"; never free-form curl error text.
@@ -1010,6 +1044,13 @@ make_stubs; load_acq
   assert_eq "classify: nonzero exit -> unreachable" "unreachable" "$(_classify_key_status '000|7')"
   # curl exit 6 = NXDOMAIN: split-horizon-DNS tell, distinct from a broad cut.
   assert_eq "classify: exit 6 -> unresolved" "unresolved" "$(_classify_key_status '000|6')"
+  # curl exit 35 = TLS/connect handshake failure. This is the Sig 2 "pinned
+  # public address" variant (KFM §30): the split-horizon name was bypassed by
+  # pinning USAi's PUBLIC IP, so DNS resolved but the connection still could not
+  # complete (the endpoint is reachable only via the corporate tunnel). It must
+  # classify as "unreachable" (a network-path problem), NOT "unresolved" and NOT
+  # a bad key — the caller must not emit a DNS-resolver hint for it.
+  assert_eq "classify: exit 35 (pinned-public) -> unreachable" "unreachable" "$(_classify_key_status '000|35')"
   # Polluted output (curl error leaked before the code) must not escape as text.
   polluted='curl: (56) OpenSSL SSL_read: unexpected eof000|56'
   assert_eq "classify: polluted curl error -> unreachable" "unreachable" "$(_classify_key_status "$polluted")"
@@ -3046,6 +3087,33 @@ assert_contains "msb #321: genuinely-missing npm reported as not present" "$npm_
 assert_not_contains "msb #321: missing-npm case does not claim unreachable" "$npm_missing_out" "NOT REACHABLE"
 cleanup_stubs
 
+# 8n4d. #321: guard against classification BLEED. When npm is present AND the
+#        registry RESPONDED (an HTTP error — connection completed), the failure
+#        is a real npm/registry error, not a network path problem. acq must give
+#        the NEUTRAL guidance and must NOT emit a DNS hint (ACQ_MSB_DNS_NAMESERVER
+#        / "did not RESOLVE") or a TLS/reachability hint ("NOT REACHABLE") — those
+#        belong only to the unresolved/unreachable branches. This pins the
+#        boundary so a future edit can't let the DNS/TLS advice bleed into the
+#        neutral case.
+make_stubs; load_acq
+: > "$CALLS"
+npm_responded_out=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/npmresp-secrets"
+  export STUB_NPM_FAIL=1 STUB_NPM_REGISTRY=responded
+  . "${REPO_ROOT}/acq.backends/common.sh"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision npmrespbox opencode /tmp 2>&1
+)
+assert_contains "msb #321: responded registry -> neutral 'appears reachable' branch" "$npm_responded_out" "registry appears reachable"
+assert_not_contains "msb #321: neutral branch emits NO DNS resolver hint" "$npm_responded_out" "ACQ_MSB_DNS_NAMESERVER"
+assert_not_contains "msb #321: neutral branch does NOT say 'did not RESOLVE'" "$npm_responded_out" "did not RESOLVE"
+assert_not_contains "msb #321: neutral branch emits NO TLS/reachability hint" "$npm_responded_out" "NOT REACHABLE"
+assert_not_contains "msb #321: neutral branch does not claim npm is missing" "$npm_responded_out" "npm is not present"
+cleanup_stubs
 
 # 8n5. Attach LAUNCHES the recorded agent as the `agent` user in the workspace,
 #      with a PTY — NOT a bare root shell (the reported bug) and NOT msb's Node

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -137,7 +137,11 @@ case "${1:-}" in
         # real probe emits `<http_code>|<curl_exit>`. Model that shape.
         # STUB_KEY_UNREACHABLE=1 models curl failing to connect (TLS reset /
         # HTTP 000 / nonzero exit) — the network-unreachable case.
-        if [ "${STUB_KEY_UNREACHABLE:-0}" = "1" ]; then
+        # STUB_KEY_UNRESOLVED=1 models DNS NXDOMAIN (curl exit 6) — the
+        # split-horizon-DNS case.
+        if [ "${STUB_KEY_UNRESOLVED:-0}" = "1" ]; then
+          printf '000|6'
+        elif [ "${STUB_KEY_UNREACHABLE:-0}" = "1" ]; then
           printf '000|56'
         else
           printf '%s|0' "${STUB_KEY_STATUS:-200}"
@@ -218,6 +222,14 @@ case "$_msb_sub" in
   exec)
     snippet=""; prev=""
     for a in "$@"; do [ "$prev" = "-c" ] && { snippet="$a"; break; }; prev="$a"; done
+    # `npm install -g …` is run as DIRECT argv (no `sh -c`), so it is matched on
+    # the full arg list, not on $snippet. STUB_NPM_FAIL=1 models the install
+    # failing so the #321 disambiguation path runs. Match it up front (before the
+    # bare-argv opencode-version probe and the $snippet cases below).
+    case " $* " in
+      *" npm install "*)
+        [ "${STUB_NPM_FAIL:-0}" = "1" ] && exit 1 || exit 0 ;;
+    esac
     # `opencode --version` postinstall functionality probe (bare argv). Default
     # broken (exit 1) so the postinstall path runs; STUB_OPENCODE_OK=1 or a
     # planted .opencode_fixed marker (written by a successful postinstall.mjs
@@ -231,6 +243,19 @@ case "$_msb_sub" in
     esac
     case "$snippet" in
       *"echo ok"*) printf 'ok\n' ;;
+      # #321: the registry reachability probe curls `https://<host>/` and prints
+      # the `<http_code>|<curl_exit>` shape _classify_key_status reads. Default
+      # models a reachable registry (200). STUB_NPM_REGISTRY=unreachable models a
+      # TLS/connection cut (000|56); =unresolved models NXDOMAIN (000|6). Match
+      # BEFORE the generic `%{http_code}` arm below (that one is the USAi key
+      # probe with an Authorization header; this one has neither header nor USAi
+      # host). Must precede the generic arm because both contain `%{http_code}`.
+      *"registry.npmjs.org"*'%{http_code}'*|*'%{http_code}'*"registry.npmjs.org"*)
+        case "${STUB_NPM_REGISTRY:-reachable}" in
+          unreachable) printf '000|56' ;;
+          unresolved)  printf '000|6'  ;;
+          *)           printf '200|0'  ;;
+        esac ;;
       *'%{http_code}'*)
         # Match check_key's `<http_code>|<curl_exit>` shape (see the sbx stub).
         if [ "${STUB_KEY_UNREACHABLE:-0}" = "1" ]; then
@@ -279,6 +304,13 @@ case "$_msb_sub" in
       # tool (socat included) as present and make STUB_SOCAT_PRESENT inert.
       *"command -v socat"*)
         [ "${STUB_SOCAT_PRESENT:-1}" = "0" ] && exit 1 || exit 0 ;;
+      # #321 npm-install-failure disambiguation: on a failed `npm install`, acq
+      # probes whether npm is present in-guest (`command -v npm`) and, if so,
+      # curls the registry host. Model npm as present by default; STUB_NPM_MISSING=1
+      # makes `command -v npm` miss (exit 1) so the genuinely-missing-npm branch is
+      # exercised. This arm MUST precede the generic `command -v` catch-all.
+      *"command -v npm"*)
+        [ "${STUB_NPM_MISSING:-0}" = "1" ] && exit 1 || exit 0 ;;
       # ADR-0021: the in-guest socat bridge (`nohup socat UNIX-LISTEN:…
       # VSOCK-CONNECT:2:<port>`) started by _acq_msb_start_ssh_agent_bridge.
       # Model a successful bridge start (exit 0). Match BEFORE the generic cases.
@@ -976,11 +1008,29 @@ make_stubs; load_acq
   assert_eq "classify: clean 401"          "401"         "$(_classify_key_status '401|0')"
   assert_eq "classify: 000 -> unreachable" "unreachable" "$(_classify_key_status '000|56')"
   assert_eq "classify: nonzero exit -> unreachable" "unreachable" "$(_classify_key_status '000|7')"
+  # curl exit 6 = NXDOMAIN: split-horizon-DNS tell, distinct from a broad cut.
+  assert_eq "classify: exit 6 -> unresolved" "unresolved" "$(_classify_key_status '000|6')"
   # Polluted output (curl error leaked before the code) must not escape as text.
   polluted='curl: (56) OpenSSL SSL_read: unexpected eof000|56'
   assert_eq "classify: polluted curl error -> unreachable" "unreachable" "$(_classify_key_status "$polluted")"
-) 2>/dev/null; pass "classify: key-status classification is clean (code|unreachable|empty)"
+) 2>/dev/null; pass "classify: key-status classification is clean (code|unresolved|unreachable|empty)"
 cleanup_stubs
+
+# 3k7a. A USAi NXDOMAIN (curl exit 6) is reported as a DNS/split-horizon problem
+#        with a resolver hint — NOT as unreachable, and NOT as a bad key. Reuses
+#        the sbx key-check path with STUB_KEY_UNRESOLVED=1 (same seeding as 3k6).
+make_stubs
+_keyrun2=$(mktemp -d "${TMPDIR:-/tmp}/acq-unres.XXXXXX")
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
+seed_sbx_usai_proxy_fixture
+unres_out=$(STUB_KEY_UNRESOLVED=1 ACQ_BACKEND=sbx "$ACQ" run opencode "$_keyrun2" 2>&1); unres_rc=$?
+assert_contains "run: NXDOMAIN names a resolution problem" "$unres_out" "did not RESOLVE"
+assert_contains "run: NXDOMAIN points at ACQ_MSB_DNS_NAMESERVER" "$unres_out" "ACQ_MSB_DNS_NAMESERVER"
+assert_not_contains "run: NXDOMAIN does NOT prompt to rotate" "$unres_out" "Rotate now"
+assert_eq "run: NXDOMAIN aborts the run (fail closed)" "1" "$unres_rc"
+rm -rf "$_keyrun2"
+cleanup_stubs
+
 
 # Verify `acq stop mybox` calls sbx stop.
 make_stubs
@@ -2154,6 +2204,73 @@ assert_contains "msb: default image is docker/sandbox-templates:shell-docker" "$
 assert_not_contains "msb: default image is NOT plain node:22-bookworm" "$prov_log" "docker.io/library/node:22-bookworm"
 cleanup_stubs
 
+# 8m0a. TLS-intercept UPSTREAM CA trust (defense-in-depth). With an explicit
+#        ACQ_MSB_UPSTREAM_CA_CERT PEM and interception ON (default), provision
+#        emits `--tls-upstream-ca-cert <PEM>` so msb's host-side proxy trusts a
+#        corporate root on its upstream leg. Uses an explicit path (portable;
+#        avoids the macOS-only keychain auto-export).
+make_stubs; load_acq
+: > "$CALLS"
+printf -- '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n' > "$STUBDIR/corp-root.pem"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/upca-secrets"
+  export ACQ_MSB_UPSTREAM_CA_CERT="$STUBDIR/corp-root.pem"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision upcabox shell /tmp >/dev/null 2>&1
+)
+upca_log=$(cat "$CALLS")
+assert_contains "msb: emits --tls-upstream-ca-cert for explicit PEM (interception on)" "$upca_log" "--tls-upstream-ca-cert $STUBDIR/corp-root.pem"
+cleanup_stubs
+
+# 8m0b. The upstream CA is emitted ONLY when interception is on. With
+#        ACQ_MSB_NO_TLS_INTERCEPT=1 there is no upstream leg to verify, so neither
+#        --tls-intercept nor --tls-upstream-ca-cert appears — even with an
+#        explicit PEM configured.
+make_stubs; load_acq
+: > "$CALLS"
+printf -- '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n' > "$STUBDIR/corp-root2.pem"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/upca2-secrets"
+  export ACQ_MSB_UPSTREAM_CA_CERT="$STUBDIR/corp-root2.pem"
+  export ACQ_MSB_NO_TLS_INTERCEPT=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision upca2box shell /tmp >/dev/null 2>&1
+)
+upca2_log=$(cat "$CALLS")
+assert_not_contains "msb: no --tls-intercept when disabled" "$upca2_log" "--tls-intercept"
+assert_not_contains "msb: no --tls-upstream-ca-cert when interception disabled" "$upca2_log" "--tls-upstream-ca-cert"
+cleanup_stubs
+
+# 8m0c. ACQ_MSB_NO_UPSTREAM_CA=1 suppresses the upstream CA even when a PEM is
+#        configured and interception is on (reproduction/testing toggle).
+make_stubs; load_acq
+: > "$CALLS"
+printf -- '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n' > "$STUBDIR/corp-root3.pem"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/upca3-secrets"
+  export ACQ_MSB_UPSTREAM_CA_CERT="$STUBDIR/corp-root3.pem"
+  export ACQ_MSB_NO_UPSTREAM_CA=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision upca3box shell /tmp >/dev/null 2>&1
+)
+upca3_log=$(cat "$CALLS")
+assert_contains "msb: interception still on under NO_UPSTREAM_CA" "$upca3_log" "--tls-intercept"
+assert_not_contains "msb: NO_UPSTREAM_CA suppresses the upstream CA flag" "$upca3_log" "--tls-upstream-ca-cert"
+cleanup_stubs
+
+
 # 8m00. ACQ_MSB_IMAGE override: a user-supplied image is passed through verbatim
 #       to `msb create` (plain-OCI overrides remain supported; the agent-user /
 #       sudo synthesis handles them). Assert the override, not the default.
@@ -2866,6 +2983,69 @@ shell_log=$(cat "$CALLS")
 assert_not_contains "msb: shell agent does not npm install" "$shell_log" "npm install"
 assert_not_contains "msb: shell agent adds no npm net-rule (strict tier)" "$shell_log" "allow@registry.npmjs.org"
 cleanup_stubs
+
+# 8n4a. #321: a FAILED npm install is DISAMBIGUATED, not conflated. When npm is
+#        present in-guest but the registry is UNREACHABLE (TLS cut), acq must say
+#        "not reachable / network" and point at KNOWN_FAILURE_MODES §30 — and must
+#        NOT imply npm is missing (the misdiagnosis that sent #305's reporter to
+#        reinstall node on the host).
+make_stubs; load_acq
+: > "$CALLS"
+npm_unreach_out=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/npmunreach-secrets"
+  export STUB_NPM_FAIL=1 STUB_NPM_REGISTRY=unreachable
+  . "${REPO_ROOT}/acq.backends/common.sh"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision npmunreachbox opencode /tmp 2>&1
+)
+assert_contains "msb #321: unreachable registry reported as NOT REACHABLE" "$npm_unreach_out" "NOT REACHABLE"
+assert_contains "msb #321: unreachable registry points at KFM §30" "$npm_unreach_out" "KNOWN_FAILURE_MODES.md §30"
+assert_not_contains "msb #321: unreachable registry does NOT claim npm is missing" "$npm_unreach_out" "npm is not present"
+cleanup_stubs
+
+# 8n4b. #321: when npm is present but the registry NXDOMAINs (curl exit 6), acq
+#        reports it as DNS (split-horizon) and points at ACQ_MSB_DNS_NAMESERVER —
+#        again NOT "npm missing".
+make_stubs; load_acq
+: > "$CALLS"
+npm_unres_out=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/npmunres-secrets"
+  export STUB_NPM_FAIL=1 STUB_NPM_REGISTRY=unresolved
+  . "${REPO_ROOT}/acq.backends/common.sh"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision npmunresbox opencode /tmp 2>&1
+)
+assert_contains "msb #321: unresolved registry reported as did not RESOLVE" "$npm_unres_out" "did not RESOLVE"
+assert_contains "msb #321: unresolved registry points at ACQ_MSB_DNS_NAMESERVER" "$npm_unres_out" "ACQ_MSB_DNS_NAMESERVER"
+cleanup_stubs
+
+# 8n4c. #321: when npm is genuinely MISSING in-guest, acq says so (the one case
+#        where "use a base image that ships node/npm" is the right advice).
+make_stubs; load_acq
+: > "$CALLS"
+npm_missing_out=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/npmmissing-secrets"
+  export STUB_NPM_FAIL=1 STUB_NPM_MISSING=1
+  . "${REPO_ROOT}/acq.backends/common.sh"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  _acq_msb_fetch_kit() { printf '%s\n' "${STUBDIR}/nokit"; }
+  mkdir -p "${STUBDIR}/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' > "${STUBDIR}/nokit/spec.yaml"
+  acq_backend_provision npmmissingbox opencode /tmp 2>&1
+)
+assert_contains "msb #321: genuinely-missing npm reported as not present" "$npm_missing_out" "npm is not present"
+assert_not_contains "msb #321: missing-npm case does not claim unreachable" "$npm_missing_out" "NOT REACHABLE"
+cleanup_stubs
+
 
 # 8n5. Attach LAUNCHES the recorded agent as the `agent` user in the workspace,
 #      with a PTY — NOT a bare root shell (the reported bug) and NOT msb's Node


### PR DESCRIPTION
## Summary

Picks up the #305 investigation and reframes it around what field + clean-install
evidence actually showed. **This PR is not a fix for a single root cause** — #305
turned out to be three distinct failures wearing the same symptom. It ships the
tooling and docs to tell them apart, an acq-side disambiguation so users are not
misdirected, and defense-in-depth for the one case acq can actually harden.

Rebased onto current `main` (includes #310 `ACQ_NETWORK_TIER` and #318
`allow@dns`); this branch builds **on** the network-tier model rather than
reverting it.

## The three signatures (docs/KNOWN_FAILURE_MODES.md §30)

| Signature (from inside the guest) | Cause | Fix |
|---|---|---|
| Broad `curl (56) unexpected eof` / HTTP `000` on **multiple** hosts at once | Corrupted / stale **msb state** (not a clean-install behavior) | Wipe msb data + reinstall, then `msb doctor` |
| **USAi only** fails with `NXDOMAIN` / `curl rc=6`, while GitHub + npm work | **Split-horizon DNS** — USAi resolves to an internal, tunnel-only address the guest's public resolver can't see | Point the guest at a resolver that can reach the internal zone (`ACQ_MSB_DNS_NAMESERVER`) |
| A **genuinely intercepted** endpoint fails its TLS handshake | The proxy's root CA isn't trusted on msb's upstream leg | acq passes it via `--tls-upstream-ca-cert` (defense-in-depth) |

The original "confirmed upstream libkrun/vmnet bug" framing is **removed**:
`superradcompany/microsandbox#1344` was opened and **closed as non-reproducible**
(a full msb data wipe + reinstall cleared the reporter; a clean machine with the
same Zscaler config never reproduced). Thanks to @wz-gsa for the clean-install
repro that isolated the split-horizon-DNS case as separate and reproducible.

## What changed

- **`acq.backends/common.sh`** — `_classify_key_status` now returns `unresolved`
  for a curl exit 6 (NXDOMAIN), distinct from `unreachable` (connection cut). New
  `_report_usai_unresolved` explains split-horizon DNS and points at
  `ACQ_MSB_DNS_NAMESERVER`; wired into `advise_valid_key` / `ensure_valid_key`
  (fails closed, never offers a rotation that can't help).
- **`acq.backends/msb.sh`** —
  - TLS-intercept **upstream CA trust** (defense-in-depth): when `--tls-intercept`
    is on, acq passes the host's corporate root(s) to msb's upstream verifier via
    `--tls-upstream-ca-cert` (explicit `ACQ_MSB_UPSTREAM_CA_CERT`, or a macOS
    auto-export of the host search-list roots; `ACQ_MSB_NO_UPSTREAM_CA` suppresses
    it for reproduction). Emitted **only** alongside `--tls-intercept`.
  - **#321 fix:** a failed in-guest `npm install` is disambiguated — probe whether
    npm is present and whether the registry resolves/connects, then print the
    message that matches the actual cause (missing npm vs unresolved vs unreachable
    registry) so a network cut is not misread as "node isn't installed."
- **`scripts/diagnose-tls-intercept`, `scripts/diagnose-host-egress-diff`** —
  read-only, unprivileged host probes that classify a failure into the three
  signatures (cert metadata + HTTP status codes only; no secrets).
- **Docs** — §30 rewritten around the triage table; a `msb doctor` verify
  one-liner in the QUICKSTART msb prerequisites; a wipe/reinstall/`msb doctor`
  recovery note in the BACKEND_GUIDE troubleshooting section.

sbx bakes opencode into its template image (no in-guest npm install), so the #321
conflation is msb-only; no sbx change.

## Verification

- `./scripts/test-acq`: **934 passed, 0 failed** (adds split-horizon/NXDOMAIN,
  upstream-CA emission, and #321 npm-message coverage).
- `bash -n` clean on `acq`, `acq.backends/*.sh`, `scripts/test-acq`, both probes.
- `shellcheck --severity=warning`, one file per invocation: clean. (`msb.sh` and
  `test-acq` need `--extended-analysis=false` to avoid the known analyzer OOM;
  the pre-commit hook already lints one-file-per-invocation.)
- `npm run lint:md`: 0 issues.
- Live msb end-to-end validation requires a virt-capable host and **cannot run in
  a sandbox** — BLOCKED. The split-horizon case in particular needs a GFE/tunnel
  host to exercise.

## Rollback

Revert the branch commits. The only behavioral surfaces are the new
`--tls-upstream-ca-cert` flag (gated behind interception-on, overridable via
`ACQ_MSB_*`) and the more specific diagnostic messages; the probe scripts and
docs are additive.

## Security impact

No change to authn/authz or data handling. Probes are read-only (cert metadata +
status codes, no secrets, no env dump). The retained upstream-CA path only *adds*
the host's existing corporate root to msb's upstream verifier when interception is
already enabled.

Closes: GSA-TTS/agentic-coding-quickstart#321

AI-assisted (OpenCode).
