### PR TITLE
fix(sbx): stop the every-attach re-attach heal-loop noise on sbx 0.38

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,14 @@ host that can create sandboxes — Docker for sbx, or KVM for msb):
 It exercises the kit/agent/USAi flow on each installed backend. It cannot run
 inside a sandbox (no nested sandboxes).
 
+Focused live checks for specific fixes (also require a sandbox-capable host):
+
+```bash
+./scripts/verify-issue-320          # sbx 0.38 re-attach heal loop (#320)
+./scripts/verify-ports-live         # msb post-hoc port publish (ADR-0015)
+./scripts/verify-net-default-egress # msb create-time published port (ADR-0019)
+```
+
 ### Quick pre-push check
 
 ```bash

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -374,6 +374,24 @@ acq_backend_provision() {
   # create must not leave a record claiming the sandbox is current.
   if [ "$_rc" -eq 0 ]; then
     acq_provenance_write sbx "$name" || true
+    # Seed the ~/.acq-extra-kits marker with the kits applied at CREATE. The
+    # re-attach heal decides whether an extra kit is already applied by reading
+    # this marker (see acq_backend_ensure_kits_applied step 4); previously only
+    # the heal path wrote it, so a sandbox created WITH ACQ_EXTRA_KITS / --kit
+    # refs never got the marker and every re-attach re-attempted every extra kit
+    # (and, under sbx 0.38, warn-failed each time). Write the same marker here so
+    # the create and heal paths agree. Marker every extra/CLI kit (ACQ_EXTRA_KITS
+    # + ACQ_CLI_KITS) by its ORIGINAL ref (stable across runs), matching the
+    # heal's append form. Built-in kits are tracked by feature-probe, not the
+    # marker, so they are intentionally not listed here.
+    local _mk=()
+    [ -n "$ACQ_EXTRA_KITS" ] && split_noglob _mk "$ACQ_EXTRA_KITS"
+    [ "${#ACQ_CLI_KITS[@]}" -gt 0 ] && _mk+=("${ACQ_CLI_KITS[@]}")
+    local _mkk
+    for _mkk in ${_mk[@]+"${_mk[@]}"}; do
+      sbx exec "$name" -- sh -c 'printf "%s\n" "$0" >> "$HOME/.acq-extra-kits"' "$_mkk" \
+        </dev/null >/dev/null 2>&1 || true
+    done
   fi
   return "$_rc"
 }
@@ -450,13 +468,75 @@ acq_backend_ports() {
 }
 
 # ---------------------------------------------------------------------------
+# _acq_sbx_kit_add — run `sbx kit add` and classify the outcome
+# ---------------------------------------------------------------------------
+# sbx 0.38 restricts `sbx kit add` to mixin kits that declare ONLY
+# environment.variables, setup.install, and permissions.network.allow. A kit
+# that declares setup.startup (every built-in kit acq ships, and any realistic
+# extra kit) is REFUSED mid-life with an error like:
+#   ERROR: kit "…" declares setup.startup, which the kit-add recreate flow does
+#   not yet apply; recreate the sandbox from scratch via `sbx rm` + `sbx create
+#   --kit` …
+# (See https://docs.docker.com/ai/sandboxes/customize/kits/#using-kits — "sbx
+# kit add … supports mixin kits limited to environment.variables, setup.install,
+# and permissions.network.allow. To use other fields, recreate …".)
+#
+# Older acq swallowed sbx's stderr (`sbx kit add … >/dev/null 2>&1`) and printed
+# a generic per-kit warning plus a "Recover with: sbx kit add …" hint that could
+# never work — hiding the real cause. This helper CAPTURES stderr and classifies:
+#   0 — success
+#   3 — refused because the kit declares setup.startup (recreate required)
+#   1 — any other failure (stderr echoed so the real cause is visible)
+# Usage: _acq_sbx_kit_add SANDBOX LOCAL_KIT_DIR
+_acq_sbx_kit_add() {
+  local name="$1" local_kit="$2" err rc
+  err=$(sbx kit add "$name" "$local_kit" </dev/null 2>&1 >/dev/null)
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    return 0
+  fi
+  case "$err" in
+    *setup.startup*|*"can only be used when creating a new sandbox"*|*"recreate the sandbox"*)
+      return 3
+      ;;
+  esac
+  # Any other failure: surface sbx's own diagnostic (no silent failure).
+  [ -n "$err" ] && printf '%s\n' "$err" >&2
+  return 1
+}
+
+# One-shot guard so the sbx-0.38 recreate advisory prints at most once per heal,
+# not once per refused kit. Reset at the top of acq_backend_ensure_kits_applied.
+_ACQ_SBX_RECREATE_NOTICE_SHOWN=0
+
+# Print the consolidated "recreate to extend/refresh" message (once). $1 is the
+# sandbox name; $2 (optional) is extra context appended to the intro line.
+_acq_sbx_print_recreate_notice() {
+  local name="$1"
+  [ "${_ACQ_SBX_RECREATE_NOTICE_SHOWN:-0}" = "1" ] && return 0
+  _ACQ_SBX_RECREATE_NOTICE_SHOWN=1
+  echo "acq: sbx >= 0.38 cannot extend a live sandbox with startup-bearing kits" >&2
+  echo "     (every built-in acq kit declares startup commands). The kit set is" >&2
+  echo "     fixed at create time on this sbx version." >&2
+  echo "     To pick up the current bundle, recreate the sandbox (this discards" >&2
+  echo "     its session/context):" >&2
+  echo "       acq rm '$name' && acq run opencode /path/to/your/project" >&2
+}
+
+# ---------------------------------------------------------------------------
 # acq_backend_apply_kit — inject a kit into an existing sandbox mid-life
 # ---------------------------------------------------------------------------
 
 acq_backend_apply_kit() {
-  local name="$1" kitref="$2" local_kit
+  local name="$1" kitref="$2" local_kit rc
   local_kit=$(_acq_sbx_translate_kit "$kitref")
-  sbx kit add "$name" "$local_kit"
+  _acq_sbx_kit_add "$name" "$local_kit"
+  rc=$?
+  if [ "$rc" -eq 3 ]; then
+    _acq_sbx_print_recreate_notice "$name"
+    return 1
+  fi
+  return "$rc"
 }
 
 # ---------------------------------------------------------------------------
@@ -474,6 +554,10 @@ acq_backend_ensure_kits_applied() {
   local name="$1"
   local force="${ACQ_FORCE_KIT_REAPPLY:-0}"
   local ok=1
+  # Reset the once-per-heal sbx-0.38 recreate advisory guard (see
+  # _acq_sbx_print_recreate_notice). Without this reset, a second heal in the
+  # same process would suppress the notice.
+  _ACQ_SBX_RECREATE_NOTICE_SHOWN=0
 
   _acq_sbx_ensure_kit_sources_allowed
 
@@ -489,40 +573,44 @@ acq_backend_ensure_kits_applied() {
   # intercepting CA is already trusted.
   if [ "$force" = "1" ] || _acq_sbx_kit_feature_absent "$name" 'test -e /usr/local/share/ca-certificates/zscaler-ca.crt && echo present'; then
     echo "acq: '$name' is missing the Zscaler CA kit; injecting with 'sbx kit add'..." >&2
-    if sbx kit add "$name" "$zscaler_local" </dev/null >/dev/null 2>&1; then
-      echo "acq: Zscaler CA kit injected into '$name'." >&2
-    else
-      echo "acq: warning: 'sbx kit add' (Zscaler CA kit) failed for '$name'." >&2
-      echo "      Recover with: sbx kit add '$name' '$zscaler_local'" >&2
-      ok=0
-    fi
+    _acq_sbx_kit_add "$name" "$zscaler_local"
+    case $? in
+      0) echo "acq: Zscaler CA kit injected into '$name'." >&2 ;;
+      3) _acq_sbx_print_recreate_notice "$name"; ok=0 ;;
+      *) echo "acq: warning: 'sbx kit add' (Zscaler CA kit) failed for '$name' (see error above)." >&2; ok=0 ;;
+    esac
   fi
 
   # 2) USAi provider kit
   if [ "$force" = "1" ] || _acq_sbx_kit_feature_absent "$name" "test -f '$USAI_KIT_CONFIG_PATH' && echo present"; then
     echo "acq: '$name' is missing the USAi kit; injecting with 'sbx kit add'..." >&2
-    if sbx kit add "$name" "$usai_local" </dev/null >/dev/null 2>&1; then
-      sbx exec "$name" -- sh -c \
-        'f="$HOME/.config/opencode/opencode.jsonc"; if [ -L "$f" ] && [ ! -e "$f" ]; then rm -f "$f"; fi' \
-        </dev/null >/dev/null 2>&1 || true
-      echo "acq: USAi kit injected into '$name'." >&2
-    else
-      echo "acq: warning: 'sbx kit add' (USAi kit) failed for '$name'." >&2
-      echo "      Recover with: sbx kit add '$name' '$usai_local'" >&2
-      ok=0
-    fi
+    _acq_sbx_kit_add "$name" "$usai_local"
+    case $? in
+      0)
+        sbx exec "$name" -- sh -c \
+          'f="$HOME/.config/opencode/opencode.jsonc"; if [ -L "$f" ] && [ ! -e "$f" ]; then rm -f "$f"; fi' \
+          </dev/null >/dev/null 2>&1 || true
+        echo "acq: USAi kit injected into '$name'." >&2
+        ;;
+      3) _acq_sbx_print_recreate_notice "$name"; ok=0 ;;
+      *) echo "acq: warning: 'sbx kit add' (USAi kit) failed for '$name' (see error above)." >&2; ok=0 ;;
+    esac
   fi
 
-  # 3) Playbook kit
-  if [ "$force" = "1" ] || _acq_sbx_kit_feature_absent "$name" 'test -e "$HOME/.agentic-coding-playbook/.git" && echo present'; then
+  # 3) Playbook kit. Probe the playbook footprint that survives BOTH delivery
+  # eras: the historical git clone (~/.agentic-coding-playbook/.git) AND the
+  # current REST-tarball delivery (patterns v1.8.0+, quickstart #203), which
+  # lands the tree with NO .git. The symlink farm consumes AGENTS.md, so its
+  # presence is the delivery-agnostic signal; probing for .git reported the
+  # playbook "absent" forever on tarball-provisioned sandboxes.
+  if [ "$force" = "1" ] || _acq_sbx_kit_feature_absent "$name" 'test -e "$HOME/.agentic-coding-playbook/AGENTS.md" && echo present'; then
     echo "acq: '$name' is missing the playbook kit; injecting with 'sbx kit add'..." >&2
-    if sbx kit add "$name" "$playbook_local" </dev/null >/dev/null 2>&1; then
-      echo "acq: playbook kit injected into '$name'. Restart the agent to pick it up." >&2
-    else
-      echo "acq: warning: 'sbx kit add' (playbook kit) failed for '$name'." >&2
-      echo "      Recover with: sbx kit add '$name' '$playbook_local'" >&2
-      ok=0
-    fi
+    _acq_sbx_kit_add "$name" "$playbook_local"
+    case $? in
+      0) echo "acq: playbook kit injected into '$name'. Restart the agent to pick it up." >&2 ;;
+      3) _acq_sbx_print_recreate_notice "$name"; ok=0 ;;
+      *) echo "acq: warning: 'sbx kit add' (playbook kit) failed for '$name' (see error above)." >&2; ok=0 ;;
+    esac
   fi
 
   # 3b) git-ssh-sign kit. The original heal loop omitted this built-in kit; a
@@ -532,12 +620,12 @@ acq_backend_ensure_kits_applied() {
   if [ "$force" = "1" ]; then
     local gitsshsign_local
     gitsshsign_local=$(_acq_sbx_translate_kit "$GITSSHSIGN_KIT")
-    if sbx kit add "$name" "$gitsshsign_local" </dev/null >/dev/null 2>&1; then
-      echo "acq: git-ssh-sign kit refreshed in '$name'." >&2
-    else
-      echo "acq: warning: 'sbx kit add' (git-ssh-sign kit) failed for '$name'." >&2
-      ok=0
-    fi
+    _acq_sbx_kit_add "$name" "$gitsshsign_local"
+    case $? in
+      0) echo "acq: git-ssh-sign kit refreshed in '$name'." >&2 ;;
+      3) _acq_sbx_print_recreate_notice "$name"; ok=0 ;;
+      *) echo "acq: warning: 'sbx kit add' (git-ssh-sign kit) failed for '$name' (see error above)." >&2; ok=0 ;;
+    esac
   fi
 
   # 4) Extra kits (tracked by marker file). Extra kits may be neutral or already
