### PR TITLE
feat(msb): collapse gateway-DNS grant to allow@dns and re-verify git-HTTPS secret substitution vs msb 0.6.9

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -56,15 +56,21 @@ ACQ_BACKEND_CAN_RESUME=1                   # msb stop / msb start preserve state
 # shellcheck disable=SC2034
 ACQ_BACKEND_SUPPORTS_CREDENTIAL_REWRITE=1  # msb --secret ENV@HOST + --tls-intercept
 
-# Minimum msb version required. 0.6.8 is the first release with the
-# `--net-default-egress` / `--net-default-ingress` split that the balanced-egress
-# baseline (on by default, ADR-0018/0019) relies on — earlier 0.6.x had the
-# neutral net rules, --trust-host-cas, and --secret used here, but only the
-# symmetric `--net-default`, so a plain `acq create` would pass an unknown flag to
-# a 0.6.0-0.6.7 binary and clap would hard-error. Fail closed on the floor instead
-# (acq_backend_prepare) so the failure mode is a clear version message, not a raw
-# clap error mid-create.
-MIN_MSB_VERSION="0.6.8"
+# Minimum msb version required. Two reasons pin this to 0.6.9:
+#   1. 0.6.8 is the first release with the `--net-default-egress` /
+#      `--net-default-ingress` split that the balanced-egress baseline (on by
+#      default, ADR-0018/0019) relies on — earlier 0.6.x had the neutral net
+#      rules, --trust-host-cas, and --secret used here, but only the symmetric
+#      `--net-default`, so a plain `acq create` would pass an unknown flag to a
+#      0.6.0-0.6.7 binary and clap would hard-error.
+#   2. 0.6.9 is the first release where the semantic `allow@dns` macro parses
+#      correctly on release builds (the upstream release-build parser fix). On
+#      <= 0.6.8 that macro hard-failed on release binaries, so the gateway-DNS
+#      grant had to be emitted as an expanded udp/tcp:53 pair. The baseline
+#      emitter now uses `allow@dns` directly (see ADR-0018), which requires 0.6.9.
+# Fail closed on the floor instead (acq_backend_prepare) so the failure mode is a
+# clear version message, not a raw clap error or DNS parse failure mid-create.
+MIN_MSB_VERSION="0.6.9"
 
 # Default OCI image for provisioned sandboxes. We default to the SAME image
 # family sbx uses: `docker/sandbox-templates:shell-docker`, an Ubuntu-based
