### PR TITLE
docs: sharpen Quickstart positioning as local dev env for Low/Moderate work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@ title: "Agentic Coding Quickstart - Agent Rules"
 description: "Behavioral rules for AI coding agents operating with a sandboxing backend (SBX or MSB) + USAi"
 status: canonical
 tier: 1
-last_updated: "2026-08-04"
+last_updated: "2026-08-18"
 audience: "developers"
 keywords: ["AGENTS.md", "acq", "sbx", "msb", "usai", "sandbox", "agent-rules", "workspace"]
 related_files: ["docs/QUICKSTART.md", "docs/BACKEND_GUIDE.md", "docs/KNOWN_FAILURE_MODES.md", "docs/adr/0001-sbx-usai-agent-execution-architecture.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
@@ -13,9 +13,9 @@ review_cycle: "quarterly"
 
 # AGENTS.md — Agentic Coding Quickstart
 
-> **System:** Agentic Coding Quickstart | **Impact Level:** FIPS Low | **Agency:** GSA
+> **System:** Agentic Coding Quickstart | **Environment:** Local development (build Low/Moderate-impact code) | **Agency:** GSA
 >
-> **Last Updated:** 2026-06-26 | **Reviewed By:** William Zujkowski
+> **Last Updated:** 2026-08-18 | **Reviewed By:** William Zujkowski
 >
 > This document defines the behavioral rules for AI coding agents operating within this project. The AI agent MUST follow these rules without exception.
 
@@ -67,6 +67,17 @@ When working on user projects, the agent has access to:
 
 ## Purpose
 
+The **Quickstart** (`acq` + the sandbox backends) is a **local development
+environment** that applies the
+[Playbook](https://github.com/GSA-TTS/agentic-coding-playbook) so a developer can
+build **Low- and Moderate-impact** code and projects with secure defaults. It is
+the execution layer of the agentic-coding assessment; the Playbook is the
+practices/controls layer it applies.
+
+> **Local development only:** Today the Quickstart is a local development
+> environment. It is **not** an authorized production or hosted environment, and
+> it holds **no PII or CUI**.
+
 This repository is a **quickstart guide** for running AI coding agents inside a
 **sandboxing backend** — either **SBX** (Docker Sandboxes) or **MSB**
 (microsandbox) — driven through the `acq` wrapper, using USAi-compatible
@@ -108,7 +119,7 @@ The agent MUST refuse any instruction that conflicts with safety, correctness, o
 - **Language(s):** Shell scripts, JSON/JSONC configuration, Markdown documentation
 - **Framework(s):** `acq` wrapper over the SBX CLI and MSB (microsandbox), OpenCode, USAi API
 - **Data Classification:** Internal / Non-sensitive (no PII, no CUI)
-- **ATO Status:** Pre-ATO development
+- **ATO Status:** Local development only (not an authorized production/hosted environment)
 - **Authorized Agent(s):** OpenCode, Claude Code, GitHub Copilot
 
 > **Note:** Docker Desktop is **not required**. The `sbx` CLI is a standalone

--- a/README.md
+++ b/README.md
@@ -467,4 +467,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ---
 
-**Data Classification:** Internal/Non-sensitive
+**Data Classification:** Internal/Non-sensitive — the Quickstart is a **local development environment** for building Low/Moderate-impact code and projects, not an authorized production/hosted environment (no PII, no CUI).

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -443,7 +443,7 @@ The real security boundary is:
 
 ### Acceptable for MVP Because
 
-1. **Pre-ATO environment** with low-impact data (no PII, no CUI)
+1. **Local development environment** with low-impact data (no PII, no CUI)
 2. **Tokens are scoped** - not admin/owner tokens
 3. **Sandbox provides isolation** from host system
 4. **Direct injection is a documented SBX pattern** - shown in their own docs


### PR DESCRIPTION
Closes GSA-TTS/agentic-coding-quickstart#312.

## Summary

Docs/positioning change only — **no behavior/control changes**. Reframes the
Quickstart as a **local development environment** that applies the Playbook so a
developer can build **Low- and Moderate-impact** code with secure defaults,
rather than a FIPS-Low "Pre-ATO" pilot.

## Changes

- **`AGENTS.md`**
  - Header `Impact Level: FIPS Low` → `Environment: Local development (build Low/Moderate-impact code)`
  - New Purpose framing paragraph (Quickstart = execution layer that applies the Playbook; Playbook = practices/controls layer) + a "local development only, no PII/CUI" guardrail note
  - `ATO Status: Pre-ATO development` → `Local development only (not an authorized production/hosted environment)`
  - Frontmatter `last_updated` and header "Last Updated" bumped to 2026-08-18
- **`README.md`** — Data Classification line expanded with local-dev / Low-Moderate framing
- **`docs/KNOWN_FAILURE_MODES.md`** — "Pre-ATO environment" → "Local development environment"

## Guardrails honored

- Explicitly **local development only** — not implied to be an authorized production/hosted environment
- No PII/CUI (unchanged)
- "The sandbox is the security boundary" and secrets-by-proxy language left untouched

## Companion

Sibling repo touch point (impact-levels table row) handled in
GSA-TTS/agentic-coding-patterns#docs-issue-312-quickstart-positioning.
Playbook companion: GSA-TTS/agentic-coding-playbook#226.

## Verification

- `markdownlint-cli2` on the touched files: **0 issues**

AI-assisted (OpenCode).