@@ -554,12 +642,14 @@ acq_backend_ensure_kits_applied() {
     esac
     echo "acq: applying extra kit to '$name': $k" >&2
     local_extra=$(_acq_sbx_translate_kit "$k")
-    if sbx kit add "$name" "$local_extra" </dev/null >/dev/null 2>&1; then
-      sbx exec "$name" -- sh -c 'printf "%s\n" "$0" >> "$HOME/.acq-extra-kits"' "$k" </dev/null >/dev/null 2>&1 || true
-    else
-      echo "acq: warning: 'sbx kit add' (extra kit) failed for '$name'." >&2
-      echo "      Recover with: sbx kit add '$name' '$local_extra'" >&2
-    fi
+    _acq_sbx_kit_add "$name" "$local_extra"
+    case $? in
+      0)
+        sbx exec "$name" -- sh -c 'printf "%s\n" "$0" >> "$HOME/.acq-extra-kits"' "$k" </dev/null >/dev/null 2>&1 || true
+        ;;
+      3) _acq_sbx_print_recreate_notice "$name" ;;
+      *) echo "acq: warning: 'sbx kit add' (extra kit) failed for '$name' (see error above)." >&2 ;;
+    esac
   done
 
   # Record host-side provenance ONLY if every built-in kit is present-or-applied.

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -512,8 +512,15 @@ acq_backend_ports() {
 # Usage: _acq_sbx_kit_add SANDBOX LOCAL_KIT_DIR
 _acq_sbx_kit_add() {
   local name="$1" local_kit="$2" err rc
-  err=$(sbx kit add "$name" "$local_kit" </dev/null 2>&1 >/dev/null)
-  rc=$?
+  # CRITICAL: acq runs under `set -e`. A refusal (the common case this whole
+  # helper exists to classify) makes `sbx kit add` exit non-zero, which would
+  # abort the entire heal at THIS assignment — before rc/classification run —
+  # if it were not guarded. Capture stderr and the real exit code without
+  # letting `set -e` fire: run the command, then read `$?` on the next line.
+  # The `|| rc=$?` idiom both suppresses `set -e` AND records the true status
+  # (a bare `err=$(...)` followed by `rc=$?` would abort under `set -e`; a
+  # trailing `|| true` would clobber the status to 0).
+  err=$(sbx kit add "$name" "$local_kit" </dev/null 2>&1 >/dev/null) && rc=0 || rc=$?
   if [ "$rc" -eq 0 ]; then
     return 0
   fi
@@ -561,8 +568,10 @@ _acq_sbx_print_recreate_notice() {
 acq_backend_apply_kit() {
   local name="$1" kitref="$2" local_kit rc
   local_kit=$(_acq_sbx_translate_kit "$kitref")
-  _acq_sbx_kit_add "$name" "$local_kit"
-  rc=$?
+  # `set -e`-safe: _acq_sbx_kit_add returns 3 (refusal) or 1 (other failure) as
+  # its NORMAL signalling. A bare call on its own line would abort under `set -e`
+  # before we read $?. Capture the status inline.
+  rc=0; _acq_sbx_kit_add "$name" "$local_kit" || rc=$?
   if [ "$rc" -eq 3 ]; then
     _acq_sbx_print_recreate_notice "$name"
     return 1
@@ -585,6 +594,7 @@ acq_backend_ensure_kits_applied() {
   local name="$1"
   local force="${ACQ_FORCE_KIT_REAPPLY:-0}"
   local ok=1
+  local _kadd_rc=0
   # Reset the once-per-heal sbx-0.38 recreate advisory guard (see
   # _acq_sbx_print_recreate_notice). Without this reset, a second heal in the
   # same process would suppress the notice.
@@ -604,8 +614,10 @@ acq_backend_ensure_kits_applied() {
   # intercepting CA is already trusted.
   if [ "$force" = "1" ] || _acq_sbx_kit_feature_absent "$name" 'test -e /usr/local/share/ca-certificates/zscaler-ca.crt && echo present'; then
     echo "acq: '$name' is missing the Zscaler CA kit; injecting with 'sbx kit add'..." >&2
-    _acq_sbx_kit_add "$name" "$zscaler_local"
-    case $? in
+    # `set -e`-safe: _acq_sbx_kit_add's non-zero returns (3=refusal, 1=other) are
+    # normal signalling — capture the status inline so the loop is not aborted.
+    _kadd_rc=0; _acq_sbx_kit_add "$name" "$zscaler_local" || _kadd_rc=$?
+    case $_kadd_rc in
       0) echo "acq: Zscaler CA kit injected into '$name'." >&2 ;;
       3) _acq_sbx_print_recreate_notice "$name"; ok=0 ;;
       *) echo "acq: warning: 'sbx kit add' (Zscaler CA kit) failed for '$name' (see error above)." >&2; ok=0 ;;
@@ -615,8 +627,8 @@ acq_backend_ensure_kits_applied() {
   # 2) USAi provider kit
   if [ "$force" = "1" ] || _acq_sbx_kit_feature_absent "$name" "test -f '$USAI_KIT_CONFIG_PATH' && echo present"; then
     echo "acq: '$name' is missing the USAi kit; injecting with 'sbx kit add'..." >&2
-    _acq_sbx_kit_add "$name" "$usai_local"
-    case $? in
+    _kadd_rc=0; _acq_sbx_kit_add "$name" "$usai_local" || _kadd_rc=$?
+    case $_kadd_rc in
       0)
         sbx exec "$name" -- sh -c \
           'f="$HOME/.config/opencode/opencode.jsonc"; if [ -L "$f" ] && [ ! -e "$f" ]; then rm -f "$f"; fi' \
@@ -636,8 +648,8 @@ acq_backend_ensure_kits_applied() {
   # playbook "absent" forever on tarball-provisioned sandboxes.
   if [ "$force" = "1" ] || _acq_sbx_kit_feature_absent "$name" 'test -e "$HOME/.agentic-coding-playbook/AGENTS.md" && echo present'; then
     echo "acq: '$name' is missing the playbook kit; injecting with 'sbx kit add'..." >&2
-    _acq_sbx_kit_add "$name" "$playbook_local"
-    case $? in
+    _kadd_rc=0; _acq_sbx_kit_add "$name" "$playbook_local" || _kadd_rc=$?
+    case $_kadd_rc in
       0) echo "acq: playbook kit injected into '$name'. Restart the agent to pick it up." >&2 ;;
       3) _acq_sbx_print_recreate_notice "$name"; ok=0 ;;
       *) echo "acq: warning: 'sbx kit add' (playbook kit) failed for '$name' (see error above)." >&2; ok=0 ;;
@@ -651,8 +663,8 @@ acq_backend_ensure_kits_applied() {
   if [ "$force" = "1" ]; then
     local gitsshsign_local
     gitsshsign_local=$(_acq_sbx_translate_kit "$GITSSHSIGN_KIT")
-    _acq_sbx_kit_add "$name" "$gitsshsign_local"
-    case $? in
+    _kadd_rc=0; _acq_sbx_kit_add "$name" "$gitsshsign_local" || _kadd_rc=$?
+    case $_kadd_rc in
       0) echo "acq: git-ssh-sign kit refreshed in '$name'." >&2 ;;
       3) _acq_sbx_print_recreate_notice "$name"; ok=0 ;;
       *) echo "acq: warning: 'sbx kit add' (git-ssh-sign kit) failed for '$name' (see error above)." >&2; ok=0 ;;
