### PR TITLE
fix(sbx): make global secret-set bash-3.2-safe (empty-array under set -u)

### DIFF
--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -753,7 +753,12 @@ acq_backend_secret_set() {
     # emits a warning). A sandbox scope is `--sandbox NAME`. See the "sbx CLI
     # secret scope-flag change" note in docs/VERIFY_BACKENDS_HANDOFF.md.
     if [ -z "$scope_flag" ]; then builtin_scope_args+=(--sandbox "$scope_name"); fi
-    printf '%s\n' "$secret_value" | sbx secret set "${builtin_scope_args[@]}" "$service"
+    # Empty-array-safe expansion: for the GLOBAL scope builtin_scope_args stays
+    # empty (no --sandbox), and `"${arr[@]}"` on an empty array is a fatal
+    # "unbound variable" under `set -u` on bash 3.2 (the macOS system bash). The
+    # `[@]+…` guard expands to nothing when the array is empty. bash 4+ tolerates
+    # the bare form, so this only bit macOS users on the `acq secret set -g` path.
+    printf '%s\n' "$secret_value" | sbx secret set ${builtin_scope_args[@]+"${builtin_scope_args[@]}"} "$service"
     exit_code=$?
     secret_value=""
   else


### PR DESCRIPTION
## What

One-line fix: guard the empty-array expansion in the sbx built-in-service secret-set path so `acq secret set -g <service>` no longer aborts on macOS bash 3.2.

## Why

On macOS the system bash is `GNU bash 3.2`. Under `set -u`, expanding an **empty** array via `"${arr[@]}"` is a fatal `unbound variable` error there (bash 4+ on Linux CI tolerates it, so CI stayed green). In `acq.backends/sbx.sh`, `builtin_scope_args` stays empty for the **global** scope (the `--sandbox NAME` element is only added for the sandbox-scoped path), so:

```
acq secret set -g github
# -> acq.backends/sbx.sh: line 756: builtin_scope_args[@]: unbound variable
```

The abort happened **after** the token was written to the acq store but **before** it was fed to `sbx`, leaving the sbx side unset while acq reported success — a security-relevant split state on a documented common path.

## Fix

```sh
printf '%s\n' "$secret_value" | sbx secret set ${builtin_scope_args[@]+"${builtin_scope_args[@]}"} "$service"
```

The `${arr[@]+"${arr[@]}"}` idiom expands to nothing when the array is empty (bash-3.2-safe; the repo already relies on bash-3.2 compatibility elsewhere).

## Testing

- Reproduced the abort on `/bin/bash` (3.2) before the fix; verified `acq secret set -g github` now feeds `sbx secret set github` after.
- `scripts/test-acq`: 848 passed / 0 failed on macOS bash 3.2 (the two `-g github` assertions that failed on `main` — `-g github -> sbx secret set github` and the other-scope `-g` feeds-sbx test — now pass).
- `shellcheck --severity=warning acq.backends/sbx.sh`: clean.

## Notes

- Pre-existing on `main`; independent of the in-flight `ACQ_NETWORK_TIER` network-tier work. Kept as a small standalone PR because it touches the secret scope-flag area that `feat/msb-oci-podman` is also iterating, so it can be reviewed/merged independently.
- Follow-up worth considering: a macOS/bash-3.2 CI lane so this class of empty-array-under-`set -u` regression is caught (CI is currently Linux/bash-4+ only). Noted in the issue.

Fixes GSA-TTS/agentic-coding-quickstart#308

AI-assisted (OpenCode).