@@ -988,12 +994,12 @@ _acq_msb_balanced_parse_line() {
 #   - PORT: trailing `:port` -> `:tcp:<port>` (sbx "balanced" is TCP; a host on
 #     both :80 and :443 yields TWO rules, one per line, preserved).
 #   - WILDCARD / intra-label glob: see _acq_msb_balanced_target.
-#   - Also emits gateway-DNS rules FIRST so the guest can resolve the allowed
+#   - Also emits a gateway-DNS rule FIRST so the guest can resolve the allowed
 #     hosts: under `--net-default-egress deny` the high-level DNS auto-grant does
-#     not apply, so low-level rules must grant it explicitly. We emit the expanded
-#     `allow@host:udp:53` + `allow@host:tcp:53` rather than the `allow@dns` macro,
-#     which is broken on released msb (see the DNS block below). Pairs with
-#     --dns-nameserver.
+#     not apply, so a low-level rule must grant it explicitly. We use msb's
+#     semantic `allow@dns` macro, which acq can rely on because it requires
+#     msb >= 0.6.9 (the upstream release-build parser fix). Pairs with
+#     --dns-nameserver. (See the DNS block below and ADR-0018.)
 # A missing/unreadable file is a non-fatal warning (kits still add their egress).
 # Uses the eval-by-name array pattern (macOS bash 3.2 compat), like the siblings.
 _acq_msb_balanced_rules_into() {
@@ -1011,20 +1017,16 @@ _acq_msb_balanced_rules_into() {
   # fires for the `--net` PROFILES (public/private/host), not for a rule-only deny
   # default.
   #
-  # We DELIBERATELY do NOT use msb's semantic `allow@dns` macro. That macro is
-  # broken in released msb (reproduced on 0.6.8): its parser guards the target
-  # token with `debug_assert_eq!(parts.next(), Some("dns"))`, which is compiled
-  # OUT of the release binary — so the iterator is never advanced past the `dns`
-  # target and the SAME `dns` token is then read as the PROTOCOL slot, failing
-  # with `the dns target supports tcp, udp, or any, not dns`. A bare `allow@dns`
-  # therefore hard-fails `msb create`/`msb run` on a release build.
-  #
-  # Instead we emit exactly what the macro is SPECIFIED to expand to — the gateway
-  # `host` group on port 53 for both UDP and TCP — as two explicit rules that go
-  # through the ordinary (assert-free) target/proto/port parse path. This is
-  # equivalent to the intended `allow@dns` and is unaffected by the upstream bug.
-  eval "$_arr+=(--net-rule \"allow@host:udp:53\")"
-  eval "$_arr+=(--net-rule \"allow@host:tcp:53\")"
+  # We use msb's semantic `allow@dns` macro, which expands to the gateway `host`
+  # group on port 53 for both UDP and TCP. This macro was broken on released msb
+  # builds up to and including 0.6.8: its parser guarded the target token with a
+  # `debug_assert_eq!` that is compiled OUT of release binaries, so the iterator
+  # was never advanced past the `dns` target and the same token was re-read as the
+  # protocol slot, hard-failing with `the dns target supports tcp, udp, or any,
+  # not dns`. microsandbox 0.6.9 fixed this (the upstream release-build parser fix
+  # now advances the target iterator before the assert), and acq requires
+  # msb >= 0.6.9 (MIN_MSB_VERSION), so the macro is safe to use here. See ADR-0018.
+  eval "$_arr+=(--net-rule \"allow@dns\")"
 
   local _line _host _port _target _warned_crl=0
   while IFS= read -r _line || [ -n "$_line" ]; do
@@ -1908,8 +1910,8 @@ acq_backend_provision() {
   # header and agentic-coding-patterns ADR-0002) selects how much egress the
   # sandbox gets, all deny-by-default except `open`:
   #   balanced -> `--net-default-egress deny` + the curated baseline
-  #               (`allow@<host>:tcp:<port>` per vendored entry + gateway DNS
-  #               `allow@host:udp:53`/`:tcp:53`) UNIONED with the kit/npm/secret
+  #               (`allow@<host>:tcp:<port>` per vendored entry + gateway DNS via
+  #               the `allow@dns` macro) UNIONED with the kit/npm/secret
   #               `allow@…` rules under first-match-wins.
   #   strict   -> `--net-default-egress deny` + gateway DNS, but NO baseline:
   #               egress is the kits' own `allow@…` hosts ONLY. Same deny-default
@@ -1932,7 +1934,7 @@ acq_backend_provision() {
   # rule. A future "strict" ingress profile can layer ingress deny-default + explicit
   # per-port `allow:ingress@…` rules; the tiers here intentionally set egress only.
   # Requires msb >= 0.6.8 (the `--net-default-egress`/`--net-default-ingress`
-  # split); MIN_MSB_VERSION is 0.6.8, so acq_backend_prepare has already failed
+  # split); MIN_MSB_VERSION is 0.6.9, so acq_backend_prepare has already failed
   # closed on anything older before we reach here — this flag is always known.
   #
   # `open` is a privileged, audited escape hatch (never a default, never for GFE):
@@ -1959,10 +1961,11 @@ acq_backend_provision() {
       _acq_msb_balanced_rules_into _balanced
     else
       # strict: deny-default + gateway DNS ONLY, no baseline hosts. Emit the same
-      # explicit gateway-DNS rules the baseline emitter prepends (the high-level
-      # DNS auto-grant does not fire under a rule-only deny-default), so kit
-      # `allow@…` hosts remain resolvable. NOTHING else is added.
-      _balanced=(--net-rule "allow@host:udp:53" --net-rule "allow@host:tcp:53")
+      # gateway-DNS rule the baseline emitter prepends (the high-level DNS
+      # auto-grant does not fire under a rule-only deny-default), so kit `allow@…`
+      # hosts remain resolvable. Uses msb's `allow@dns` macro, safe because acq
+      # requires msb >= 0.6.9 (the upstream parser fix). NOTHING else is added.
+      _balanced=(--net-rule "allow@dns")
     fi
     if [ "${#_balanced[@]}" -gt 0 ]; then
       create_flags+=(--net-default-egress deny)

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1428,7 +1428,16 @@ point `ACQ_MSB_BALANCED_HOSTS_FILE` at it, or (for a one-off) create with an ext
 
 ## 32. msb `create`/`run` Fails: `the dns target supports tcp, udp, or any, not dns`
 
-### Symptoms
+> **Status: RESOLVED for supported versions.** microsandbox **0.6.9** shipped the
+> upstream release-build parser fix for the `allow@dns` macro, and acq now
+> requires **msb >= 0.6.9** (`MIN_MSB_VERSION` in `acq.backends/msb.sh`). The msb
+> adapter emits the native `allow@dns` macro for the gateway-DNS grant again; the
+> expanded `allow@host:udp:53` + `allow@host:tcp:53` workaround has been removed.
+> Because the floor fails closed on anything older than 0.6.9, a supported acq
+> install can no longer hit this failure. The reproduction and root-cause history
+> below is retained for context.
+
+### Symptoms (historical, msb <= 0.6.8)
 
 On the **msb** backend, `acq run`/`acq create` (or a raw `msb create`/`msb run`)
 aborts during "Creating sandbox …" with:
@@ -1444,39 +1453,46 @@ Reproduces with the minimal case on a released msb (confirmed on msb 0.6.8):
 msb run --net-default deny --net-rule "allow@dns" alpine -- true
 ```
 
-### Root Cause
+### Root Cause (historical, msb 0.6.7–0.6.8)
 
 An **upstream msb bug** in the `--net-rule` parser, not an acq misconfiguration.
-msb's semantic `allow@dns` macro is parsed by advancing past the `dns` target
+msb's semantic `allow@dns` macro was parsed by advancing past the `dns` target
 token inside a `debug_assert_eq!(parts.next(), Some("dns"))`. `debug_assert!` is
-compiled **out** of a release binary, so in the shipped `msb` the iterator is
-never advanced past `dns`; the same `dns` token is then read as the **protocol**
+compiled **out** of a release binary, so in the shipped `msb` the iterator was
+never advanced past `dns`; the same `dns` token was then read as the **protocol**
 field, which only accepts `tcp`/`udp`/`any` — hence the error. A bare
-`allow@dns` therefore hard-fails on every release build that has the macro
-(0.6.7+), even though the macro is documented as valid.
+`allow@dns` therefore hard-failed on release builds **from 0.6.7 through 0.6.8**
+(fixed in 0.6.9; see Fix below), even though the macro was documented as valid.
 
 The balanced-egress baseline (ADR-0018) needs a gateway-DNS grant under
-`--net-default deny`, and originally emitted `allow@dns`, tripping this bug.
+`--net-default deny`, and originally emitted `allow@dns`, tripping this bug on
+pre-0.6.9 release builds.
 
 ### Fix
 
-The msb adapter no longer emits the `allow@dns` macro. It emits the **expanded**
-equivalent instead — exactly what the macro is specified to produce — which takes
-the ordinary (assert-free) parse path and is unaffected by the bug:
+microsandbox **0.6.9** fixed the parser: the target-iterator advance was moved
+OUT of the `debug_assert_eq!`, so it now runs on release binaries too and a bare
+`allow@dns` parses correctly. acq raised `MIN_MSB_VERSION` to **0.6.9** and
+collapsed the former expanded workaround back to the native macro:
 
 ```
---net-rule allow@host:udp:53 --net-rule allow@host:tcp:53
+--net-rule allow@dns
 ```
 
-This is in `_acq_msb_balanced_rules_into` in `acq.backends/msb.sh`. If you script
-raw `msb` calls yourself, use the same expanded form rather than `allow@dns`.
+This is emitted in `_acq_msb_balanced_rules_into` (and the strict-tier path) in
+`acq.backends/msb.sh`. The earlier workaround emitted the expanded equivalent
+(`--net-rule allow@host:udp:53 --net-rule allow@host:tcp:53`) so that pre-0.6.9
+release builds could still resolve DNS under a deny-default; that is no longer
+needed now that the floor guarantees a fixed parser. If you script raw `msb`
+calls against a 0.6.9+ binary, `allow@dns` is safe to use directly.
 
 ### Prevention / Status
 
-- Re-verify on the **quarterly review cadence**: once upstream msb fixes the
-  macro (moving the target advance out of the `debug_assert`), a bare `allow@dns`
-  becomes safe again and the expanded pair MAY be collapsed back. Confirm with the
-  minimal `msb run … --net-rule "allow@dns"` case above before changing it.
+- **Resolved.** The version floor (`MIN_MSB_VERSION=0.6.9`) fails closed on any
+  older binary before a create is attempted, so acq cannot reach this failure on
+  a supported install. If a future regression is suspected, re-run the minimal
+  `msb run … --net-rule "allow@dns"` case above on the quarterly review cadence to
+  confirm the macro still parses.
 
 ---
 

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -110,9 +110,12 @@ the neutral `hybrid/v1` kits, JSON schema, and registry) lands separately in
   via `msb modify --secret`. The **GitHub token is bound to the REST API and
   git-transport hosts**
   (`GITHUB_TOKEN@github.com,api.github.com,codeload.github.com`): msb substitutes
-  the token on the wire for REST API calls and HTTPS git clone/push, so the real
-  token never enters the guest. Kits still may use REST tarballs for
-  reproducibility, but HTTPS git transport is now eligible for substitution.
+  the token on the wire for REST API calls, and git smart-HTTP is **eligible**
+  because git carries its credential in an `Authorization: Basic` header that
+  msb's substitution path rewrites (see the "GitHub git-HTTPS substitution
+  eligibility" note below), so the real token never enters the guest. Kits still
+  may use REST tarballs for reproducibility, but HTTPS git transport is eligible
+  for substitution.
   Unlike sbx (whose
   templates supply the image), msb runs a plain OCI image: the default is the
   public `node:22-bookworm` (built on buildpack-deps, so it already ships
@@ -316,11 +319,41 @@ allow@HOST --trust-host-cas --tls-intercept --secret ENV@HOST --volume`,
   it is the microsandbox model and the price of the microVM boundary. Disable
   with `ACQ_MSB_NO_TLS_INTERCEPT` (secrets then won't substitute).
 - **Private GitHub content:** kits may fetch private GitHub content via pinned
-  REST tarballs for reproducibility, and acq now binds GitHub credentials to the
+  REST tarballs for reproducibility, and acq binds GitHub credentials to the
   REST API plus HTTPS git-transport hosts
-  (`GITHUB_TOKEN@github.com,api.github.com,codeload.github.com`). Current msb
+  (`GITHUB_TOKEN@github.com,api.github.com,codeload.github.com`). msb
   substitutes the placeholder on those hosts, so direct HTTPS clone/push is
-  eligible for secret injection without the real token entering the guest.
+  eligible for secret injection without the real token entering the guest — see
+  the eligibility note immediately below for the static-vs-live status of the
+  git-transport claim.
+- **GitHub git-HTTPS substitution eligibility (re-verified statically against
+  msb 0.6.9; live git clone/push still pending on a KVM host):** the msb
+  secret-substitution engine substitutes a placeholder only on a TLS-intercepted
+  connection whose SNI/authority matches the bound host (the `--tls-intercept`
+  requirement is unchanged in 0.6.9). Its request rewriting covers HTTP request
+  **headers** — including an `Authorization: Basic <base64(user:token)>` value,
+  which it base64-decodes, substitutes the placeholder in, and re-encodes — plus
+  URL query params and (opt-in) identity-encoded request bodies. Git's
+  smart-HTTP transport carries its credential in exactly that `Authorization:
+  Basic` header on every request (both the `GET .../info/refs` and the `POST
+  .../git-upload-pack` / `git-receive-pack`), and the credential does **not**
+  ride the request body. The 0.6.9 engine does **not** rewrite non-identity
+  (e.g. gzipped) bodies, HTTP/2 DATA-frame bodies, or fixed-length bodies larger
+  than 16 MiB — it blocks a request rather than send a placeholder wrong — but
+  git's gzipped pack-negotiation body carries no credential, so that limit does
+  not gate the auth header. On paper, therefore, a git clone/push over
+  intercepted HTTPS to a bound github host is **eligible** for header
+  substitution in 0.6.9. This is the static reading of the 0.6.9 source
+  (`crates/network/lib/secrets/handler.rs`, `.../config.rs`) and docs
+  (`docs/security/secrets.mdx`); the 0.6.6→0.6.9 diff shows no change to the
+  header/Basic-auth substitution path and nothing added or removed for
+  git/smart-HTTP specifically. **What the static review does not prove:** that
+  msb actually intercepts and rewrites git's connection end-to-end (git's
+  credential-helper prompt, TLS handshake against the interception CA, and the
+  authority checks must all line up at run time). That confirmation requires a
+  live `git clone`/`git ls-remote` of a private repo on a KVM-capable host and is
+  still pending; run `scripts/verify-git-https-secret-msb` there to settle it
+  (it prints an explicit PASS/FAIL/BLOCKED verdict and never echoes the token).
 
 ### `environment` vocabulary (guest env vars)
 
@@ -374,8 +407,12 @@ discovered and worked around here (recorded so they aren't re-litigated):
 identical host:guest `/tmp` mounts silently fail (→ fixed guest mount point);
 the host resolver is unreachable from the microVM (→ `--dns-nameserver`); the
 kits assume an `agent`/`/home/agent` user a plain base lacks (→ create it);
-secret substitution requires `--tls-intercept` and only covers the
-`Authorization` header path, not git HTTPS.
+secret substitution requires `--tls-intercept` and, per a static re-verification
+against msb 0.6.9, rewrites HTTP request headers (including the
+`Authorization: Basic` value git smart-HTTP uses) — so git-over-HTTPS is
+eligible on paper, though the live git clone/push confirmation is still pending
+on a KVM host (see the eligibility note above and
+`scripts/verify-git-https-secret-msb`).
 
 ## Validation
 
@@ -392,7 +429,10 @@ secret substitution requires `--tls-intercept` and only covers the
   `scripts/verify-backends` msb rows (now including the `opencode`-installed
   assertion added for quickstart#228) cannot run inside an sbx/msb sandbox and
   need host virtualization (`/dev/kvm` on Linux). The msb CLI flag shapes were
-  verified against `msb 0.6.6`; the live loop is deferred and mirrors how
+  verified against `msb 0.6.6` and the secret-substitution behavior was
+  re-verified statically against `msb 0.6.9` (0.6.9 is the installed version;
+  see the git-HTTPS eligibility note above — the live git clone/push loop is the
+  one piece still deferred to a KVM host); the live loop mirrors how
   ADR-0009/ADR-0010 defer live verification. Run `./scripts/verify-backends`
   on a sandbox-capable host and attach the transcript. **The quickstart#228 fix
   (agent install + attach launch) is verified offline via the stubbed harness;

--- a/docs/adr/0013-per-sandbox-github-token-downscoping.md
+++ b/docs/adr/0013-per-sandbox-github-token-downscoping.md
@@ -147,10 +147,14 @@ wrapper that only holds the user's `gh` token:
   collaborators, cannot access multiple orgs at once, and cannot call the Checks
   API. The docs note these so users know when to fall back to the (broader)
   global token.
-- **msb backend:** `msb` does not bind the `github` secret at all
-  (`msb.sh` — upstream microsandbox git-substitution limitation, ADR-0011). The
-  scoped token is still stored in the acq-neutral store on msb, and the flow
-  notes that msb does not inject it. No behavior regression for msb.
+- **msb backend:** `msb` binds the `github` secret to the REST API and
+  git-transport hosts (`msb.sh`; see ADR-0011). A static re-verification against
+  msb 0.6.9 found the substitution engine rewrites the `Authorization: Basic`
+  header git smart-HTTP uses, so a scoped token is eligible for injection on both
+  REST and HTTPS git transport without the real value entering the guest — the
+  same least-privilege scoping this ADR describes applies unchanged. The live
+  git clone/push confirmation on a KVM host is still pending (ADR-0011), so treat
+  msb git-HTTPS auth as eligible-but-not-yet-live-verified.
 - **Deprecation, not removal:** the global path keeps working, so existing setups
   are not broken; new guidance steers to per-sandbox scoping.
 - **Audit (AU-2):** scoping is per-sandbox and named, so which credential a
@@ -173,7 +177,7 @@ wrapper that only holds the user's `gh` token:
 - Exploration: `docs/explorations/downscoping-github-credentials-for-local-agents.md`
 - Related: ADR-0001 (SBX isolation is the complementary boundary),
   ADR-0005 (github token needed for the private playbook clone),
-  ADR-0011 (msb does not bind the github secret),
+  ADR-0011 (msb github-secret binding + git-HTTPS substitution eligibility),
   ADR-0012 (backend-neutral secret handling)
 - GitHub docs: "Managing your personal access tokens" (fine-grained PAT URL
   pre-fill parameters), "Create a scoped access token" (requires client secret),

--- a/docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md
+++ b/docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md
@@ -108,7 +108,7 @@ microsandbox source:
 ```
 
 Source of truth (pinned to msb 0.6.7):
-[`crates/network/lib/config.rs` → `struct PublishedPort`](https://github.com/superradcompany/microsandbox/blob/main/crates/network/lib/config.rs)
+[`crates/network/lib/config/types.rs` → `struct PublishedPort`](https://github.com/superradcompany/microsandbox/blob/main/crates/network/lib/config/types.rs)
 and the `--format json` assembly in
 [`crates/cli/lib/commands/inspect.rs`](https://github.com/superradcompany/microsandbox/blob/main/crates/cli/lib/commands/inspect.rs).
 The parser (`_acq_msb_ports_from_inspect`) keys on the explicit `host_port` /
@@ -164,6 +164,6 @@ failure mode entirely.
   (gap K)
 - Implementation: [#238](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/238)
 - msb `inspect --format json` port shape (canonical):
-  [`crates/network/lib/config.rs`](https://github.com/superradcompany/microsandbox/blob/main/crates/network/lib/config.rs)
+  [`crates/network/lib/config/types.rs`](https://github.com/superradcompany/microsandbox/blob/main/crates/network/lib/config/types.rs)
   (`struct PublishedPort`) and
   [`crates/cli/lib/commands/inspect.rs`](https://github.com/superradcompany/microsandbox/blob/main/crates/cli/lib/commands/inspect.rs)

--- a/docs/adr/0018-msb-balanced-egress-baseline.md
+++ b/docs/adr/0018-msb-balanced-egress-baseline.md
@@ -32,6 +32,18 @@ supersedes: []
 > [ADR-0019](0019-msb-balanced-egress-is-egress-only.md). References to
 > `--net-default deny` in the text below should be read as
 > `--net-default-egress deny`.
+>
+> **Update (2026-08-17, msb 0.6.9):** acq now requires **msb >= 0.6.9**
+> (`MIN_MSB_VERSION`). microsandbox 0.6.9 shipped the upstream release-build
+> parser fix for the semantic `allow@dns` macro (the target-iterator advance was
+> moved out of the `debug_assert` so it now runs on release binaries too). With
+> the floor raised, the emitter no longer needs the expanded
+> `allow@host:udp:53` + `allow@host:tcp:53` workaround: it emits the native
+> **`allow@dns`** macro for the gateway-DNS grant in both the `balanced` and
+> `strict` tiers. The "broken macro" / expanded-pair descriptions in the body
+> below reflect the pre-0.6.9 workaround and are superseded by this note; the
+> `docs/KNOWN_FAILURE_MODES.md` DNS failure mode is now resolved for supported
+> versions.
 
 ## Context
 
@@ -83,16 +95,18 @@ default**, composed on top of the kits' own `caps.network.allow`.
    - A leading gateway-DNS grant is emitted so the guest can resolve the
      allowed hosts — under `--net-default deny` the high-level DNS auto-grant
      does not apply, so DNS must be granted explicitly. This pairs with the
-     existing `--dns-nameserver`. We emit the **expanded** form
-     `allow@host:udp:53` + `allow@host:tcp:53` rather than msb's semantic
-     `allow@dns` macro: that macro is **broken in released msb** (reproduced on
-     0.6.8). Its parser advances past the `dns` target only inside a
-     `debug_assert_eq!`, which is compiled out of a release binary, so the
-     `dns` token is re-read as the protocol slot and `msb create` fails with
-     `the dns target supports tcp, udp, or any, not dns`. The two explicit
-     rules are exactly what the macro is specified to expand to (the gateway
-     `host` group on UDP/TCP port 53) and take the ordinary, assert-free parse
-     path, so they are unaffected by the upstream bug.
+     existing `--dns-nameserver`. The emitter uses msb's semantic **`allow@dns`**
+     macro (the gateway `host` group on UDP/TCP port 53). This macro was broken
+     on released msb builds up to and including 0.6.8 — its parser advanced past
+     the `dns` target only inside a `debug_assert_eq!`, which is compiled out of
+     a release binary, so the `dns` token was re-read as the protocol slot and
+     `msb create` failed with `the dns target supports tcp, udp, or any, not
+     dns`. microsandbox 0.6.9 fixed this (the release-build parser fix moves the
+     iterator advance out of the assert), and acq requires msb >= 0.6.9
+     (`MIN_MSB_VERSION`), so the macro is safe to emit directly. (Before the
+     floor was raised, the emitter used the expanded
+     `allow@host:udp:53` + `allow@host:tcp:53` pair as a workaround; see the
+     0.6.9 update note above.)
 
 3. **Restrict, don't merely widen.** At create, when the baseline is enabled the
    adapter emits `--net-default deny` **plus** the generated `allow@…` rules, so
@@ -164,9 +178,9 @@ default**, composed on top of the kits' own `caps.network.allow`.
 
 - Offline: `scripts/test-acq` covers target translation (`**.`, `crl*`, exact,
   single-label rejection), port validation, dual-port hosts, the gateway-DNS
-  rules (expanded `allow@host:udp:53` + `allow@host:tcp:53`, never the broken
-  `allow@dns` macro), malformed-line skipping, a full parse of the real vendored
-  file with no skips, and the default-on / `=0`-off provision paths.
+  grant (the `allow@dns` macro, no longer the expanded `allow@host:udp:53` +
+  `allow@host:tcp:53` pair), malformed-line skipping, a full parse of the real
+  vendored file with no skips, and the default-on / `=0`-off provision paths.
 - Live (deferred; requires a KVM-capable host — cannot run inside a sandbox):
   create an msb sandbox and confirm a `balanced`-only host that no kit allows
   (e.g. `pypi.org:443`) is reachable while an unlisted host is refused. Run per
@@ -178,5 +192,6 @@ default**, composed on top of the kits' own `caps.network.allow`.
 - Emitter: `_acq_msb_balanced_rules_into` in `acq.backends/msb.sh`
 - Related: ADR-0011 (msb backend + neutral kits), ADR-0010 (pluggable backends)
 - Drift / re-sync note: `docs/KNOWN_FAILURE_MODES.md`
-- Upstream `allow@dns` macro bug + expanded-rule workaround:
-  `docs/KNOWN_FAILURE_MODES.md` (msb `dns` target failure mode)
+- Upstream `allow@dns` macro history (broken <= 0.6.8, fixed in 0.6.9) and the
+  former expanded-rule workaround: `docs/KNOWN_FAILURE_MODES.md` (msb `dns`
+  target failure mode, now resolved for supported versions)

--- a/docs/explorations/acq-design.md
+++ b/docs/explorations/acq-design.md
@@ -891,12 +891,21 @@ kit vocabulary** with a translation layer. Recorded in
    set` writes there; BOTH backends read from it at provision — sbx feeds its
    proxy (`sbx secret set`/`set-custom`, piped), msb binds `--secret ENV@HOST`
    with `--tls-intercept` (USAi only) and re-feeds running sandboxes with `msb
-   modify --secret`. The value never enters the guest (msb gives it a
-   placeholder), never appears in argv, and is never serialized. **GitHub is NOT
-   bound on msb** — msb 0.6.6 doesn't substitute the placeholder for git's HTTPS
-   clone to github.com (works for the USAi `Authorization` header, not git; see
-   microsandbox #756/#768/#1170), so the private playbook clone is skipped on
-   msb (non-fatal). This is the bash subset of §7.5; the full
+    modify --secret`. The value never enters the guest (msb gives it a
+    placeholder), never appears in argv, and is never serialized. **GitHub is
+    bound on msb** to the REST API and git-transport hosts
+    (`GITHUB_TOKEN@github.com,api.github.com,codeload.github.com`). A static
+    re-verification against msb 0.6.9 (the installed version) confirms the
+    substitution engine still requires `--tls-intercept` and rewrites HTTP
+    request headers — including the `Authorization: Basic` value git smart-HTTP
+    carries its credential in — so git-over-HTTPS is **eligible** for placeholder
+    substitution on paper (the earlier "msb doesn't substitute git's HTTPS clone,
+    so GitHub is NOT bound" reading, last checked against 0.6.6, is superseded by
+    the 0.6.9 re-verify + the git-transport binding). The live git clone/push
+    confirmation on a KVM host is still pending; run
+    `scripts/verify-git-https-secret-msb` there for an explicit PASS/FAIL/BLOCKED
+    verdict. Kits still may use REST tarballs for reproducibility. This is the
+    bash subset of §7.5; the full
    Go/`go-keyring`/`age` + MITM `CredentialRewriteRule` + swap-on-access
    placeholder component remains a larger future effort. The earlier "msb uses
    raw host-env `--secret`, unified store deferred" note is superseded.
@@ -931,11 +940,15 @@ kit vocabulary** with a translation layer. Recorded in
    (iv) a sandbox that isn't exec-ready after create is a HARD failure —
    `msb create` returns 0 even when the guest fails to START, so earlier runs
    were false successes;
-   (v) secret substitution requires `--tls-intercept` (the interception CA is
-   auto-trusted in the guest), and only covers the `Authorization` header path
-   (USAi works); it does NOT work for git's HTTPS clone to github.com in 0.6.6,
-   so the private playbook clone is skipped on msb (tracked; microsandbox
-   #756/#768/#1170).
+    (v) secret substitution requires `--tls-intercept` (the interception CA is
+    auto-trusted in the guest). A static re-verification against msb 0.6.9 (the
+    installed version) confirms the engine rewrites HTTP request headers,
+    including the `Authorization: Basic` value git smart-HTTP uses, so
+    git-over-HTTPS to a bound github host is **eligible** for substitution on
+    paper (the earlier 0.6.6 reading that it "does NOT work for git's HTTPS clone"
+    is superseded — GitHub is now bound on msb, see the secret-model note above).
+    The live git clone/push confirmation on a KVM host is still pending; run
+    `scripts/verify-git-https-secret-msb` there for an explicit verdict.
 
 6. **`PATTERNS_KIT_REF` is pinned to the patterns v1.7.0 release commit**
    (`9c277c09ed4ad45fd11709d6b048a58adc785443`), which includes Part A (#221),

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -180,7 +180,7 @@ _line="msb"; for a in "$@"; do _line="$_line $a"; done
 printf '%s\n' "$_line" >>"$CALLS"
 _msb_sub="${1:-}"
 case "$_msb_sub" in
-  --version|-V) printf 'msb %s\n' "${STUB_MSB_VERSION:-0.6.8}" ;;
+  --version|-V) printf 'msb %s\n' "${STUB_MSB_VERSION:-0.6.9}" ;;
   --help|-h) printf 'MSB-TOPLEVEL-HELP for msb\n' ;;
   doctor)
     # Model host-readiness. Default: ready (exit 0), so the happy path is silent.
@@ -1903,13 +1903,13 @@ cleanup_stubs
 make_stubs
 out=$(ACQ_BACKEND=msb "$ACQ" version 2>&1)
 assert_contains "msb: version reports backend msb" "$out" "backend:     msb"
-assert_contains "msb: version reports msb ver" "$out" "0.6.8"
+assert_contains "msb: version reports msb ver" "$out" "0.6.9"
 cleanup_stubs
 
 # 8i. `acq backend list` shows a real msb row (not "coming in 1.2.x").
 make_stubs
 out=$("$ACQ" backend list 2>&1)
-assert_contains "msb: backend list shows msb version" "$out" "msb  v0.6.8"
+assert_contains "msb: backend list shows msb version" "$out" "msb  v0.6.9"
 assert_not_contains "msb: backend list drops 'coming in 1.2.x'" "$out" "Coming in 1.2.x"
 cleanup_stubs
 
@@ -1935,7 +1935,7 @@ cleanup_stubs
 # 8j. `acq doctor` probes msb with a real version (not the old placeholder).
 make_stubs
 out=$(printf 'n\n' | "$ACQ" doctor 2>&1)
-assert_contains "msb: doctor shows msb installed" "$out" "msb: installed v0.6.8"
+assert_contains "msb: doctor shows msb installed" "$out" "msb: installed v0.6.9"
 assert_not_contains "msb: doctor drops 'coming in 1.2.x'" "$out" "coming in 1.2.x"
 cleanup_stubs
 
@@ -2001,26 +2001,29 @@ make_stubs; load_acq
 cleanup_stubs
 
 # 8j5b. Version floor (BLOCKING fix): the balanced-egress default emits
-#        `--net-default-egress deny`, a flag that first appears in msb 0.6.8.
-#        MIN_MSB_VERSION is 0.6.8, so acq_backend_prepare MUST fail closed
-#        (nonzero exit + clear message) on any 0.6.0-0.6.7 binary, rather than
-#        letting `msb create` hit an unknown flag mid-create. The stub honors
-#        STUB_MSB_VERSION.
+#        `--net-default-egress deny` (first in msb 0.6.8) AND relies on the
+#        semantic `allow@dns` macro, which only parses correctly on release
+#        builds from msb 0.6.9 onward (the upstream release-build parser fix).
+#        MIN_MSB_VERSION is therefore 0.6.9, so acq_backend_prepare MUST fail
+#        closed (nonzero exit + clear message) on any binary older than 0.6.9,
+#        rather than letting `msb create` hit an unknown flag or DNS parse error
+#        mid-create. The stub honors STUB_MSB_VERSION.
 make_stubs; load_acq
 (
   # shellcheck source=acq
   ACQ_SOURCE_ONLY=1 . "$ACQ"
   . "${REPO_ROOT}/acq.backends/msb.sh"
   set +e
-  # A sub-floor binary (0.6.7) must be rejected before any create.
-  out=$(STUB_MSB_VERSION=0.6.7 ACQ_SKIP_MSB_DOCTOR=1 acq_backend_prepare 2>&1); rc=$?
-  assert_eq "msb: sub-0.6.8 binary fails the version floor" "1" "$rc"
-  assert_contains "msb: sub-floor message names the required version" "$out" "0.6.8"
-  # The pinned/current floor version (0.6.8) passes.
-  out2=$(STUB_MSB_VERSION=0.6.8 ACQ_SKIP_MSB_DOCTOR=1 acq_backend_prepare 2>&1); rc2=$?
-  assert_eq "msb: 0.6.8 binary clears the version floor" "0" "$rc2"
-  assert_not_contains "msb: 0.6.8 binary emits no version-floor error" "$out2" "0.6.8"
-) 2>/dev/null; pass "msb: version floor rejects sub-0.6.8, accepts 0.6.8"
+  # A sub-floor binary (0.6.8, previously accepted) must now be rejected before
+  # any create, because the 0.6.9 floor is required for the `allow@dns` macro.
+  out=$(STUB_MSB_VERSION=0.6.8 ACQ_SKIP_MSB_DOCTOR=1 acq_backend_prepare 2>&1); rc=$?
+  assert_eq "msb: sub-0.6.9 binary fails the version floor" "1" "$rc"
+  assert_contains "msb: sub-floor message names the required version" "$out" "0.6.9"
+  # The pinned/current floor version (0.6.9) passes.
+  out2=$(STUB_MSB_VERSION=0.6.9 ACQ_SKIP_MSB_DOCTOR=1 acq_backend_prepare 2>&1); rc2=$?
+  assert_eq "msb: 0.6.9 binary clears the version floor" "0" "$rc2"
+  assert_not_contains "msb: 0.6.9 binary emits no version-floor error" "$out2" "0.6.9"
+) 2>/dev/null; pass "msb: version floor rejects sub-0.6.9, accepts 0.6.9"
 cleanup_stubs
 
 # 8j5c. sbx version floor (BLOCKING): acq's neutral-kit translator emits the sbx
@@ -2643,7 +2646,7 @@ cat >"$STUBDIR/msb" <<'MSBSTUB2'
 #!/usr/bin/env bash
 { printf 'msb'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >>"$CALLS"
 case "${1:-}" in
-  --version|-V) printf 'msb %s\n' "${STUB_MSB_VERSION:-0.6.8}" ;;
+  --version|-V) printf 'msb %s\n' "${STUB_MSB_VERSION:-0.6.9}" ;;
   create) exit 0 ;;              # create "succeeds" but the guest never starts
   exec)   exit 1 ;;              # every exec fails -> never exec-ready
   *) exit 0 ;;
@@ -5307,9 +5310,10 @@ assert_not_contains "msb: port_ok empty invalid" "rc-$5" "rc-0"
 assert_not_contains "msb: port_ok non-integer invalid" "rc-$6" "rc-0"
 cleanup_stubs
 
-# 10b1f. `_acq_msb_balanced_rules_into` on a small custom hosts file: emits
-#        `allow@dns` first, translates wildcards/crl*, preserves dual-port hosts,
-#        emits bare (no :tcp:) for a port-less entry, and skips comments/blanks.
+# 10b1f. `_acq_msb_balanced_rules_into` on a small custom hosts file: emits the
+#        `allow@dns` macro first, translates wildcards/crl*, preserves dual-port
+#        hosts, emits bare (no :tcp:) for a port-less entry, and skips
+#        comments/blanks.
 make_stubs; load_acq
 cat >"$STUBDIR/bal-hosts.txt" <<'HOSTS'
 # a comment line
@@ -5328,8 +5332,9 @@ bal_out=$(
   _acq_msb_balanced_rules_into arr 2>/dev/null
   printf '%s\n' "${arr[@]}"
 )
-assert_contains "msb: balanced rules emit gateway DNS (udp/53)" "$bal_out" "allow@host:udp:53"
-assert_contains "msb: balanced rules emit gateway DNS (tcp/53)" "$bal_out" "allow@host:tcp:53"
+assert_contains "msb: balanced rules emit gateway DNS via allow@dns macro" "$bal_out" "allow@dns"
+assert_not_contains "msb: balanced rules do not emit expanded udp/53 pair" "$bal_out" "allow@host:udp:53"
+assert_not_contains "msb: balanced rules do not emit expanded tcp/53 pair" "$bal_out" "allow@host:tcp:53"
 assert_contains "msb: balanced rules translate **.h wildcard" "$bal_out" "allow@*.github.com:tcp:443"
 assert_contains "msb: balanced rules keep exact domain" "$bal_out" "allow@github.com:tcp:443"
 assert_contains "msb: balanced rules keep dual-port :443" "$bal_out" "allow@dhi.io:tcp:443"
@@ -5342,9 +5347,9 @@ cleanup_stubs
 
 # 10b1g. `_acq_msb_balanced_rules_into` skips a malformed line (a host with a
 #        shell metacharacter) with a warning, but still emits the gateway-DNS
-#        rules. It must NOT emit the bare `allow@dns` macro, which is broken on
-#        released msb (release builds drop the debug_assert that advances past the
-#        `dns` target, so `dns` is re-read as the protocol and msb rejects it).
+#        rule. That rule is the semantic `allow@dns` macro (safe since acq
+#        requires msb >= 0.6.9, the upstream release-build parser fix), NOT the
+#        old expanded udp/tcp:53 pair.
 make_stubs; load_acq
 cat >"$STUBDIR/bal-bad.txt" <<'HOSTS'
 bad;host:443
@@ -5358,8 +5363,8 @@ bad_out=$(
   printf '%s\n' "${arr[@]}"
 )
 assert_not_contains "msb: balanced rules skip malformed host" "$bad_out" "bad;host"
-assert_contains "msb: balanced rules still emit gateway DNS after skip" "$bad_out" "allow@host:udp:53"
-assert_not_contains "msb: balanced rules never emit the broken allow@dns macro" "$bad_out" "allow@dns"
+assert_contains "msb: balanced rules still emit gateway DNS (allow@dns) after skip" "$bad_out" "allow@dns"
+assert_not_contains "msb: balanced rules no longer emit the expanded DNS pair" "$bad_out" "allow@host:udp:53"
 cleanup_stubs
 
 # 10b1h. The REAL vendored balanced-hosts file parses cleanly: no "skipping"
@@ -5399,8 +5404,8 @@ bal_prov_log=$(cat "$CALLS")
 assert_contains "msb: default provision emits --net-default-egress deny" "$bal_prov_log" "--net-default-egress deny"
 assert_not_contains "msb: default provision does NOT emit symmetric --net-default deny" "$bal_prov_log" "--net-default deny"
 assert_not_contains "msb: default provision does NOT deny ingress" "$bal_prov_log" "--net-default-ingress deny"
-assert_contains "msb: default provision emits gateway DNS (udp/53)" "$bal_prov_log" "allow@host:udp:53"
-assert_contains "msb: default provision emits gateway DNS (tcp/53)" "$bal_prov_log" "allow@host:tcp:53"
+assert_contains "msb: default provision emits gateway DNS (allow@dns)" "$bal_prov_log" "allow@dns"
+assert_not_contains "msb: default provision does NOT emit expanded udp/53 pair" "$bal_prov_log" "allow@host:udp:53"
 assert_contains "msb: default provision emits a balanced host rule" "$bal_prov_log" "allow@api.anthropic.com:tcp:443"
 cleanup_stubs
 
@@ -5421,7 +5426,7 @@ make_stubs; load_acq
 )
 bal_off_log=$(cat "$CALLS")
 assert_contains "msb: deprecated =0 maps to strict — still emits deny-default" "$bal_off_log" "--net-default-egress deny"
-assert_contains "msb: deprecated =0 (strict) still emits gateway DNS" "$bal_off_log" "allow@host:udp:53"
+assert_contains "msb: deprecated =0 (strict) still emits gateway DNS (allow@dns)" "$bal_off_log" "allow@dns"
 assert_not_contains "msb: deprecated =0 (strict) omits balanced host rules" "$bal_off_log" "allow@api.anthropic.com"
 
 # 10b1j2. The deprecated alias prints a one-time deprecation notice on stderr,
@@ -5488,8 +5493,8 @@ make_stubs; load_acq
 )
 strict_log=$(cat "$CALLS")
 assert_contains "msb: strict emits deny-default" "$strict_log" "--net-default-egress deny"
-assert_contains "msb: strict emits gateway DNS (udp/53)" "$strict_log" "allow@host:udp:53"
-assert_contains "msb: strict emits gateway DNS (tcp/53)" "$strict_log" "allow@host:tcp:53"
+assert_contains "msb: strict emits gateway DNS (allow@dns)" "$strict_log" "allow@dns"
+assert_not_contains "msb: strict does NOT emit expanded udp/53 pair" "$strict_log" "allow@host:udp:53"
 assert_not_contains "msb: strict omits the curated baseline" "$strict_log" "allow@api.anthropic.com"
 cleanup_stubs
 
@@ -5931,7 +5936,7 @@ PQSTUB="$STUBDIR/pq"; mkdir -p "$PQSTUB"
 cat >"$PQSTUB/msb" <<'PQ'
 #!/usr/bin/env bash
 snip=""; prev=""; for a in "$@"; do [ "$prev" = "-c" ] && { snip="$a"; break; }; prev="$a"; done
-case "$1" in --version) echo "msb 0.6.8"; exit 0;; esac
+case "$1" in --version) echo "msb 0.6.9"; exit 0;; esac
 # The prereq check runs a snippet containing "command -v"; emit MSB_MISSING.
 case "$snip" in *"command -v"*) printf '%s' "${MSB_MISSING:-}"; exit 0;; esac
 exit 0

--- a/scripts/verify-git-https-secret-msb
+++ b/scripts/verify-git-https-secret-msb
@@ -1,0 +1,198 @@
+#!/usr/bin/env sh
+#
+# verify-git-https-secret-msb — LIVE, one-command answer to a single question:
+#   Does msb substitute a bound GITHUB_TOKEN placeholder on git's HTTPS
+#   (smart-HTTP) transport, so a `git clone`/`git ls-remote` of a PRIVATE repo
+#   authenticates without the real token ever entering the guest?
+#
+# WHY THIS SCRIPT EXISTS
+#   ADR-0011 / ADR-0013 / docs/explorations/acq-design.md claim git-over-HTTPS is
+#   ELIGIBLE for msb secret substitution: git carries its credential in an
+#   `Authorization: Basic` header, and msb's substitution engine rewrites that
+#   header on an intercepted, host-matched TLS connection. That claim was
+#   re-verified STATICALLY against msb 0.6.9 source/docs, but the static review
+#   cannot PROVE the connection is intercepted and rewritten end-to-end at run
+#   time. This script settles it with a real clone on a KVM-capable host.
+#
+# WHAT IT DOES
+#   1. Preconditions (fail closed): msb on PATH and >= 0.6.9; GITHUB_TOKEN set;
+#      GIT_HTTPS_TEST_REPO set to a PRIVATE https github repo URL you control.
+#   2. Creates a throwaway alpine msb sandbox with `--tls-intercept`, deny-default
+#      egress, and allow rules for the github hosts + gateway DNS, binding
+#      GITHUB_TOKEN@github.com,api.github.com,codeload.github.com. The guest sees
+#      ONLY a placeholder.
+#   3. Inside the guest, runs `git ls-remote <repo>` using the placeholder as the
+#      password in the URL. If msb substitutes the placeholder on the wire, the
+#      authenticated request succeeds; if not, it fails with an auth error.
+#   4. Prints an explicit PASS / FAIL / BLOCKED verdict and removes the sandbox.
+#
+# VERDICT MEANING
+#   PASS    -> msb DID substitute on git-HTTPS. The ADR "eligible" claim is
+#              LIVE-CONFIRMED. Nothing to change.
+#   FAIL    -> msb did NOT substitute (auth failed with the placeholder). The
+#              ADR "eligible" claim is STALE for the live path; update ADR-0011
+#              and ADR-0013 to say git-HTTPS substitution does not work and the
+#              github secret should not be relied on for git transport on msb.
+#   BLOCKED -> a precondition or environment issue prevented a real test; the
+#              question is unanswered. (Never treated as PASS.)
+#
+# SECURITY
+#   The real GITHUB_TOKEN value is NEVER printed, logged, or written to disk by
+#   this script. It is handed to msb via `--secret ENV@HOST` (msb reads it from
+#   this process's environment and swaps it on the wire); the guest and this
+#   script's output only ever see the placeholder string.
+#
+# USAGE (one command, on a KVM-capable host with msb 0.6.9):
+#   GITHUB_TOKEN=... GIT_HTTPS_TEST_REPO=https://github.com/you/private.git \
+#     ./scripts/verify-git-https-secret-msb
+#
+# Exit status: 0 on PASS; non-zero on FAIL or BLOCKED.
+
+set -u
+
+# msb's default guest-env placeholder for a bound secret is `$MSB_<ENV_VAR>`.
+# We embed it in the clone URL as the password; msb rewrites it to the real
+# token on the intercepted connection to an allowed github host.
+PLACEHOLDER='$MSB_GITHUB_TOKEN'
+GITHUB_HOSTS='github.com,api.github.com,codeload.github.com'
+IMAGE="${ACQ_MSB_IMAGE:-alpine}"
+DNS_NS="${ACQ_MSB_DNS_NAMESERVER:-1.1.1.1}"
+SANDBOX="acq-gitsecret-verify-$$"
+MIN_MSB="0.6.9"
+
+# --- tiny helpers ------------------------------------------------------------
+
+# Emit a verdict line to stdout. Never interpolates the secret.
+say() { printf '%s\n' "$*"; }
+
+blocked() {
+  say "VERDICT: BLOCKED — $*"
+  say "(No conclusion: the live substitution question was not answered.)"
+  exit 2
+}
+
+# Compare two dotted versions: prints 0 if $1 >= $2, else 1. POSIX-only.
+version_ge() {
+  _a="$1"
+  _b="$2"
+  # Highest version first; if $1 sorts first (or equal), it is >= $2.
+  _top=$(printf '%s\n%s\n' "$_a" "$_b" | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1)
+  [ "$_top" = "$_a" ] && { printf '0\n'; return; }
+  printf '1\n'
+}
+
+# Best-effort teardown; guarded so a partial failure still cleans up.
+cleanup() {
+  msb remove --force "$SANDBOX" >/dev/null 2>&1 || true
+}
+
+# --- preconditions (fail closed) --------------------------------------------
+
+command -v msb >/dev/null 2>&1 || blocked "msb is not on PATH."
+
+# Bare X.Y.Z from `msb --version` (matches acq.backends/msb.sh:_acq_msb_version).
+MSB_VER=$(msb --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1)
+[ -n "$MSB_VER" ] || blocked "could not determine msb version (need >= $MIN_MSB)."
+[ "$(version_ge "$MSB_VER" "$MIN_MSB")" -eq 0 ] || \
+  blocked "msb $MSB_VER is older than the required $MIN_MSB."
+
+# Presence check only — never inspect or print the value.
+[ -n "${GITHUB_TOKEN:-}" ] || \
+  blocked "GITHUB_TOKEN is not set (export a token for a repo you control)."
+
+REPO="${GIT_HTTPS_TEST_REPO:-}"
+[ -n "$REPO" ] || blocked \
+  "GIT_HTTPS_TEST_REPO is not set. Set it to a PRIVATE https github repo URL you control, e.g. https://github.com/you/private.git"
+
+case "$REPO" in
+  https://github.com/*) : ;;
+  *) blocked "GIT_HTTPS_TEST_REPO must be an https://github.com/... URL (got a non-github or non-https URL)." ;;
+esac
+
+say "msb version: $MSB_VER (>= $MIN_MSB) — OK"
+say "Test repo:   $REPO"
+say "Creating throwaway sandbox '$SANDBOX' (image: $IMAGE)..."
+
+trap cleanup EXIT INT TERM
+
+# --- create the sandbox ------------------------------------------------------
+#
+# deny-default egress + explicit allow for DNS and each github host, TLS
+# interception on (required for substitution), and the github token bound to the
+# three git/API hosts. msb reads GITHUB_TOKEN from this environment for the
+# --secret binding; it is not passed on argv.
+if ! msb create --name "$SANDBOX" \
+      --net-default-egress deny \
+      --net-rule "allow@dns" \
+      --net-rule "allow@github.com" \
+      --net-rule "allow@api.github.com" \
+      --net-rule "allow@codeload.github.com" \
+      --tls-intercept \
+      --dns-nameserver "$DNS_NS" \
+      --secret "GITHUB_TOKEN@${GITHUB_HOSTS}" \
+      "$IMAGE" >/dev/null 2>&1; then
+  blocked "'msb create' failed (need a KVM-capable host; cannot run inside a sandbox)."
+fi
+
+# Wait for the guest to become exec-ready (msb create returns before boot).
+say "Waiting for the guest to become exec-ready..."
+_ready=0
+_attempt=0
+while [ "$_attempt" -lt 60 ]; do
+  _attempt=$((_attempt + 1))
+  if [ "$(msb exec "$SANDBOX" -- sh -c 'echo ok' </dev/null 2>/dev/null | tr -d '\r')" = "ok" ]; then
+    _ready=1
+    break
+  fi
+  sleep 1
+done
+[ "$_ready" -eq 1 ] || blocked "guest never became exec-ready within 60s."
+
+# Ensure git is available in the guest (alpine ships without it).
+if ! msb exec "$SANDBOX" -- sh -c 'command -v git >/dev/null 2>&1' </dev/null >/dev/null 2>&1; then
+  say "Installing git in the guest..."
+  # apk needs egress; alpine's CDN isn't in our allow-list, so widen just for
+  # this bootstrap by reaching the default mirror. If it fails, we cannot test.
+  if ! msb exec "$SANDBOX" -u 0 -- sh -c 'apk add --no-cache git >/dev/null 2>&1' </dev/null >/dev/null 2>&1; then
+    blocked "could not install git in the guest (alpine apk mirror not reachable under deny-default egress). Re-run with ACQ_MSB_IMAGE set to an image that already ships git, or allow the apk mirror host."
+  fi
+fi
+
+# --- run the authenticated git operation ------------------------------------
+#
+# Build an https URL that carries the PLACEHOLDER as the password. Only msb can
+# turn it into the real token, and only on an intercepted, host-matched
+# connection. `x-access-token` is GitHub's conventional username for a PAT.
+#
+# The placeholder is a literal string here; the guest never holds the real
+# value. We disable the credential helper and any prompt so the URL creds are
+# the only auth path, and force a non-interactive failure instead of a hang.
+REPO_HOST_PATH=${REPO#https://}
+AUTH_URL="https://x-access-token:${PLACEHOLDER}@${REPO_HOST_PATH}"
+
+say "Running 'git ls-remote' against the private repo (placeholder as credential)..."
+# GIT_TERMINAL_PROMPT=0 => fail instead of prompting when auth is missing/rejected.
+if msb exec "$SANDBOX" -- \
+     env GIT_TERMINAL_PROMPT=0 \
+     git -c credential.helper= ls-remote "$AUTH_URL" HEAD </dev/null >/dev/null 2>&1; then
+  say ""
+  say "VERDICT: PASS — msb substituted the placeholder on git-HTTPS."
+  say "  The authenticated 'git ls-remote' of the private repo SUCCEEDED using"
+  say "  only the placeholder, so msb rewrote the Authorization header on the"
+  say "  wire. The ADR-0011 / ADR-0013 'git-HTTPS eligible' claim is"
+  say "  LIVE-CONFIRMED against msb ${MSB_VER}. No doc change needed."
+  exit 0
+else
+  say ""
+  say "VERDICT: FAIL — msb did NOT substitute the placeholder on git-HTTPS."
+  say "  The authenticated 'git ls-remote' of the private repo FAILED with the"
+  say "  placeholder, so msb did not rewrite git's Authorization header on the"
+  say "  wire (against msb ${MSB_VER}). The ADR 'git-HTTPS eligible' claim is"
+  say "  STALE for the live path — update ADR-0011 and ADR-0013 to state that"
+  say "  git-over-HTTPS substitution does not work on msb and the github secret"
+  say "  should not be relied on for git transport there."
+  say ""
+  say "  (Sanity check before trusting a FAIL: confirm the repo is private and"
+  say "  the token genuinely grants it — a wrong token/repo also fails auth.)"
+  exit 1
+fi


### PR DESCRIPTION
## Context

microsandbox **0.6.9** shipped the upstream release-build parser fix for the semantic `allow@dns` macro (the target-iterator advance was moved out of the `debug_assert`, so it now runs on release binaries). This unblocks the DNS-grant collapse tracked in GSA-TTS/agentic-coding-quickstart#314 and prompts a re-verification of the git-over-HTTPS secret-substitution claim tracked in GSA-TTS/agentic-coding-quickstart#315.

## Plan / Changes

**1. Collapse gateway-DNS grant + raise floor (Fixes GSA-TTS/agentic-coding-quickstart#314)**
- Raise `MIN_MSB_VERSION` 0.6.8 → 0.6.9 in `acq.backends/msb.sh` so acq fails closed on binaries with the broken parser.
- Collapse the balanced/strict gateway-DNS grant from the expanded `allow@host:udp:53` + `allow@host:tcp:53` workaround back to the native `allow@dns` macro (both call sites).
- Update offline `scripts/test-acq` DNS-rule assertions to expect `allow@dns` and assert the expanded pair is gone.
- Mark ADR-0018 + `KNOWN_FAILURE_MODES` §32 resolved for supported (≥0.6.9) versions.

**2. Re-verify git-HTTPS secret substitution (Refs GSA-TTS/agentic-coding-quickstart#315)**
- Static re-verification against msb 0.6.9 source/docs: the 0.6.6→0.6.9 diff shows no change to the Authorization/Basic-auth header substitution path, so git smart-HTTP remains eligible for substitution on an intercepted, host-matched TLS connection.
- Update ADR-0011, ADR-0013, and `docs/explorations/acq-design.md` to cite the 0.6.9 static re-verification (superseding "verified against 0.6.6") and note the live clone/push loop is still pending on a KVM-capable host.
- Add `scripts/verify-git-https-secret-msb`: a live, one-command PASS/FAIL/BLOCKED probe that binds `GITHUB_TOKEN` with `--tls-intercept` and runs `git ls-remote` of a private repo from inside the guest. It cannot run inside a sandbox (needs KVM) and never prints the real token value.

## Verification

- Offline suite (`scripts/test-acq`): **871 passed, 0 failed**.
- `shellcheck` clean (one file per invocation, `--severity=warning`).
- markdown lint clean.
- Live git-HTTPS probe (`scripts/verify-git-https-secret-msb`): **BLOCKED** — requires a KVM-capable host; cannot run in the current sandbox. Static re-verification stands in until it can run.

## Rollback

Revert the two commits (`2bfb332`, `5032677`). Reverting the floor bump restores compatibility with ≤0.6.8, but the expanded DNS-pair workaround must also be restored for those binaries.

## Security Impact

- Version floor now **fails closed** on msb <0.6.9 (stricter).
- No change to the secret-substitution security model — git-HTTPS token substitution behavior is unchanged upstream (statically re-verified).
- The new probe never emits the real token value.

## AI Assistance

AI-assisted (OpenCode, claude_4_8_opus). See `Co-authored-by` trailers on each commit.