@@ -676,8 +688,8 @@ acq_backend_ensure_kits_applied() {
     fi
     echo "acq: applying extra kit to '$name': $k" >&2
     local_extra=$(_acq_sbx_translate_kit "$k")
-    _acq_sbx_kit_add "$name" "$local_extra"
-    case $? in
+    _kadd_rc=0; _acq_sbx_kit_add "$name" "$local_extra" || _kadd_rc=$?
+    case $_kadd_rc in
       0)
         sbx exec "$name" -- sh -c 'printf "%s\n" "$0" >> "$HOME/.acq-extra-kits"' "$k" </dev/null >/dev/null 2>&1 || true
         ;;

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -395,8 +395,14 @@ acq_backend_provision() {
 # are tracked by feature-probe, not the marker, so they are not listed here.
 #
 # ACQ_CLI_KITS (`--kit` on the CLI) are recorded for completeness even though the
-# current heal loop only re-drives ACQ_EXTRA_KITS — the marker is the honest
-# record of what was applied at create.
+# current sbx heal loop only re-drives ACQ_EXTRA_KITS. This is safe, not a
+# functional suppression input: on sbx, `--kit` refs are baked in as create-time
+# `sbx create --kit` flags and never re-applied mid-life (unlike msb, which folds
+# ACQ_CLI_KITS into its heal). The marker is a suppression list, so a recorded CLI
+# ref can only ever be matched if the SAME ref is also supplied via ACQ_EXTRA_KITS
+# — and in that degenerate case skipping re-apply is the correct outcome (the kit
+# was already applied at create). So the CLI entries are a truthful record of what
+# was applied at create; they can never wrongly suppress a needed apply.
 _acq_sbx_seed_extra_kit_marker() {
   local name="$1" _mkk
   local _mk=()
@@ -529,12 +535,17 @@ _acq_sbx_kit_add() {
   fi
   case "$err" in
     # Heuristic: the classification is pinned to sbx 0.38's wording (see ADR-0009
-    # and the doc link above). `setup.startup` is the primary discriminator; the
-    # prose alternates catch reworded variants sbx may emit for the same refusal
-    # (e.g. "declares startup", "startup … recreate", "create a new sandbox").
-    # If sbx reworks the message past all of these, a genuine refusal degrades to
-    # rc=1 (real stderr surfaced, ok=0) — safe (no false "current"), but the
-    # noise this fix removes could return; broaden here if that happens.
+    # and the doc link above). This only ever runs when sbx is already confirmed
+    # >= MIN_SBX_VERSION (0.38.0) — acq_backend_prepare enforces that version floor
+    # at every dispatch entry point before any heal — so the match is bounded to
+    # the versions whose wording it targets, not applied blindly to arbitrary
+    # future/older sbx. `setup.startup` is the primary discriminator; the prose
+    # alternates catch reworded variants sbx may emit for the same refusal (e.g.
+    # "declares startup", "startup … recreate", "create a new sandbox"). If a
+    # future sbx reworks the message past all of these, a genuine refusal degrades
+    # to rc=1 (real stderr surfaced, ok=0) — safe (no false "current"), but the
+    # noise this fix removes could return; the MIN_SBX_VERSION bump that ships that
+    # rewording is the re-verify trigger to broaden the patterns here.
     *setup.startup*|*"declares startup"*|*startup*recreate*|\
     *"can only be used when creating a new sandbox"*|\
     *"create a new sandbox"*|*"recreate the sandbox"*)
@@ -645,10 +656,10 @@ acq_backend_ensure_kits_applied() {
 
   # 3) Playbook kit. Probe the playbook footprint that survives BOTH delivery
   # eras: the historical git clone (~/.agentic-coding-playbook/.git) AND the
-  # current REST-tarball delivery (patterns v1.8.0+, quickstart #203), which
-  # lands the tree with NO .git. The symlink farm consumes AGENTS.md, so its
-  # presence is the delivery-agnostic signal; probing for .git reported the
-  # playbook "absent" forever on tarball-provisioned sandboxes.
+  # current REST-tarball delivery (patterns v1.8.0+), which lands the tree with
+  # NO .git. The symlink farm consumes AGENTS.md, so its presence is the
+  # delivery-agnostic signal; probing for .git reported the playbook "absent"
+  # forever on tarball-provisioned sandboxes.
   if [ "$force" = "1" ] || _acq_sbx_kit_feature_absent "$name" 'test -e "$HOME/.agentic-coding-playbook/AGENTS.md" && echo present'; then
     echo "acq: '$name' is missing the playbook kit; injecting with 'sbx kit add'..." >&2
     _kadd_rc=0; _acq_sbx_kit_add "$name" "$playbook_local" || _kadd_rc=$?

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -374,26 +374,48 @@ acq_backend_provision() {
   # create must not leave a record claiming the sandbox is current.
   if [ "$_rc" -eq 0 ]; then
     acq_provenance_write sbx "$name" || true
-    # Seed the ~/.acq-extra-kits marker with the kits applied at CREATE. The
-    # re-attach heal decides whether an extra kit is already applied by reading
-    # this marker (see acq_backend_ensure_kits_applied step 4); previously only
-    # the heal path wrote it, so a sandbox created WITH ACQ_EXTRA_KITS / --kit
-    # refs never got the marker and every re-attach re-attempted every extra kit
-    # (and, under sbx 0.38, warn-failed each time). Write the same marker here so
-    # the create and heal paths agree. Marker every extra/CLI kit (ACQ_EXTRA_KITS
-    # + ACQ_CLI_KITS) by its ORIGINAL ref (stable across runs), matching the
-    # heal's append form. Built-in kits are tracked by feature-probe, not the
-    # marker, so they are intentionally not listed here.
-    local _mk=()
-    [ -n "$ACQ_EXTRA_KITS" ] && split_noglob _mk "$ACQ_EXTRA_KITS"
-    [ "${#ACQ_CLI_KITS[@]}" -gt 0 ] && _mk+=("${ACQ_CLI_KITS[@]}")
-    local _mkk
-    for _mkk in ${_mk[@]+"${_mk[@]}"}; do
-      sbx exec "$name" -- sh -c 'printf "%s\n" "$0" >> "$HOME/.acq-extra-kits"' "$_mkk" \
-        </dev/null >/dev/null 2>&1 || true
-    done
+    _acq_sbx_seed_extra_kit_marker "$name"
   fi
   return "$_rc"
+}
+
+# ---------------------------------------------------------------------------
+# _acq_sbx_seed_extra_kit_marker — write ~/.acq-extra-kits at CREATE
+# ---------------------------------------------------------------------------
+# The re-attach heal decides whether an extra kit is already applied by reading
+# this marker (see acq_backend_ensure_kits_applied step 4); previously only the
+# heal path wrote it, so a sandbox created WITH ACQ_EXTRA_KITS / --kit refs never
+# got the marker and every re-attach re-attempted every extra kit (and, under
+# sbx 0.38, warn-failed each time). Write the same marker here so the create and
+# heal paths agree: one ORIGINAL ref per line (stable across runs), matching the
+# heal's append form (so the heal's exact-line match detects it). Built-in kits
+# are tracked by feature-probe, not the marker, so they are not listed here.
+#
+# ACQ_CLI_KITS (`--kit` on the CLI) are recorded for completeness even though the
+# current heal loop only re-drives ACQ_EXTRA_KITS — the marker is the honest
+# record of what was applied at create.
+_acq_sbx_seed_extra_kit_marker() {
+  local name="$1" _mkk
+  local _mk=()
+  [ -n "$ACQ_EXTRA_KITS" ] && split_noglob _mk "$ACQ_EXTRA_KITS"
+  [ "${#ACQ_CLI_KITS[@]}" -gt 0 ] && _mk+=("${ACQ_CLI_KITS[@]}")
+  # Nothing to record — skip the (potentially slow) exec-ready wait entirely.
+  [ "${#_mk[@]}" -gt 0 ] || return 0
+  # A freshly-created sandbox is not immediately exec-able; the heal path guards
+  # its probes the same way. Without this, the marker write can race the sandbox
+  # becoming ready, silently write nothing, and reintroduce the re-attempt bug.
+  if ! _acq_sbx_wait_for_exec_ready "$name"; then
+    echo "acq: warning: sandbox '$name' not exec-ready; could not record the" \
+         "extra-kit marker (~/.acq-extra-kits). Re-attach may re-attempt extra kits." >&2
+    return 0
+  fi
+  for _mkk in ${_mk[@]+"${_mk[@]}"}; do
+    if ! sbx exec "$name" -- sh -c 'printf "%s\n" "$0" >> "$HOME/.acq-extra-kits"' "$_mkk" \
+        </dev/null >/dev/null 2>&1; then
+      echo "acq: warning: could not record extra kit '$_mkk' in ~/.acq-extra-kits" \
+           "for '$name'; re-attach may re-attempt it." >&2
+    fi
+  done
 }
 
 # ---------------------------------------------------------------------------
@@ -496,7 +518,16 @@ _acq_sbx_kit_add() {
     return 0
   fi
   case "$err" in
-    *setup.startup*|*"can only be used when creating a new sandbox"*|*"recreate the sandbox"*)
+    # Heuristic: the classification is pinned to sbx 0.38's wording (see ADR-0009
+    # and the doc link above). `setup.startup` is the primary discriminator; the
+    # prose alternates catch reworded variants sbx may emit for the same refusal
+    # (e.g. "declares startup", "startup … recreate", "create a new sandbox").
+    # If sbx reworks the message past all of these, a genuine refusal degrades to
+    # rc=1 (real stderr surfaced, ok=0) — safe (no false "current"), but the
+    # noise this fix removes could return; broaden here if that happens.
+    *setup.startup*|*"declares startup"*|*startup*recreate*|\
+    *"can only be used when creating a new sandbox"*|\
+    *"create a new sandbox"*|*"recreate the sandbox"*)
       return 3
       ;;
   esac
@@ -510,7 +541,7 @@ _acq_sbx_kit_add() {
 _ACQ_SBX_RECREATE_NOTICE_SHOWN=0
 
 # Print the consolidated "recreate to extend/refresh" message (once). $1 is the
-# sandbox name; $2 (optional) is extra context appended to the intro line.
+# sandbox name.
 _acq_sbx_print_recreate_notice() {
   local name="$1"
   [ "${_ACQ_SBX_RECREATE_NOTICE_SHOWN:-0}" = "1" ] && return 0
@@ -629,17 +660,20 @@ acq_backend_ensure_kits_applied() {
   fi
 
   # 4) Extra kits (tracked by marker file). Extra kits may be neutral or already
-  #    sbx-v2; _acq_sbx_translate_kit handles both. The marker uses the original
-  #    ref (stable across runs), not the translated local dir. Extra-kit failures
-  #    do not affect the built-in bundle's provenance verdict.
+  #    sbx-v2; _acq_sbx_translate_kit handles both. The marker records one
+  #    ORIGINAL ref per line (stable across runs), not the translated local dir.
+  #    Extra-kit failures do not affect the built-in bundle's provenance verdict.
   local applied k local_extra
   applied=$(sbx exec "$name" -- sh -c 'cat "$HOME/.acq-extra-kits" 2>/dev/null' </dev/null 2>/dev/null || true)
   local _extras=()
   [ -n "$ACQ_EXTRA_KITS" ] && split_noglob _extras "$ACQ_EXTRA_KITS"
   for k in ${_extras[@]+"${_extras[@]}"}; do
-    case "$applied" in
-      *"$k"*) continue ;;
-    esac
+    # Whole-line match (the marker is written one ref per line via printf
+    # '%s\n'). A substring test would wrongly treat a ref that is a prefix of an
+    # already-applied ref (e.g. `…&dir=kit` vs `…&dir=kit-extended`) as applied.
+    if printf '%s\n' "$applied" | grep -Fxq -- "$k"; then
+      continue
+    fi
     echo "acq: applying extra kit to '$name': $k" >&2
     local_extra=$(_acq_sbx_translate_kit "$k")
     _acq_sbx_kit_add "$name" "$local_extra"

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -3,7 +3,7 @@ title: "acq Backend Guide"
 description: "Per-backend strengths, tradeoffs, and configuration for acq"
 status: canonical
 tier: 2
-last_updated: "2026-08-04"
+last_updated: "2026-08-18"
 audience: "developers"
 keywords: ["acq", "backend", "sbx", "msb", "microsandbox", "tradeoffs"]
 related_files: ["docs/QUICKSTART.md", "docs/QUICKSTART_SBX.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md", "docs/adr/0014-neutral-port-publish-and-background-vocab.md", "docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md"]
@@ -103,6 +103,7 @@ export ACQ_BACKEND=sbx
   print that guidance instead of failing opaquely. msb is unaffected (it
   re-applies kits idempotently via `msb exec`). See the update note in
   [ADR-0009](adr/0009-require-sbx-0.35.0-in-place-kit-healing.md).
+  Live-verify this behavior on an sbx host with `./scripts/verify-issue-320`.
 - The sbx `docker sandbox` commands (deprecated by Docker) must not be used;
   use `sbx` CLI directly
 

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -48,7 +48,10 @@ from Docker Inc. It provides:
 - **Kit ecosystem**: Reuses all four community kits unchanged (`usai-provider`,
   `agentic-coding-playbook`, `zscaler-ca-certificate`, `git-ssh-sign`)
 - **In-place healing**: Missing kits are added with `sbx kit add` on reconnect
-  without losing sandbox state (requires sbx >= 0.35.0)
+  without losing sandbox state (requires sbx >= 0.35.0). **Note (sbx 0.38+):**
+  `sbx kit add` no longer applies startup-bearing kits mid-life (see the
+  limitation note below), so the built-in bundle can only be
+  extended/refreshed by recreating the sandbox.
 - **Port forwarding**: Supports `--publish` for exposing agent web UIs
 
 ### Requirements
@@ -90,6 +93,16 @@ export ACQ_BACKEND=sbx
 
 - `sbx kit add` (healing) is experimental; see
   [KNOWN_FAILURE_MODES.md](KNOWN_FAILURE_MODES.md)
+- **sbx 0.38 cannot extend a live sandbox with startup-bearing kits.**
+  `sbx kit add` on 0.38 only applies mixin kits declaring exclusively
+  `environment.variables`, `setup.install`, and `permissions.network.allow`; a
+  kit declaring `setup.startup` is refused mid-life. Every built-in acq kit
+  declares startup commands, so on sbx 0.38 the built-in bundle can be
+  extended/refreshed **only by recreating the sandbox** (`acq rm && acq run`).
+  acq's heal path, `acq kit apply`, and `acq kit update` detect the refusal and
+  print that guidance instead of failing opaquely. msb is unaffected (it
+  re-applies kits idempotently via `msb exec`). See the update note in
+  [ADR-0009](adr/0009-require-sbx-0.35.0-in-place-kit-healing.md).
 - The sbx `docker sandbox` commands (deprecated by Docker) must not be used;
   use `sbx` CLI directly
 
@@ -600,7 +613,7 @@ rationale, the fixed vsock port (3552), and the trust-boundary discussion.
 | Port forwarding | `acq ports` (post-hoc) | create/run (`-p`) via neutral `publishedPorts` now (shipped); **plus** post-hoc `acq ports --publish` via `msb ssh serve` + `ssh -L` now implemented (ADR-0015) — live end-to-end verification pending a KVM host |
 | Agent binary | supplied by the sbx agent template | installed at provision on a plain base (`npm install -g opencode-ai`), then launched on attach |
 | OpenCode web UI | `openchamber` acq kit (publishes port 4096) | same kit once it declares `backends: [sbx, msb]` against the released patterns schema (neutral port/background vocab consumed by both backends; the patterns repo's openchamber kit) |
-| In-place kit heal | `sbx kit add` (state-preserving, 0.35.0+) | re-apply kits idempotently (no state-preserving add) |
+| In-place kit heal | `sbx kit add` (state-preserving, 0.35.0+; **no startup-bearing kits on 0.38+ — recreate to extend/refresh**) | re-apply kits idempotently (no state-preserving add) |
 
 ### Known limitations
 

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -3,7 +3,7 @@ title: "Known Failure Modes"
 description: "Real-world failure patterns when using Docker SBX + USAi + agent frameworks"
 status: canonical
 tier: 2
-last_updated: "2026-08-17"
+last_updated: "2026-08-18"
 audience: "developers"
 keywords: ["debugging", "troubleshooting", "sbx", "usai", "failures"]
 ---
@@ -640,13 +640,19 @@ without `acq` (so the kits were not applied), or with a plain backend `run`
 (e.g. `sbx run` / `msb run`) without the kit refs.
 
 **Upgrading an existing sandbox (pre-kit).** A sandbox created before the kit
-migration has no USAi provider config and no playbook clone. `acq` now **heals
-it in place**: the next time you `acq run` against such a sandbox, it detects the
-missing kit(s) and injects them (on sbx via `sbx kit add`). As of `sbx` 0.35.0
-`sbx kit add` **recreates the sandbox container with the augmented kit set and
-preserves state**, so your work and sessions survive — no export/recreate/import
-dance, and no manual steps.
+migration has no USAi provider config and no playbook clone. `acq` attempts to
+**heal it in place**: the next time you `acq run` against such a sandbox, it
+detects the missing kit(s) and injects them (on sbx via `sbx kit add`). This
+worked on sbx 0.35.0–0.37.x, where `sbx kit add` recreated the container with the
+augmented kit set while preserving state.
 
+> **sbx 0.38 caveat.** On sbx >= 0.38, `sbx kit add` no longer applies
+> startup-bearing kits mid-life (see [Section 35](#35-re-attach-heal-loop-warns-every-time-on-sbx-038--sbx-kit-add-refuses-startup-bearing-kits)),
+> and every built-in acq kit declares startup commands. In-place healing of the
+> built-in bundle therefore does **not** work on 0.38+: to add or refresh the
+> bundle you must recreate the sandbox (`acq rm && acq run`). acq detects the
+> refusal and prints that guidance.
+>
 > **Historical note.** Earlier releases could *not* auto-heal in place: on
 > `sbx` ≤ 0.34.x, `sbx kit add` failed (`failed to read tar header: unexpected
 > EOF`) on any kit shipping a static file — including the `usai-provider` kit
@@ -1666,6 +1672,79 @@ running on the host (or no key is loaded), there is nothing to forward.
 Then re-run `acq run …`; the forward is applied automatically. See
 [ADR-0021](adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md) for the full
 mechanism and the trust-boundary discussion.
+
+---
+
+## 35. Re-attach Heal Loop Warns Every Time on sbx 0.38 — `sbx kit add` Refuses Startup-Bearing Kits
+
+### Symptoms
+
+On the **sbx** backend (sbx >= 0.38), every re-attach to an existing sandbox
+(`acq run <name>`) reports the sandbox is "missing the playbook kit", re-attempts
+every extra kit, and each `sbx kit add` warn-fails — on **every** attach, even
+for a sandbox that was provisioned correctly. Running the printed recover command
+by hand shows the real cause:
+
+```
+$ sbx kit add <sandbox> <translated-playbook-kit-dir>
+ERROR: kit "agentic-coding-playbook" declares setup.startup, which the kit-add
+recreate flow does not yet apply; recreate the sandbox from scratch via
+`sbx rm` + `sbx create --kit` to use this kit
+```
+
+### Root Cause
+
+Three issues compounded:
+
+1. **sbx 0.38 refuses startup-bearing kits mid-life.** `sbx kit add` on 0.38 only
+   applies mixin kits declaring exclusively `environment.variables`,
+   `setup.install`, and `permissions.network.allow`
+   ([Docker kits docs](https://docs.docker.com/ai/sandboxes/customize/kits/)). Every
+   built-in acq kit declares startup commands (translated into `setup.startup`), so
+   **all** mid-life built-in kit adds are refused. acq swallowed sbx's stderr
+   (`sbx kit add … >/dev/null 2>&1`) and printed a generic warning plus a
+   "Recover with: sbx kit add …" hint that could never succeed.
+2. **A stale playbook feature-probe.** The heal probed the playbook with
+   `test -e "$HOME/.agentic-coding-playbook/.git"`. Since patterns v1.8.0 moved
+   playbook delivery from a git clone to a REST tarball (the #203 fix), the tree
+   has **no `.git`**, so the probe reported the playbook absent on every re-attach,
+   forever — re-triggering the (now-refused) add each time.
+3. **The `~/.acq-extra-kits` marker was never written at create.** The re-attach
+   heal decided whether an extra kit was already applied by reading
+   `~/.acq-extra-kits`, but only the heal path wrote it. A sandbox created **with**
+   `ACQ_EXTRA_KITS` (or `--kit`) never got the marker, so every re-attach
+   re-attempted every extra kit (and, under (1), warn-failed).
+
+### Fix
+
+`acq` (this repo):
+
+- Captures `sbx kit add` stderr and **detects the startup refusal**, printing a
+  single actionable "recreate to extend/refresh" message
+  (`acq rm <name> && acq run …`) instead of per-kit warnings with recover
+  commands that cannot work. Other (genuine) failures now surface sbx's own
+  diagnostic rather than being hidden. `acq kit update` fails with the same
+  guidance. acq does **not** auto-recreate (a recreate discards the sandbox's
+  session/context — it stays a deliberate, user-consented action).
+- Probes the playbook with `test -e "$HOME/.agentic-coding-playbook/AGENTS.md"`,
+  which matches **both** the historical git-clone and the current tarball
+  delivery.
+- Writes `~/.acq-extra-kits` at **create** for every extra/CLI kit, so re-attach
+  correctly sees them as already applied.
+
+To pick up a refreshed built-in bundle on sbx 0.38 you must recreate the sandbox
+(this discards its session/context):
+
+```bash
+acq rm <sandbox>
+acq run opencode /path/to/your/project
+```
+
+**msb is unaffected** — it re-applies kits idempotently via `msb exec` and has no
+`sbx kit add`. The upstream "not yet" in the sbx error suggests startup support in
+the kit-add flow may return; if it does, in-place healing can be re-enabled. See
+the update note in
+[ADR-0009](adr/0009-require-sbx-0.35.0-in-place-kit-healing.md).
 
 ---
 

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1746,6 +1746,23 @@ the kit-add flow may return; if it does, in-place healing can be re-enabled. See
 the update note in
 [ADR-0009](adr/0009-require-sbx-0.35.0-in-place-kit-healing.md).
 
+### Verifying the fix (live)
+
+On a real sbx host (this cannot run inside a sandbox — no nested sandboxes), one
+command reproduces the exact scenario and asserts all three fixes:
+
+```bash
+./scripts/verify-issue-320
+```
+
+It provisions a throwaway sandbox with a startup-bearing extra kit, re-attaches,
+and checks that: the extra-kit marker was written at create; the re-attach heal
+is a quiet no-op (no "missing the playbook kit", no extra-kit re-attempt, no
+bogus "Recover with" hint); a forced mid-life re-add surfaces exactly one
+recreate notice; and `acq kit update` fails fast (or short-circuits when already
+current). The offline regression guard is in `scripts/test-acq` (the sbx
+heal-loop cases).
+
 ---
 
 When something fails, work through this list:

--- a/docs/adr/0009-require-sbx-0.35.0-in-place-kit-healing.md
+++ b/docs/adr/0009-require-sbx-0.35.0-in-place-kit-healing.md
@@ -22,6 +22,30 @@ supersedes: []
 > (it is a lower bound satisfied by 0.38.0); the effective floor in
 > `acq.backends/sbx.sh` (`MIN_SBX_VERSION`) is now 0.38.0. The Linux/ARM64 "no
 > 0.35.x build, wait for 0.36.x" caveat is moot at the 0.38.0 floor.
+>
+> **Update (2026-08-18): sbx 0.38 no longer supports in-place healing of the
+> built-in bundle.** sbx 0.38's `sbx kit add` only applies mixin kits that
+> declare *exclusively* `environment.variables`, `setup.install`, and
+> `permissions.network.allow`. A kit that declares `setup.startup` is **refused
+> mid-life** with an error naming `setup.startup` and directing the user to
+> recreate the sandbox (`sbx rm` + `sbx create --kit`). See the
+> [Docker kits docs](https://docs.docker.com/ai/sandboxes/customize/kits/) —
+> *"`sbx kit add` … supports mixin kits limited to `environment.variables`,
+> `setup.install`, and `permissions.network.allow`. To use other fields, recreate
+> the sandbox with `--kit`."* Every kit in acq's built-in bundle declares startup
+> commands (they are translated into `setup.startup`), so on sbx 0.38 **every
+> mid-life built-in kit add is refused** and the state-preserving in-place heal
+> this ADR relied on no longer applies. The heal path
+> (`acq_backend_ensure_kits_applied`), `acq kit apply`, and `acq kit update`
+> therefore **detect this refusal and print a single actionable "recreate to
+> extend/refresh" message** (`acq rm && acq run`) rather than per-kit warnings
+> with recover commands that cannot work; provenance is left unchanged so the
+> sandbox correctly stays stale/unknown. acq does **not** auto-recreate — a
+> recreate discards the sandbox's session/context, so it stays a deliberate,
+> user-consented action (safety > convenience). The "not yet" in the upstream
+> error suggests sbx may restore startup support in the kit-add flow; if it does,
+> in-place healing can be re-enabled. This limitation drove
+> [quickstart#320](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/320).
 
 ## Context and Problem Statement
 

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -4833,12 +4833,13 @@ cleanup_stubs
 make_stubs; load_acq
 _plant_sbx_startup_refusal_stub
 printf 'sebox\n' > "$STUBDIR/.sandbox_list"
-# Point the stub's $CALLS/$STUBDIR at this test's dirs, put the stub sbx first on
-# PATH, and run the heal in a subshell that sources acq exactly as the live
-# re-attach path does (ACQ_SOURCE_ONLY keeps `set -e` active from acq's header).
+# Run the heal in a subshell that sources acq exactly as the live re-attach path
+# does (ACQ_SOURCE_ONLY keeps `set -e` active from acq's header). Export the
+# stub env in the subshell so the child `bash -c` inherits $CALLS/$STUBDIR/$PATH
+# and the refusal stub is first on PATH.
 out=$(
-  CALLS="$CALLS" STUBDIR="$STUBDIR" PATH="$STUBDIR:$PATH" \
-  ACQ_FORCE_KIT_REAPPLY=1 bash -c '
+  export CALLS STUBDIR ACQ_FORCE_KIT_REAPPLY=1
+  PATH="$STUBDIR:$PATH" bash -c '
     ACQ_SOURCE_ONLY=1 . "'"$ACQ"'" >/dev/null 2>&1
     acq_resolve_backend sbx >/dev/null 2>&1
     acq_backend_ensure_kits_applied sebox
@@ -4967,6 +4968,7 @@ cleanup_stubs
 # 9q7. CREATE-TIME MARKER covers CLI --kit refs (ACQ_CLI_KITS) too.
 make_stubs; load_acq
 : > "$CALLS"
+# shellcheck disable=SC2034  # ACQ_CLI_KITS is consumed by acq_backend_provision (sourced)
 ( ACQ_CLI_KITS=("git+https://github.com/GSA-TTS/agentic-coding-patterns.git#ref=deadbeef&dir=cli-kit-x")
   acq_backend_provision climarkerbox shell /tmp >/dev/null 2>&1 ) || true
 log=$(cat "$CALLS")

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -4768,6 +4768,183 @@ assert_not_contains "provision(sbx): no notice when SSH_AUTH_SOCK is unset" "$sb
 cleanup_stubs
 
 # ===========================================================================
+# 9q. sbx 0.38 startup-kit refusal + stale-probe + create-time extra-kit marker
+#     (quickstart #320). All offline via the stubbed sbx.
+# ===========================================================================
+
+# Helper: plant an sbx stub whose `kit add` FAILS with the 0.38 startup-refusal
+# error on stderr (exit 1), and whose feature-probe reports ABSENT so the heal
+# attempts the add. Everything else no-ops. Used by the refusal tests below.
+_plant_sbx_startup_refusal_stub() {
+  cat >"$STUBDIR/sbx" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'sbx'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >>"$CALLS"
+case "${1:-}" in
+  version) printf 'sbx version: v0.38.0 abc123\n' ;;
+  ls) [ -f "$STUBDIR/.sandbox_list" ] && cat "$STUBDIR/.sandbox_list"; exit 0 ;;
+  kit)
+    if [ "${2:-}" = "add" ]; then
+      printf 'ERROR: kit "agentic-coding-playbook" declares setup.startup, which the kit-add recreate flow does not yet apply; recreate the sandbox from scratch via `sbx rm` + `sbx create --kit` to use this kit\n' >&2
+      exit 1
+    fi
+    exit 0 ;;
+  exec)
+    snippet=""; prev=""
+    for a in "$@"; do [ "$prev" = "-c" ] && { snippet="$a"; break; }; prev="$a"; done
+    case "$snippet" in *present*) printf 'absent\n' ;; *) exit 0 ;; esac ;;
+  settings) exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x "$STUBDIR/sbx"
+}
+
+# 9q1. The 0.38 startup refusal is DETECTED and surfaced as a single consolidated
+#      "recreate to extend/refresh" message — NOT per-kit "Recover with" hints —
+#      and provenance is left unknown (no false "current").
+make_stubs; load_acq
+_plant_sbx_startup_refusal_stub
+printf 'refusebox\n' > "$STUBDIR/.sandbox_list"
+out=$(acq_backend_ensure_kits_applied refusebox 2>&1) || true
+assert_contains "heal(sbx 0.38): prints recreate guidance" "$out" "cannot extend a live sandbox with startup-bearing kits"
+assert_contains "heal(sbx 0.38): recreate hint names acq rm + acq run" "$out" "acq rm 'refusebox' && acq run"
+assert_not_contains "heal(sbx 0.38): no bogus per-kit Recover-with hint" "$out" "Recover with: sbx kit add"
+assert_eq "heal(sbx 0.38): refusal leaves status unknown" "unknown" "$(acq_provenance_status sbx refusebox)"
+cleanup_stubs
+
+# 9q2. The consolidated recreate message is printed AT MOST ONCE per heal even
+#      though multiple built-in kits are refused.
+make_stubs; load_acq
+_plant_sbx_startup_refusal_stub
+printf 'oncebox\n' > "$STUBDIR/.sandbox_list"
+out=$(acq_backend_ensure_kits_applied oncebox 2>&1) || true
+_notice_count=$(printf '%s\n' "$out" | grep -c "cannot extend a live sandbox with startup-bearing kits")
+assert_eq "heal(sbx 0.38): recreate notice printed exactly once" "1" "$_notice_count"
+cleanup_stubs
+
+# 9q3. `acq kit update` fails fast with the recreate guidance under the refusal
+#      (rather than looping per-kit warnings).
+make_stubs; load_acq
+_plant_sbx_startup_refusal_stub
+printf 'updbox\n' > "$STUBDIR/.sandbox_list"
+_seed_stale_provenance sbx updbox
+out=$(ACQ_BACKEND=sbx "$ACQ" kit update updbox --yes 2>&1); rc=$?
+assert_eq "kit update(sbx 0.38): refusal exits nonzero" "1" "$rc"
+assert_contains "kit update(sbx 0.38): shows recreate guidance" "$out" "cannot extend a live sandbox with startup-bearing kits"
+assert_eq "kit update(sbx 0.38): stays stale (no false current)" "stale" "$(acq_provenance_status sbx updbox)"
+cleanup_stubs
+
+# 9q4. A NON-refusal `sbx kit add` failure surfaces sbx's own stderr (no silent
+#      failure) rather than the recreate message.
+make_stubs; load_acq
+cat >"$STUBDIR/sbx" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'sbx'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >>"$CALLS"
+case "${1:-}" in
+  version) printf 'sbx version: v0.38.0 abc123\n' ;;
+  ls) [ -f "$STUBDIR/.sandbox_list" ] && cat "$STUBDIR/.sandbox_list"; exit 0 ;;
+  kit) [ "${2:-}" = "add" ] && { printf 'ERROR: some other transient failure\n' >&2; exit 1; }; exit 0 ;;
+  exec)
+    snippet=""; prev=""
+    for a in "$@"; do [ "$prev" = "-c" ] && { snippet="$a"; break; }; prev="$a"; done
+    case "$snippet" in *present*) printf 'absent\n' ;; *) exit 0 ;; esac ;;
+  settings) exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$STUBDIR/sbx"
+printf 'otherbox\n' > "$STUBDIR/.sandbox_list"
+out=$(acq_backend_ensure_kits_applied otherbox 2>&1) || true
+assert_contains "heal(sbx): non-refusal failure surfaces sbx stderr" "$out" "some other transient failure"
+assert_not_contains "heal(sbx): non-refusal failure is NOT the recreate message" "$out" "cannot extend a live sandbox"
+cleanup_stubs
+
+# 9q5. STALE PLAYBOOK PROBE: the heal probes the tarball-era footprint
+#      (~/.agentic-coding-playbook/AGENTS.md), NOT the git-clone-era /.git. When
+#      AGENTS.md is present the playbook add is skipped; the probe snippet must
+#      reference AGENTS.md and never .git.
+make_stubs; load_acq
+# sbx stub: feature-probe reports PRESENT for any probe (so nothing is added),
+# and record the exact probe snippet(s) seen.
+cat >"$STUBDIR/sbx" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'sbx'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >>"$CALLS"
+case "${1:-}" in
+  version) printf 'sbx version: v0.38.0 abc123\n' ;;
+  ls) [ -f "$STUBDIR/.sandbox_list" ] && cat "$STUBDIR/.sandbox_list"; exit 0 ;;
+  exec)
+    snippet=""; prev=""
+    for a in "$@"; do [ "$prev" = "-c" ] && { snippet="$a"; break; }; prev="$a"; done
+    case "$snippet" in *present*) printf 'present\n' ;; *) exit 0 ;; esac ;;
+  kit) exit 0 ;;
+  settings) exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$STUBDIR/sbx"
+printf 'probebox\n' > "$STUBDIR/.sandbox_list"
+acq_backend_ensure_kits_applied probebox >/dev/null 2>&1 || true
+log=$(cat "$CALLS")
+assert_contains "heal(sbx): playbook probe uses AGENTS.md footprint" "$log" ".agentic-coding-playbook/AGENTS.md"
+assert_not_contains "heal(sbx): playbook probe no longer uses .git" "$log" ".agentic-coding-playbook/.git"
+# All probes reported present, so no built-in kit add was attempted.
+assert_not_contains "heal(sbx): present-probe skips playbook add" "$log" "sbx kit add probebox"
+cleanup_stubs
+
+# 9q6. CREATE-TIME MARKER: provisioning WITH ACQ_EXTRA_KITS writes each extra kit
+#      to ~/.acq-extra-kits, so a subsequent re-attach heal sees it as applied.
+make_stubs; load_acq
+: > "$CALLS"
+( export ACQ_EXTRA_KITS="git+https://github.com/GSA-TTS/agentic-coding-patterns.git#ref=deadbeef&dir=some-extra-kit"
+  acq_backend_provision markerbox shell /tmp >/dev/null 2>&1 ) || true
+log=$(cat "$CALLS")
+assert_contains "provision(sbx): marks extra kit into ~/.acq-extra-kits at create" "$log" ".acq-extra-kits"
+assert_contains "provision(sbx): marker records the extra kit ref" "$log" "some-extra-kit"
+cleanup_stubs
+
+# 9q7. CREATE-TIME MARKER covers CLI --kit refs (ACQ_CLI_KITS) too.
+make_stubs; load_acq
+: > "$CALLS"
+( ACQ_CLI_KITS=("git+https://github.com/GSA-TTS/agentic-coding-patterns.git#ref=deadbeef&dir=cli-kit-x")
+  acq_backend_provision climarkerbox shell /tmp >/dev/null 2>&1 ) || true
+log=$(cat "$CALLS")
+assert_contains "provision(sbx): marks CLI --kit ref into ~/.acq-extra-kits at create" "$log" "cli-kit-x"
+cleanup_stubs
+
+# 9q8. MARKER SUPPRESSES RE-APPLY: with the marker present, the re-attach heal
+#      does NOT re-attempt an already-applied extra kit (so no refusal noise).
+make_stubs; load_acq
+# sbx stub: built-in probes report present; the marker read returns the extra
+# kit ref; record calls. `kit add` would fail if reached (must NOT be reached).
+cat >"$STUBDIR/sbx" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'sbx'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >>"$CALLS"
+case "${1:-}" in
+  version) printf 'sbx version: v0.38.0 abc123\n' ;;
+  ls) [ -f "$STUBDIR/.sandbox_list" ] && cat "$STUBDIR/.sandbox_list"; exit 0 ;;
+  exec)
+    snippet=""; prev=""
+    for a in "$@"; do [ "$prev" = "-c" ] && { snippet="$a"; break; }; prev="$a"; done
+    case "$snippet" in
+      *acq-extra-kits*) printf '%s\n' "git+https://github.com/GSA-TTS/agentic-coding-patterns.git#ref=deadbeef&dir=some-extra-kit" ;;
+      *present*) printf 'present\n' ;;
+      *) exit 0 ;;
+    esac ;;
+  kit) [ "${2:-}" = "add" ] && { printf 'ERROR: declares setup.startup\n' >&2; exit 1; }; exit 0 ;;
+  settings) exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$STUBDIR/sbx"
+printf 'skipbox\n' > "$STUBDIR/.sandbox_list"
+out=$( ACQ_EXTRA_KITS="git+https://github.com/GSA-TTS/agentic-coding-patterns.git#ref=deadbeef&dir=some-extra-kit" \
+       acq_backend_ensure_kits_applied skipbox 2>&1 ) || true
+log=$(cat "$CALLS")
+assert_not_contains "heal(sbx): marked extra kit is not re-applied" "$log" "sbx kit add skipbox"
+assert_not_contains "heal(sbx): marked extra kit yields no refusal noise" "$out" "cannot extend a live sandbox"
+cleanup_stubs
+
+# ===========================================================================
 # 10. kit-translate: neutral hybrid/v1 -> sbx-v2 synthesis (offline)
 # ===========================================================================
 

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -4822,6 +4822,34 @@ _notice_count=$(printf '%s\n' "$out" | grep -c "cannot extend a live sandbox wit
 assert_eq "heal(sbx 0.38): recreate notice printed exactly once" "1" "$_notice_count"
 cleanup_stubs
 
+# 9q2b. REGRESSION (live-run #3): under `set -e` — how real acq and
+#       verify-issue-320 run — a refusal must NOT abort the heal at the first
+#       kit. The harness normally runs `set +e`, which masked a bug where
+#       `_acq_sbx_kit_add` (returning 3/1 as normal signalling) aborted the whole
+#       heal before the recreate notice or the remaining kits ran. Reproduce the
+#       REAL path: a fresh subshell that sources acq (which sets `set -e`),
+#       resolves the backend, and runs the forced heal — with the refusal stub on
+#       PATH. Assert the notice prints AND all three built-ins are attempted.
+make_stubs; load_acq
+_plant_sbx_startup_refusal_stub
+printf 'sebox\n' > "$STUBDIR/.sandbox_list"
+# Point the stub's $CALLS/$STUBDIR at this test's dirs, put the stub sbx first on
+# PATH, and run the heal in a subshell that sources acq exactly as the live
+# re-attach path does (ACQ_SOURCE_ONLY keeps `set -e` active from acq's header).
+out=$(
+  CALLS="$CALLS" STUBDIR="$STUBDIR" PATH="$STUBDIR:$PATH" \
+  ACQ_FORCE_KIT_REAPPLY=1 bash -c '
+    ACQ_SOURCE_ONLY=1 . "'"$ACQ"'" >/dev/null 2>&1
+    acq_resolve_backend sbx >/dev/null 2>&1
+    acq_backend_ensure_kits_applied sebox
+  ' 2>&1
+) || true
+assert_contains "heal(sbx 0.38, set -e): recreate notice still prints" "$out" "cannot extend a live sandbox with startup-bearing kits"
+assert_contains "heal(sbx 0.38, set -e): Zscaler kit attempted" "$out" "missing the Zscaler CA kit"
+assert_contains "heal(sbx 0.38, set -e): USAi kit still attempted (no early abort)" "$out" "missing the USAi kit"
+assert_contains "heal(sbx 0.38, set -e): playbook kit still attempted (no early abort)" "$out" "missing the playbook kit"
+cleanup_stubs
+
 # 9q3. `acq kit update` fails fast with the recreate guidance under the refusal
 #      (rather than looping per-kit warnings).
 make_stubs; load_acq

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -4859,6 +4859,40 @@ assert_contains "heal(sbx): non-refusal failure surfaces sbx stderr" "$out" "som
 assert_not_contains "heal(sbx): non-refusal failure is NOT the recreate message" "$out" "cannot extend a live sandbox"
 cleanup_stubs
 
+# 9q4b. A REWORDED 0.38 refusal (sbx changes its exact wording but still names
+#       startup + recreate) is STILL classified as a refusal, not degraded to a
+#       generic failure. Guards the heuristic pattern in _acq_sbx_kit_add against
+#       upstream rewording (review finding: the match is prose-anchored).
+make_stubs; load_acq
+cat >"$STUBDIR/sbx" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'sbx'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >>"$CALLS"
+case "${1:-}" in
+  version) printf 'sbx version: v0.38.0 abc123\n' ;;
+  ls) [ -f "$STUBDIR/.sandbox_list" ] && cat "$STUBDIR/.sandbox_list"; exit 0 ;;
+  kit)
+    if [ "${2:-}" = "add" ]; then
+      # Reworded refusal: no literal "setup.startup" token, but still says the
+      # kit declares startup commands and must recreate the sandbox.
+      printf 'Error: this kit declares startup commands; recreate the sandbox to apply it\n' >&2
+      exit 1
+    fi
+    exit 0 ;;
+  exec)
+    snippet=""; prev=""
+    for a in "$@"; do [ "$prev" = "-c" ] && { snippet="$a"; break; }; prev="$a"; done
+    case "$snippet" in *present*) printf 'absent\n' ;; *) exit 0 ;; esac ;;
+  settings) exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$STUBDIR/sbx"
+printf 'rewordbox\n' > "$STUBDIR/.sandbox_list"
+out=$(acq_backend_ensure_kits_applied rewordbox 2>&1) || true
+assert_contains "heal(sbx): reworded refusal still classified as recreate" "$out" "cannot extend a live sandbox with startup-bearing kits"
+assert_not_contains "heal(sbx): reworded refusal is not surfaced as a raw failure" "$out" "declares startup commands; recreate the sandbox to apply it"
+cleanup_stubs
+
 # 9q5. STALE PLAYBOOK PROBE: the heal probes the tarball-era footprint
 #      (~/.agentic-coding-playbook/AGENTS.md), NOT the git-clone-era /.git. When
 #      AGENTS.md is present the playbook add is skipped; the probe snippet must
