### PR TITLE
fix(http-test): Ensure the test can install git in alpine

### DIFF
--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -323,11 +323,11 @@ allow@HOST --trust-host-cas --tls-intercept --secret ENV@HOST --volume`,
   REST API plus HTTPS git-transport hosts
   (`GITHUB_TOKEN@github.com,api.github.com,codeload.github.com`). msb
   substitutes the placeholder on those hosts, so direct HTTPS clone/push is
-  eligible for secret injection without the real token entering the guest — see
-  the eligibility note immediately below for the static-vs-live status of the
-  git-transport claim.
-- **GitHub git-HTTPS substitution eligibility (re-verified statically against
-  msb 0.6.9; live git clone/push still pending on a KVM host):** the msb
+  eligible for secret injection without the real token entering the guest. The
+  credential-substitution path for git smart-HTTP was live-confirmed against
+  msb 0.6.9 with `scripts/verify-git-https-secret-msb`, which authenticated a
+  private-repo `git ls-remote` using only the guest placeholder.
+- **GitHub git-HTTPS substitution (live-confirmed against msb 0.6.9):** the msb
   secret-substitution engine substitutes a placeholder only on a TLS-intercepted
   connection whose SNI/authority matches the bound host (the `--tls-intercept`
   requirement is unchanged in 0.6.9). Its request rewriting covers HTTP request
@@ -347,13 +347,11 @@ allow@HOST --trust-host-cas --tls-intercept --secret ENV@HOST --volume`,
   (`crates/network/lib/secrets/handler.rs`, `.../config.rs`) and docs
   (`docs/security/secrets.mdx`); the 0.6.6→0.6.9 diff shows no change to the
   header/Basic-auth substitution path and nothing added or removed for
-  git/smart-HTTP specifically. **What the static review does not prove:** that
-  msb actually intercepts and rewrites git's connection end-to-end (git's
-  credential-helper prompt, TLS handshake against the interception CA, and the
-  authority checks must all line up at run time). That confirmation requires a
-  live `git clone`/`git ls-remote` of a private repo on a KVM-capable host and is
-  still pending; run `scripts/verify-git-https-secret-msb` there to settle it
-  (it prints an explicit PASS/FAIL/BLOCKED verdict and never echoes the token).
+  git/smart-HTTP specifically. The runtime path was then live-confirmed on a
+  KVM-capable host with `scripts/verify-git-https-secret-msb`: a private-repo
+  `git ls-remote` succeeded using only the guest placeholder as the URL
+  credential, proving msb intercepted the TLS connection and rewrote git's
+  `Authorization: Basic` header without the real token entering the guest.
 
 ### `environment` vocabulary (guest env vars)
 
@@ -408,11 +406,11 @@ identical host:guest `/tmp` mounts silently fail (→ fixed guest mount point);
 the host resolver is unreachable from the microVM (→ `--dns-nameserver`); the
 kits assume an `agent`/`/home/agent` user a plain base lacks (→ create it);
 secret substitution requires `--tls-intercept` and, per a static re-verification
-against msb 0.6.9, rewrites HTTP request headers (including the
-`Authorization: Basic` value git smart-HTTP uses) — so git-over-HTTPS is
-eligible on paper, though the live git clone/push confirmation is still pending
-on a KVM host (see the eligibility note above and
-`scripts/verify-git-https-secret-msb`).
+against msb 0.6.9 plus live verification with
+`scripts/verify-git-https-secret-msb`, rewrites HTTP request headers (including
+the `Authorization: Basic` value git smart-HTTP uses). git-over-HTTPS auth to a
+bound GitHub host is therefore live-confirmed for a private-repo `git ls-remote`
+using only the guest placeholder.
 
 ## Validation
 