@@ -4909,6 +4943,29 @@ make_stubs; load_acq
   acq_backend_provision climarkerbox shell /tmp >/dev/null 2>&1 ) || true
 log=$(cat "$CALLS")
 assert_contains "provision(sbx): marks CLI --kit ref into ~/.acq-extra-kits at create" "$log" "cli-kit-x"
+cleanup_stubs
+
+# 9q7b. CREATE FAILURE writes NO marker: if `sbx create` fails, the marker block
+#       is gated behind the success check, so no ~/.acq-extra-kits write happens
+#       (mirrors the provenance-write contract — a failed create claims nothing).
+make_stubs; load_acq
+# sbx stub whose `create` FAILS; everything else no-ops.
+cat >"$STUBDIR/sbx" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'sbx'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >>"$CALLS"
+case "${1:-}" in
+  version) printf 'sbx version: v0.38.0 abc123\n' ;;
+  create) printf 'ERROR: create failed\n' >&2; exit 1 ;;
+  exec) printf 'ok\n' ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$STUBDIR/sbx"
+: > "$CALLS"
+( export ACQ_EXTRA_KITS="git+https://github.com/GSA-TTS/agentic-coding-patterns.git#ref=deadbeef&dir=fail-extra-kit"
+  acq_backend_provision failbox shell /tmp >/dev/null 2>&1 ) || true
+log=$(cat "$CALLS")
+assert_not_contains "provision(sbx): failed create writes NO extra-kit marker" "$log" ".acq-extra-kits"
 cleanup_stubs
 
 # 9q8. MARKER SUPPRESSES RE-APPLY: with the marker present, the re-attach heal

--- a/scripts/verify-git-https-secret-msb
+++ b/scripts/verify-git-https-secret-msb
@@ -53,7 +53,7 @@ set -u
 # msb's default guest-env placeholder for a bound secret is `$MSB_<ENV_VAR>`.
 # We embed it in the clone URL as the password; msb rewrites it to the real
 # token on the intercepted connection to an allowed github host.
-PLACEHOLDER='$MSB_GITHUB_TOKEN'
+PLACEHOLDER='$MSB_''GITHUB_TOKEN' # Avoids unintentional substitution in git; see superradcompany/microsandbox#1354
 GITHUB_HOSTS='github.com,api.github.com,codeload.github.com'
 IMAGE="${ACQ_MSB_IMAGE:-alpine}"
 DNS_NS="${ACQ_MSB_DNS_NAMESERVER:-1.1.1.1}"

--- a/scripts/verify-issue-320
+++ b/scripts/verify-issue-320
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# verify-issue-320 — live end-to-end check for the sbx-0.38 re-attach heal-loop
+# fix (GSA-TTS/agentic-coding-quickstart#320). This is the ONE host-side command
+# that reproduces the exact issue scenario against the real sbx toolchain and
+# asserts all three fixes:
+#
+#   1. sbx 0.38 `kit add` refuses startup-bearing kits — a genuine mid-life add
+#      surfaces ONE consolidated "recreate to extend/refresh" message (not
+#      per-kit warnings with bogus "Recover with: sbx kit add" hints), and
+#      `acq kit update` fails fast with the same guidance.
+#   2. The playbook feature-probe uses ~/.agentic-coding-playbook/AGENTS.md
+#      (survives the tarball delivery), so a correctly-provisioned sandbox does
+#      NOT report "missing the playbook kit" on re-attach.
+#   3. The ~/.acq-extra-kits marker is written at CREATE for extra/CLI kits, so
+#      re-attach treats them as applied and does NOT re-attempt them.
+#
+# The net observable win is: a second `acq run <name>` (re-attach) is a QUIET
+# no-op for a correctly-provisioned sandbox — no per-attach heal noise.
+#
+# Requires a real sbx-capable host with sbx 0.38+ and acq (this CANNOT run inside
+# a sandbox — no nested sandboxes). It is self-contained and idempotent: it
+# stands up a throwaway sandbox WITH an extra startup-bearing kit, detaches,
+# re-attaches, asserts the fixed behavior, and always cleans up.
+#
+# Usage:
+#   ./scripts/verify-issue-320 [SANDBOX_NAME]
+# Default sandbox name: v320
+set -u
+
+SANDBOX="${1:-v320}"
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+ACQ="$SCRIPT_DIR/acq"
+BE=(--backend sbx)
+
+# Throwaway workspace + extra-kit dirs. The extra kit declares a `startup`
+# command so it is exactly the class sbx 0.38 refuses to add mid-life — that is
+# what exercises fixes #1 and #3.
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/v320-ws.XXXXXX")
+KITDIR=$(mktemp -d "${TMPDIR:-/tmp}/v320-kit.XXXXXX")
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  \033[32mok  \033[0m %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  \033[31mBAD \033[0m %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
+info() { printf '\n== %s ==\n' "$1"; }
+
+cleanup() {
+  info "cleanup"
+  "$ACQ" "${BE[@]}" rm "$SANDBOX" >/dev/null 2>&1 && echo "  removed sandbox $SANDBOX" || true
+  rm -rf "$WORKDIR" "$KITDIR" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# --- 0. Preconditions ------------------------------------------------------
+info "preconditions"
+if [ -f /.dockerenv ] || [ -n "${SBX_SANDBOX:-}" ] || [ -n "${MSB_SANDBOX:-}" ]; then
+  bad "refusing to run inside a sandbox (no nested sandboxes) — run on an sbx host"
+  exit 2
+fi
+command -v sbx >/dev/null 2>&1 && ok "sbx on PATH ($(sbx version 2>/dev/null | head -1))" || { bad "sbx not on PATH"; exit 1; }
+# The fixes target sbx 0.38+ behavior; older sbx will still pass the quiet-heal
+# assertions but the refusal path (#1) only fires on >= 0.38. Note the version.
+_sbxver=$(sbx version 2>/dev/null | head -1)
+printf '        sbx version: %s\n' "$_sbxver"
+
+# A real workspace the create can mount.
+( cd "$WORKDIR" && git init -q 2>/dev/null && echo hi > README.md ) || true
+
+# Fresh start: remove any stale sandbox of this name.
+"$ACQ" "${BE[@]}" rm "$SANDBOX" >/dev/null 2>&1 || true
+
+# --- 1. Write a throwaway extra kit that DECLARES a startup command ---------
+# This is the crux: a startup-bearing kit is exactly what sbx 0.38 `kit add`
+# refuses mid-life. Applied at CREATE via --kit, it must (a) get markered in
+# ~/.acq-extra-kits (fix #3) and (b) NOT be re-attempted on re-attach.
+cat > "$KITDIR/spec.yaml" <<'EOF'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: v320-extra
+displayName: Issue-320 Extra Kit
+description: startup-bearing extra kit for the #320 re-attach live check
+commands:
+  - phase: startup
+    command:
+      - sh
+      - -c
+      - 'echo v320-extra-startup-ran > /tmp/v320-extra.marker'
+EOF
+
+# --- 2. Create the sandbox WITH the extra startup-bearing kit --------------
+info "create sandbox ($SANDBOX) with a startup-bearing extra kit (via --kit)"
+# Non-interactive: decline the github-scope prompt by feeding "N" on stdin.
+if printf 'N\n' | "$ACQ" "${BE[@]}" create shell "$WORKDIR" --name "$SANDBOX" --kit "$KITDIR" >/tmp/v320-create.log 2>&1; then
+  ok "acq create (with startup-bearing --kit) returned 0"
+else
+  bad "acq create failed" "$(tail -8 /tmp/v320-create.log)"; exit 1
+fi
+if sbx ls 2>/dev/null | grep -q "$SANDBOX"; then ok "sandbox is listed"; else bad "sandbox not listed"; exit 1; fi
+
+# --- 3. FIX #3: the extra-kit marker was written AT CREATE -----------------
+info "FIX #3: ~/.acq-extra-kits marker written at create"
+marker=$("$ACQ" "${BE[@]}" exec "$SANDBOX" -- sh -c 'cat "$HOME/.acq-extra-kits" 2>/dev/null' 2>/dev/null || true)
+printf '%s\n' "$marker" | sed 's/^/    | /'
+if printf '%s\n' "$marker" | grep -q "$KITDIR"; then
+  ok "marker lists the extra kit ref applied at create"
+else
+  bad "marker missing the create-time extra kit (fix #3 regression)" "marker was: $marker"
+fi
+
+# --- 4. FIX #2 + #3: re-attach is a QUIET no-op ----------------------------
+# The heal runs on re-attach. With the AGENTS.md probe (fix #2) and the
+# create-time marker (fix #3), a correctly-provisioned sandbox must NOT report a
+# missing playbook kit and must NOT re-attempt the extra kit. We drive just the
+# heal (not a full interactive attach) via `acq kit check`, which does not heal;
+# instead re-run the code path by invoking `acq run` non-interactively is
+# awkward (it would attach). So exercise the heal directly through a re-attach
+# with a no-op agent command and capture its stderr.
+info "FIX #2/#3: re-attach heal produces no per-attach noise"
+# `acq run <name> -- true` re-attaches to the existing sandbox, runs the heal,
+# then runs `true` and exits — capturing the heal's stderr without an
+# interactive session.
+reattach_out=$(printf 'N\n' | "$ACQ" "${BE[@]}" run "$SANDBOX" -- true 2>&1 || true)
+printf '%s\n' "$reattach_out" | sed 's/^/    | /'
+if printf '%s\n' "$reattach_out" | grep -q "missing the playbook kit"; then
+  bad "re-attach reported 'missing the playbook kit' (fix #2 regression)"
+else
+  ok "re-attach did NOT report a missing playbook kit (fix #2)"
+fi
+if printf '%s\n' "$reattach_out" | grep -q "applying extra kit to '$SANDBOX': $KITDIR"; then
+  bad "re-attach re-attempted the create-time extra kit (fix #3 regression)"
+else
+  ok "re-attach did NOT re-attempt the create-time extra kit (fix #3)"
+fi
+if printf '%s\n' "$reattach_out" | grep -q "Recover with: sbx kit add"; then
+  bad "re-attach printed the bogus 'Recover with: sbx kit add' hint (fix #1 regression)"
+else
+  ok "re-attach did not print the bogus per-kit recover hint (fix #1)"
+fi
+
+# --- 5. FIX #1: a genuine mid-life add is refused with ONE clear message ----
+# Force the heal to try re-adding the whole built-in bundle mid-life
+# (ACQ_FORCE_KIT_REAPPLY=1, as `acq kit update` does). On sbx 0.38 every
+# startup-bearing built-in is refused; acq must print exactly ONE consolidated
+# recreate notice, not per-kit warnings.
+info "FIX #1: forced mid-life re-add surfaces one recreate message"
+force_out=$(ACQ_FORCE_KIT_REAPPLY=1 "$ACQ" "${BE[@]}" run "$SANDBOX" -- true 2>&1 || true)
+printf '%s\n' "$force_out" | sed 's/^/    | /'
+_notice_count=$(printf '%s\n' "$force_out" | grep -c "cannot extend a live sandbox with startup-bearing kits" || true)
+case "$_sbxver" in
+  *0.3[89]*|*0.4*|*0.5*|*1.*)
+    # sbx >= 0.38: the refusal path should fire and be consolidated to one notice.
+    if [ "$_notice_count" -ge 1 ]; then
+      ok "printed the sbx-0.38 recreate notice on forced mid-life re-add"
+    else
+      bad "no recreate notice on forced re-add (expected on sbx >= 0.38)" "count=$_notice_count"
+    fi
+    if [ "$_notice_count" -le 1 ]; then
+      ok "recreate notice emitted at most once (not per-kit)"
+    else
+      bad "recreate notice emitted $_notice_count times (should be once per heal)"
+    fi
+    ;;
+  *)
+    ok "sbx < 0.38 detected — startup-kit refusal path not applicable, skipping notice assertion"
+    ;;
+esac
+
+# --- 6. FIX #1: `acq kit update` fails fast --------------------------------
+# On a stale/unknown sandbox under sbx 0.38, `acq kit update --yes` must fail
+# fast (non-zero) rather than loop per-kit. (If the sandbox is already "current"
+# acq short-circuits with exit 0 and prints "already on the pinned bundle" —
+# that is also acceptable, since there is nothing to re-add.)
+info "FIX #1: acq kit update fails fast (or is a no-op if already current)"
+ku_out=$("$ACQ" "${BE[@]}" kit update "$SANDBOX" --yes 2>&1); ku_rc=$?
+printf '%s\n' "$ku_out" | sed 's/^/    | /'
+if printf '%s\n' "$ku_out" | grep -q "already on the pinned bundle"; then
+  ok "kit update short-circuited (sandbox already current) — nothing to re-add"
+elif [ "$ku_rc" -ne 0 ]; then
+  ok "kit update failed fast (rc=$ku_rc) with guidance instead of per-kit looping"
+  printf '%s\n' "$ku_out" | grep -q "cannot extend a live sandbox with startup-bearing kits" \
+    && ok "kit update surfaced the recreate guidance" \
+    || bad "kit update failed but without the recreate guidance"
+else
+  bad "kit update returned 0 without being 'already current' (expected fail-fast on 0.38)"
+fi
+
+# --- Summary ---------------------------------------------------------------
+printf '\n  passed: %d   failed: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/verify-issue-320
+++ b/scripts/verify-issue-320
@@ -64,9 +64,30 @@ if [ -f /.dockerenv ] || [ -n "${SBX_SANDBOX:-}" ] || [ -n "${MSB_SANDBOX:-}" ];
 fi
 command -v sbx >/dev/null 2>&1 && ok "sbx on PATH ($(sbx version 2>/dev/null | head -1))" || { bad "sbx not on PATH"; exit 1; }
 # The fixes target sbx 0.38+ behavior; older sbx will still pass the quiet-heal
-# assertions but the refusal path (#1) only fires on >= 0.38. Note the version.
+# assertions but the refusal path (#1) only fires on >= 0.38. Parse the numeric
+# version and compare NUMERICALLY (not by globbing version ranges, which would
+# silently miss 0.6.x / 0.100.x / 2.x and skip the fix-#1 assertion on a future
+# host). SBX_IS_038 is 1 when sbx >= 0.38.0.
 _sbxver=$(sbx version 2>/dev/null | head -1)
 printf '        sbx version: %s\n' "$_sbxver"
+# _ver_ge A B — echo "yes" if version A >= B (major.minor.patch, missing parts=0).
+_ver_ge() {
+  _va=$(printf '%s' "$1" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1)
+  _vb="$2"
+  IFS='.' read -r a1 a2 a3 <<EOF
+$_va
+EOF
+  IFS='.' read -r b1 b2 b3 <<EOF
+$_vb
+EOF
+  a1=${a1:-0}; a2=${a2:-0}; a3=${a3:-0}
+  b1=${b1:-0}; b2=${b2:-0}; b3=${b3:-0}
+  if [ "$a1" -ne "$b1" ]; then [ "$a1" -gt "$b1" ] && echo yes || echo no; return; fi
+  if [ "$a2" -ne "$b2" ]; then [ "$a2" -gt "$b2" ] && echo yes || echo no; return; fi
+  if [ "$a3" -ge "$b3" ]; then echo yes; else echo no; fi
+}
+SBX_IS_038=0
+[ "$(_ver_ge "$_sbxver" 0.38.0)" = "yes" ] && SBX_IS_038=1
 
 # A real workspace the create can mount.
 ( cd "$WORKDIR" && git init -q 2>/dev/null && echo hi > README.md ) || true
@@ -196,24 +217,21 @@ info "FIX #1: forced mid-life re-add surfaces one recreate message"
 force_out=$(ACQ_FORCE_KIT_REAPPLY=1 "$ACQ" "${BE[@]}" run "$SANDBOX" -- sh -c ':' 2>&1 || true)
 printf '%s\n' "$force_out" | sed 's/^/    | /'
 _notice_count=$(printf '%s\n' "$force_out" | grep -c "cannot extend a live sandbox with startup-bearing kits" || true)
-case "$_sbxver" in
-  *0.3[89]*|*0.4*|*0.5*|*1.*)
-    # sbx >= 0.38: the refusal path should fire and be consolidated to one notice.
-    if [ "$_notice_count" -ge 1 ]; then
-      ok "printed the sbx-0.38 recreate notice on forced mid-life re-add"
-    else
-      bad "no recreate notice on forced re-add (expected on sbx >= 0.38)" "count=$_notice_count"
-    fi
-    if [ "$_notice_count" -le 1 ]; then
-      ok "recreate notice emitted at most once (not per-kit)"
-    else
-      bad "recreate notice emitted $_notice_count times (should be once per heal)"
-    fi
-    ;;
-  *)
-    ok "sbx < 0.38 detected — startup-kit refusal path not applicable, skipping notice assertion"
-    ;;
-esac
+if [ "$SBX_IS_038" = "1" ]; then
+  # sbx >= 0.38: the refusal path should fire and be consolidated to one notice.
+  if [ "$_notice_count" -ge 1 ]; then
+    ok "printed the sbx-0.38 recreate notice on forced mid-life re-add"
+  else
+    bad "no recreate notice on forced re-add (expected on sbx >= 0.38)" "count=$_notice_count"
+  fi
+  if [ "$_notice_count" -le 1 ]; then
+    ok "recreate notice emitted at most once (not per-kit)"
+  else
+    bad "recreate notice emitted $_notice_count times (should be once per heal)"
+  fi
+else
+  ok "sbx < 0.38 detected — startup-kit refusal path not applicable, skipping notice assertion"
+fi
 
 # --- 6. FIX #1: `acq kit update` fails fast --------------------------------
 # On a stale/unknown sandbox under sbx 0.38, `acq kit update --yes` must fail

--- a/scripts/verify-issue-320
+++ b/scripts/verify-issue-320
@@ -46,10 +46,15 @@ info() { printf '\n== %s ==\n' "$1"; }
 
 cleanup() {
   info "cleanup"
+  _unseed_github
   "$ACQ" "${BE[@]}" rm "$SANDBOX" >/dev/null 2>&1 && echo "  removed sandbox $SANDBOX" || true
   rm -rf "$WORKDIR" "$KITDIR" 2>/dev/null || true
 }
 trap cleanup EXIT INT TERM
+
+# _unseed_github is defined later (after SANDBOX/GH_SEEDED are known); guard the
+# trap against firing before it exists.
+_unseed_github() { :; }
 
 # --- 0. Preconditions ------------------------------------------------------
 info "preconditions"
@@ -65,6 +70,42 @@ printf '        sbx version: %s\n' "$_sbxver"
 
 # A real workspace the create can mount.
 ( cd "$WORKDIR" && git init -q 2>/dev/null && echo hi > README.md ) || true
+
+# --- 0b. Seed a GitHub token so the (private) playbook tarball fetch works --
+# The built-in agentic-coding-playbook kit fetches a PRIVATE repo source tarball
+# from api.github.com at create; without a token the fetch fails and
+# ~/.agentic-coding-playbook/AGENTS.md never lands — which would make the
+# "playbook present on re-attach" assertion (fix #2) fail for an ENVIRONMENTAL
+# reason, not a real regression. Mirror scripts/verify-backends: seed a
+# sandbox-scoped github secret from an env token or `gh auth token` BEFORE
+# create. If none is available, the playbook assertion is SKIPPED (not failed) —
+# a token-less run still validates fixes #1 and #3.
+_gh_token() {
+  if [ -n "${GH_TOKEN:-}" ]; then printf '%s' "$GH_TOKEN"; return 0; fi
+  if [ -n "${GITHUB_TOKEN:-}" ]; then printf '%s' "$GITHUB_TOKEN"; return 0; fi
+  command -v gh >/dev/null 2>&1 || return 0
+  gh auth token 2>/dev/null || true
+}
+GH_SEEDED=0
+_gt=$(_gh_token)
+if [ -n "$_gt" ]; then
+  # `acq secret set <sandbox> github` reads the value on stdin (never argv).
+  if printf '%s\n' "$_gt" | "$ACQ" "${BE[@]}" secret set "$SANDBOX" github >/dev/null 2>&1; then
+    GH_SEEDED=1
+    ok "seeded sandbox-scoped github token (playbook fetch can authenticate)"
+  else
+    printf '        note: could not seed github token; playbook assertion will be skipped\n'
+  fi
+else
+  printf '        note: no github token (env or gh); playbook assertion will be skipped\n'
+fi
+_gt=""
+
+# Clean up the seeded secret on exit (in addition to sandbox teardown).
+_unseed_github() {
+  [ "$GH_SEEDED" = "1" ] || return 0
+  "$ACQ" "${BE[@]}" secret rm "$SANDBOX" github >/dev/null 2>&1 || true
+}
 
 # Fresh start: remove any stale sandbox of this name.
 "$ACQ" "${BE[@]}" rm "$SANDBOX" >/dev/null 2>&1 || true
@@ -110,21 +151,30 @@ fi
 # --- 4. FIX #2 + #3: re-attach is a QUIET no-op ----------------------------
 # The heal runs on re-attach. With the AGENTS.md probe (fix #2) and the
 # create-time marker (fix #3), a correctly-provisioned sandbox must NOT report a
-# missing playbook kit and must NOT re-attempt the extra kit. We drive just the
-# heal (not a full interactive attach) via `acq kit check`, which does not heal;
-# instead re-run the code path by invoking `acq run` non-interactively is
-# awkward (it would attach). So exercise the heal directly through a re-attach
-# with a no-op agent command and capture its stderr.
+# missing playbook kit and must NOT re-attempt the extra kit. We exercise the
+# heal by re-attaching with a no-op agent command and capturing its stderr (the
+# heal runs before the agent command on the re-attach path).
 info "FIX #2/#3: re-attach heal produces no per-attach noise"
-# `acq run <name> -- true` re-attaches to the existing sandbox, runs the heal,
-# then runs `true` and exits — capturing the heal's stderr without an
-# interactive session.
-reattach_out=$(printf 'N\n' | "$ACQ" "${BE[@]}" run "$SANDBOX" -- true 2>&1 || true)
+# `acq run <name> -- CMD` re-attaches to the existing sandbox, runs the heal,
+# then runs CMD and exits — capturing the heal's stderr without an interactive
+# session. Use `sh -c :` (a shell builtin no-op) rather than `true`: the sbx
+# agent templates route `-- CMD` through a shell, and a bare `true` was observed
+# to hit the guest's non-executable /usr/bin/true ("cannot execute binary
+# file" / exit 126) on the shell agent. `sh -c :` always succeeds and never
+# needs an executable lookup.
+reattach_out=$(printf 'N\n' | "$ACQ" "${BE[@]}" run "$SANDBOX" -- sh -c ':' 2>&1 || true)
 printf '%s\n' "$reattach_out" | sed 's/^/    | /'
-if printf '%s\n' "$reattach_out" | grep -q "missing the playbook kit"; then
-  bad "re-attach reported 'missing the playbook kit' (fix #2 regression)"
+if [ "$GH_SEEDED" = "1" ]; then
+  if printf '%s\n' "$reattach_out" | grep -q "missing the playbook kit"; then
+    bad "re-attach reported 'missing the playbook kit' (fix #2 regression)"
+  else
+    ok "re-attach did NOT report a missing playbook kit (fix #2)"
+  fi
 else
-  ok "re-attach did NOT report a missing playbook kit (fix #2)"
+  # Without a token the playbook tarball fetch could not run at create, so the
+  # playbook is legitimately absent — the "missing" line here is expected and
+  # NOT a fix-#2 regression. Skip the assertion rather than fail spuriously.
+  printf '        skip  fix #2 playbook-present assertion (no github token seeded)\n'
 fi
 if printf '%s\n' "$reattach_out" | grep -q "applying extra kit to '$SANDBOX': $KITDIR"; then
   bad "re-attach re-attempted the create-time extra kit (fix #3 regression)"
@@ -143,7 +193,7 @@ fi
 # startup-bearing built-in is refused; acq must print exactly ONE consolidated
 # recreate notice, not per-kit warnings.
 info "FIX #1: forced mid-life re-add surfaces one recreate message"
-force_out=$(ACQ_FORCE_KIT_REAPPLY=1 "$ACQ" "${BE[@]}" run "$SANDBOX" -- true 2>&1 || true)
+force_out=$(ACQ_FORCE_KIT_REAPPLY=1 "$ACQ" "${BE[@]}" run "$SANDBOX" -- sh -c ':' 2>&1 || true)
 printf '%s\n' "$force_out" | sed 's/^/    | /'
 _notice_count=$(printf '%s\n' "$force_out" | grep -c "cannot extend a live sandbox with startup-bearing kits" || true)
 case "$_sbxver" in

--- a/scripts/verify-issue-320
+++ b/scripts/verify-issue-320
@@ -169,21 +169,32 @@ else
   bad "marker missing the create-time extra kit (fix #3 regression)" "marker was: $marker"
 fi
 
-# --- 4. FIX #2 + #3: re-attach is a QUIET no-op ----------------------------
+# --- 4. FIX #2 + #3: re-attach heal is a QUIET no-op ----------------------
 # The heal runs on re-attach. With the AGENTS.md probe (fix #2) and the
 # create-time marker (fix #3), a correctly-provisioned sandbox must NOT report a
-# missing playbook kit and must NOT re-attempt the extra kit. We exercise the
-# heal by re-attaching with a no-op agent command and capturing its stderr (the
-# heal runs before the agent command on the re-attach path).
+# missing playbook kit and must NOT re-attempt the extra kit.
+#
+# We invoke the EXACT function the re-attach path calls
+# (acq_backend_ensure_kits_applied) directly, by sourcing acq in a subshell with
+# ACQ_SOURCE_ONLY=1 — the same pattern scripts/verify-backends uses to reach acq
+# internals. This exercises the real heal with NO agent attach, so we avoid the
+# sbx shell-agent's `-- CMD` execution path entirely (a bare `acq run <name> --
+# CMD` routes CMD to the guest's non-executable /bin/sh and prints a confusing
+# "agent exited with code 126" that has nothing to do with the heal under test).
 info "FIX #2/#3: re-attach heal produces no per-attach noise"
-# `acq run <name> -- CMD` re-attaches to the existing sandbox, runs the heal,
-# then runs CMD and exits — capturing the heal's stderr without an interactive
-# session. Use `sh -c :` (a shell builtin no-op) rather than `true`: the sbx
-# agent templates route `-- CMD` through a shell, and a bare `true` was observed
-# to hit the guest's non-executable /usr/bin/true ("cannot execute binary
-# file" / exit 126) on the shell agent. `sh -c :` always succeeds and never
-# needs an executable lookup.
-reattach_out=$(printf 'N\n' | "$ACQ" "${BE[@]}" run "$SANDBOX" -- sh -c ':' 2>&1 || true)
+_run_heal() {
+  # $1: extra env assignments (e.g. "ACQ_FORCE_KIT_REAPPLY=1"), or empty.
+  # acq is a bash script (arrays, BASH_SOURCE), so source it with `bash`, not the
+  # host /bin/sh. ACQ_SOURCE_ONLY=1 makes acq return after loading its functions
+  # (and common.sh) without dispatching. Resolve the sbx backend, then run the
+  # real heal for $SANDBOX; capture stdout+stderr.
+  env $1 bash -c '
+    ACQ_SOURCE_ONLY=1 . "'"$ACQ"'" >/dev/null 2>&1
+    acq_resolve_backend sbx >/dev/null 2>&1
+    acq_backend_ensure_kits_applied "'"$SANDBOX"'"
+  ' 2>&1 || true
+}
+reattach_out=$(_run_heal "")
 printf '%s\n' "$reattach_out" | sed 's/^/    | /'
 if [ "$GH_SEEDED" = "1" ]; then
   if printf '%s\n' "$reattach_out" | grep -q "missing the playbook kit"; then
@@ -214,7 +225,7 @@ fi
 # startup-bearing built-in is refused; acq must print exactly ONE consolidated
 # recreate notice, not per-kit warnings.
 info "FIX #1: forced mid-life re-add surfaces one recreate message"
-force_out=$(ACQ_FORCE_KIT_REAPPLY=1 "$ACQ" "${BE[@]}" run "$SANDBOX" -- sh -c ':' 2>&1 || true)
+force_out=$(_run_heal "ACQ_FORCE_KIT_REAPPLY=1")
 printf '%s\n' "$force_out" | sed 's/^/    | /'
 _notice_count=$(printf '%s\n' "$force_out" | grep -c "cannot extend a live sandbox with startup-bearing kits" || true)
 if [ "$SBX_IS_038" = "1" ]; then


### PR DESCRIPTION
## Summary

Re-attaching to an existing sandbox (`acq run <name>`) on the **sbx** backend
attempted kit "heals" on every attach, and every attempt failed with the real
`sbx` error suppressed. Three compounding bugs (per
GSA-TTS/agentic-coding-quickstart#320) turned this into per-attach warning noise.
This PR fixes all three and adds offline + live coverage.

> **AI-assisted:** implemented with an AI coding agent (OpenCode). Human-owned and
> reviewed; live verification pending on a real sbx host (see below).

## Root cause (three compounding bugs)

1. **sbx 0.38 `kit add` refuses startup-bearing kits.** Per the
   [Docker kits docs](https://docs.docker.com/ai/sandboxes/customize/kits/),
   `sbx kit add` only applies mixin kits declaring exclusively
   `environment.variables`, `setup.install`, and `permissions.network.allow`. Every
   built-in acq kit declares startup commands (translated to `setup.startup`), so
   **all** mid-life built-in adds are refused. acq swallowed sbx's stderr
   (`>/dev/null 2>&1`) and printed a generic warning plus a misleading
   "Recover with: sbx kit add …" hint that itself cannot work.
2. **Stale playbook feature-probe.** The heal probed
   `test -e "$HOME/.agentic-coding-playbook/.git"`. Since patterns v1.8.0 moved
   playbook delivery from a git clone to a REST tarball (the #203 fix), the tree
   has **no `.git`**, so the probe reported the playbook absent on every re-attach,
   forever.
3. **`~/.acq-extra-kits` marker never written at create.** Only the heal path
   wrote it. A sandbox created **with** `ACQ_EXTRA_KITS` / `--kit` never got the
   marker, so every re-attach re-attempted every extra kit (and, under (1),
   warn-failed).

## Changes

- **`acq.backends/sbx.sh`**
  - New `_acq_sbx_kit_add` helper **captures** `sbx kit add` stderr and classifies
    the outcome (success / 0.38 startup-refusal / other failure). A new
    `_acq_sbx_print_recreate_notice` prints **one** consolidated
    "recreate to extend/refresh" message per heal
    (`acq rm <name> && acq run …`) instead of per-kit warnings with bogus recover
    hints. Genuine (non-refusal) failures now surface sbx's real diagnostic. The
    heal path, `acq kit apply`, and (via `acq_bundle_reapply`) `acq kit update`
    all use it; `acq kit update` fails fast. acq never auto-recreates (a recreate
    discards session/context — it stays a user-consented action).
  - Playbook probe changed to `test -e "$HOME/.agentic-coding-playbook/AGENTS.md"`,
    which survives **both** the historical git-clone and current tarball delivery
    (matches `scripts/verify-backends`).
  - `acq_backend_provision` seeds `~/.acq-extra-kits` at create for **every**
    extra/CLI kit (`ACQ_EXTRA_KITS` + `ACQ_CLI_KITS`), so re-attach treats them as
    applied.
- **Tests** — `scripts/test-acq`: new offline cases for refusal detection,
  once-per-heal message, `acq kit update` fail-fast, non-refusal stderr
  passthrough, the AGENTS.md probe, and create-time markering + re-apply
  suppression.
- **Live check** — `scripts/verify-issue-320`: a single self-contained host-side
  command that reproduces the exact scenario against the real sbx toolchain and
  asserts all three fixes.
- **Docs** — ADR-0009 update note, `KNOWN_FAILURE_MODES.md` §35 (new) + §19
  correction, `BACKEND_GUIDE.md` capability/limitation notes, `CONTRIBUTING.md`
  cross-link.

`msb` is unaffected (it re-applies kits idempotently via `msb exec`; no
`sbx kit add`).

## Verification

Offline (run in CI / this environment):

- `./scripts/test-acq` — **936 passed, 0 failed**.
- `shellcheck --severity=warning` clean on `acq`, `acq.backends/common.sh`,
  `acq.backends/sbx.sh`, and `scripts/verify-issue-320`
  (`scripts/test-acq` lints one-file-per-invocation per the repo's ShellCheck
  note; `bash -n` confirms its syntax).
- `markdownlint-cli2` — 0 errors on touched docs.

**Live end-to-end (REQUIRED before marking ready):** the sbx 0.38 refusal path
and the re-attach quiet-no-op cannot run in CI (no nested sandboxes). On a real
sbx 0.38+ host:

```bash
./scripts/verify-issue-320
```

This PR stays a **draft** until that live run is confirmed on-host; the result
will be posted as a PR update per AGENTS.md §8.3.

## Rollback

Revert the commits on this branch (`fix(sbx)`, `test(sbx)`, `docs`,
`test(sbx): verify-issue-320`). No schema/state migration; the changes are
behavioral in the heal path plus additive tests/docs.

## Security impact

None to auth/authz/data handling. The change **reduces** noise and stops emitting
misleading recovery guidance; it surfaces sbx's real stderr instead of hiding it.

## Notes

- Base branch is `fix/msb-token-substituion` (not `main`) so the pending
  token-substitution fix is excluded from this diff; retarget to `main` once that
  fix merges.
- Item (1) is fundamentally an upstream sbx limitation (the error's "not yet"
  suggests a future fix); this PR only improves acq's UX around it.

Refs: GSA-TTS/agentic-coding-quickstart#320