@@ -429,10 +427,9 @@ on a KVM host (see the eligibility note above and
   `scripts/verify-backends` msb rows (now including the `opencode`-installed
   assertion added for quickstart#228) cannot run inside an sbx/msb sandbox and
   need host virtualization (`/dev/kvm` on Linux). The msb CLI flag shapes were
-  verified against `msb 0.6.6` and the secret-substitution behavior was
-  re-verified statically against `msb 0.6.9` (0.6.9 is the installed version;
-  see the git-HTTPS eligibility note above — the live git clone/push loop is the
-  one piece still deferred to a KVM host); the live loop mirrors how
+  verified against `msb 0.6.6`, and the git-HTTPS secret-substitution behavior
+  was re-verified statically and live-confirmed with a private-repo
+  `git ls-remote` against `msb 0.6.9`; the remaining live loop mirrors how
   ADR-0009/ADR-0010 defer live verification. Run `./scripts/verify-backends`
   on a sandbox-capable host and attach the transcript. **The quickstart#228 fix
   (agent install + attach launch) is verified offline via the stubbed harness;

--- a/docs/adr/0013-per-sandbox-github-token-downscoping.md
+++ b/docs/adr/0013-per-sandbox-github-token-downscoping.md
@@ -150,11 +150,11 @@ wrapper that only holds the user's `gh` token:
 - **msb backend:** `msb` binds the `github` secret to the REST API and
   git-transport hosts (`msb.sh`; see ADR-0011). A static re-verification against
   msb 0.6.9 found the substitution engine rewrites the `Authorization: Basic`
-  header git smart-HTTP uses, so a scoped token is eligible for injection on both
-  REST and HTTPS git transport without the real value entering the guest — the
-  same least-privilege scoping this ADR describes applies unchanged. The live
-  git clone/push confirmation on a KVM host is still pending (ADR-0011), so treat
-  msb git-HTTPS auth as eligible-but-not-yet-live-verified.
+  header git smart-HTTP uses, and a live `scripts/verify-git-https-secret-msb`
+  run against a private repo confirmed `git ls-remote` succeeds using only the
+  guest placeholder. A scoped token is therefore injected for both REST and HTTPS
+  git transport without the real value entering the guest, so the same
+  least-privilege scoping this ADR describes applies unchanged.
 - **Deprecation, not removal:** the global path keeps working, so existing setups
   are not broken; new guidance steers to per-sandbox scoping.
 - **Audit (AU-2):** scoping is per-sandbox and named, so which credential a

--- a/docs/explorations/acq-design.md
+++ b/docs/explorations/acq-design.md
@@ -898,14 +898,13 @@ kit vocabulary** with a translation layer. Recorded in
     re-verification against msb 0.6.9 (the installed version) confirms the
     substitution engine still requires `--tls-intercept` and rewrites HTTP
     request headers — including the `Authorization: Basic` value git smart-HTTP
-    carries its credential in — so git-over-HTTPS is **eligible** for placeholder
-    substitution on paper (the earlier "msb doesn't substitute git's HTTPS clone,
-    so GitHub is NOT bound" reading, last checked against 0.6.6, is superseded by
-    the 0.6.9 re-verify + the git-transport binding). The live git clone/push
-    confirmation on a KVM host is still pending; run
-    `scripts/verify-git-https-secret-msb` there for an explicit PASS/FAIL/BLOCKED
-    verdict. Kits still may use REST tarballs for reproducibility. This is the
-    bash subset of §7.5; the full
+    carries its credential in — and a live
+    `scripts/verify-git-https-secret-msb` run against a private repo confirmed
+    `git ls-remote` succeeds using only the guest placeholder. The earlier
+    0.6.6-era non-binding assumption is superseded by the 0.6.9 re-verify, the
+    git-transport binding, and the live git-HTTPS confirmation. Kits still may
+    use REST tarballs for reproducibility. This is the bash subset of §7.5; the
+    full
    Go/`go-keyring`/`age` + MITM `CredentialRewriteRule` + swap-on-access
    placeholder component remains a larger future effort. The earlier "msb uses
    raw host-env `--secret`, unified store deferred" note is superseded.
@@ -944,11 +943,11 @@ kit vocabulary** with a translation layer. Recorded in
     auto-trusted in the guest). A static re-verification against msb 0.6.9 (the
     installed version) confirms the engine rewrites HTTP request headers,
     including the `Authorization: Basic` value git smart-HTTP uses, so
-    git-over-HTTPS to a bound github host is **eligible** for substitution on
-    paper (the earlier 0.6.6 reading that it "does NOT work for git's HTTPS clone"
-    is superseded — GitHub is now bound on msb, see the secret-model note above).
-    The live git clone/push confirmation on a KVM host is still pending; run
-    `scripts/verify-git-https-secret-msb` there for an explicit verdict.
+    git-over-HTTPS to a bound github host is eligible for substitution, and a
+    live private-repo `git ls-remote` with
+    `scripts/verify-git-https-secret-msb` confirmed that substitution path works
+    at runtime. The earlier 0.6.6-era negative reading is superseded — GitHub is
+    now bound on msb, see the secret-model note above.
 
 6. **`PATTERNS_KIT_REF` is pinned to the patterns v1.7.0 release commit**
    (`9c277c09ed4ad45fd11709d6b048a58adc785443`), which includes Part A (#221),

--- a/scripts/verify-git-https-secret-msb
+++ b/scripts/verify-git-https-secret-msb
@@ -52,9 +52,11 @@ set -u
 
 # msb's default guest-env placeholder for a bound secret is `$MSB_<ENV_VAR>`.
 # We embed it in the clone URL as the password; msb rewrites it to the real
-# token on the intercepted connection to an allowed github host.
-PLACEHOLDER='$MSB_''GITHUB_TOKEN' # Avoids unintentional substitution in git; see superradcompany/microsandbox#1354
+# token on the intercepted connection to an allowed github host. Split the
+# literal so host-side tooling does not substitute it before git sees it.
+PLACEHOLDER='$MSB_''GITHUB_TOKEN'
 GITHUB_HOSTS='github.com,api.github.com,codeload.github.com'
+APK_HOST='dl-cdn.alpinelinux.org'
 IMAGE="${ACQ_MSB_IMAGE:-alpine}"
 DNS_NS="${ACQ_MSB_DNS_NAMESERVER:-1.1.1.1}"
 SANDBOX="acq-gitsecret-verify-$$"
@@ -119,14 +121,17 @@ trap cleanup EXIT INT TERM
 #
 # deny-default egress + explicit allow for DNS and each github host, TLS
 # interception on (required for substitution), and the github token bound to the
-# three git/API hosts. msb reads GITHUB_TOKEN from this environment for the
-# --secret binding; it is not passed on argv.
+# three git/API hosts. Alpine's default apk mirror is allowed only so the guest
+# can install git when the selected image does not already include it. msb reads
+# GITHUB_TOKEN from this environment for the --secret binding; it is not passed
+# on argv.
 if ! msb create --name "$SANDBOX" \
       --net-default-egress deny \
       --net-rule "allow@dns" \
       --net-rule "allow@github.com" \
       --net-rule "allow@api.github.com" \
       --net-rule "allow@codeload.github.com" \
+  --net-rule "allow@${APK_HOST}" \
       --tls-intercept \
       --dns-nameserver "$DNS_NS" \
       --secret "GITHUB_TOKEN@${GITHUB_HOSTS}" \
@@ -151,10 +156,9 @@ done
 # Ensure git is available in the guest (alpine ships without it).
 if ! msb exec "$SANDBOX" -- sh -c 'command -v git >/dev/null 2>&1' </dev/null >/dev/null 2>&1; then
   say "Installing git in the guest..."
-  # apk needs egress; alpine's CDN isn't in our allow-list, so widen just for
-  # this bootstrap by reaching the default mirror. If it fails, we cannot test.
+  # apk needs egress to Alpine's default mirror. If it fails, we cannot test.
   if ! msb exec "$SANDBOX" -u 0 -- sh -c 'apk add --no-cache git >/dev/null 2>&1' </dev/null >/dev/null 2>&1; then
-    blocked "could not install git in the guest (alpine apk mirror not reachable under deny-default egress). Re-run with ACQ_MSB_IMAGE set to an image that already ships git, or allow the apk mirror host."
+    blocked "could not install git in the guest (alpine apk mirror $APK_HOST not reachable under deny-default egress). Re-run with ACQ_MSB_IMAGE set to an image that already ships git."
   fi
 fi
 


### PR DESCRIPTION
## Summary

Verifies that the msb git http substitution requests to github.com happens

## Related Issues

Fixes #315 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits format](../CONTRIBUTING.md#commit-message-guidelines) (e.g., `feat:`, `fix:`, `docs:`)
- [x] I have tested my changes locally
- [x] I have updated documentation as needed
- [x] I have not included any secrets, API keys, or sensitive information

## Test Results

Verified on my host:
```
bretamogilefsky@F09R9J-QWH7C7MK agentic-coding-quickstart % GITHUB_TOKEN="$(gh auth token)" \
GIT_HTTPS_TEST_REPO=https://github.com/mogul/private.git \
  ./scripts/verify-git-https-secret-msb
msb version: 0.6.9 (>= 0.6.9) — OK
Test repo:   https://github.com/mogul/private.git
Creating throwaway sandbox 'acq-gitsecret-verify-78157' (image: alpine)...
Waiting for the guest to become exec-ready...
Installing git in the guest...
Running 'git ls-remote' against the private repo (placeholder as credential)...

VERDICT: PASS — msb substituted the placeholder on git-HTTPS.
  The authenticated 'git ls-remote' of the private repo SUCCEEDED using
  only the placeholder, so msb rewrote the Authorization header on the
  wire. The ADR-0011 / ADR-0013 'git-HTTPS eligible' claim is
  LIVE-CONFIRMED against msb 0.6.9. No doc change needed.
```

## Additional Notes

None.