### PR TITLE
fix(acq): persist --kit/extra refs and restore them on start/restart

### DIFF
--- a/acq
+++ b/acq
@@ -695,7 +695,8 @@ case "$subcommand" in
         # daemon kit) instead of coming back with the service dead. When `--kit`
         # WAS re-passed, ACQ_CLI_KITS is already populated and authoritative for
         # this invocation, so we must not clobber it — hence the empty-guard.
-        # See acq_cli_kits_load / docs/KNOWN_FAILURE_MODES.md #33.
+        # See acq_cli_kits_load and the "--kit Services Dead After a
+        # Resume/Reboot" section in docs/KNOWN_FAILURE_MODES.md.
         if [ "${#ACQ_CLI_KITS[@]}" -eq 0 ]; then
           acq_cli_kits_load "${ACQ_RESOLVED_BACKEND}" "$local_name"
         fi
@@ -769,7 +770,8 @@ case "$subcommand" in
       # startup on a name-only re-attach too (the user did not re-pass `--kit`
       # here). Guarded on an empty in-memory set so a `--kit` re-passed on THIS
       # invocation (already captured into ACQ_CLI_KITS) stays authoritative and
-      # is not clobbered. See acq_cli_kits_load / docs/KNOWN_FAILURE_MODES.md #33.
+      # is not clobbered. See acq_cli_kits_load and the "--kit Services Dead
+      # After a Resume/Reboot" section in docs/KNOWN_FAILURE_MODES.md.
       if [ "${#ACQ_CLI_KITS[@]}" -eq 0 ]; then
         acq_cli_kits_load "${ACQ_RESOLVED_BACKEND}" "$first"
       fi

--- a/acq
+++ b/acq
@@ -690,6 +690,15 @@ case "$subcommand" in
         # provenance record to "current", so reading status after it would never
         # see stale/unknown and the offer below would be dead.
         _pre_heal_status=$(acq_provenance_status "${ACQ_RESOLVED_BACKEND}" "$local_name")
+        # If the user did NOT re-pass `--kit` on this re-attach, reload the refs
+        # persisted at create so the heal re-runs their startup (e.g. a `--kit`
+        # daemon kit) instead of coming back with the service dead. When `--kit`
+        # WAS re-passed, ACQ_CLI_KITS is already populated and authoritative for
+        # this invocation, so we must not clobber it — hence the empty-guard.
+        # See acq_cli_kits_load / docs/KNOWN_FAILURE_MODES.md #33.
+        if [ "${#ACQ_CLI_KITS[@]}" -eq 0 ]; then
+          acq_cli_kits_load "${ACQ_RESOLVED_BACKEND}" "$local_name"
+        fi
         acq_backend_ensure_kits_applied "$local_name" || true
         # Existing sandbox: offer a refresh if it predates the pinned bundle.
         # Never blocks; skipped under --no-update-check / ACQ_UPDATE_CHECK=0. A
@@ -756,6 +765,14 @@ case "$subcommand" in
       # "current"), then heal, then offer a refresh. Never
       # blocks; skipped under --no-update-check / ACQ_UPDATE_CHECK=0.
       _pre_heal_status=$(acq_provenance_status "${ACQ_RESOLVED_BACKEND}" "$first")
+      # Reload persisted CLI (`--kit`) / extra kit refs so the heal re-runs their
+      # startup on a name-only re-attach too (the user did not re-pass `--kit`
+      # here). Guarded on an empty in-memory set so a `--kit` re-passed on THIS
+      # invocation (already captured into ACQ_CLI_KITS) stays authoritative and
+      # is not clobbered. See acq_cli_kits_load / docs/KNOWN_FAILURE_MODES.md #33.
+      if [ "${#ACQ_CLI_KITS[@]}" -eq 0 ]; then
+        acq_cli_kits_load "${ACQ_RESOLVED_BACKEND}" "$first"
+      fi
       acq_backend_ensure_kits_applied "$first" || true
       maybe_offer_bundle_refresh "${ACQ_RESOLVED_BACKEND}" "$first" "$_pre_heal_status"
       warn_if_no_ssh_signing_key
@@ -844,6 +861,12 @@ case "$subcommand" in
       exit 1
     fi
     acq_backend_start "$local_name"
+    # Reload the CLI (`--kit`) / extra kit refs persisted at provision so the
+    # heal below re-runs THEIR startup too, not just the built-ins. Without this
+    # a sandbox created with `--kit <daemon-kit>` resumes with that kit's
+    # supervised service dead (ports mapped, nothing listening). No-op for a
+    # legacy sandbox with no record. See acq_cli_kits_load.
+    acq_cli_kits_load "${ACQ_RESOLVED_BACKEND}" "$local_name"
     # Heal re-runs kit startup (idempotent). ensure_kits_applied on msb also
     # start-if-stopped guards internally, so this is safe even if the resume above
     # was a no-op on an already-running sandbox.
@@ -874,6 +897,9 @@ case "$subcommand" in
     acq_backend_stop "$local_name" \
       || echo "acq: restart: stop failed; attempting start anyway." >&2
     acq_backend_start "$local_name"
+    # Reload persisted CLI/extra kit refs so the heal re-runs their startup too
+    # (same rationale as the 'start' arm above). No-op for a legacy sandbox.
+    acq_cli_kits_load "${ACQ_RESOLVED_BACKEND}" "$local_name"
     acq_backend_ensure_kits_applied "$local_name" || true
     echo "acq: restarted '$local_name' and re-applied kit startup." >&2
     ;;

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -1218,6 +1218,113 @@ acq_bundle_reapply() {
   return 1
 }
 
+# ============================================================================
+# CLI / extra kit-reference persistence (restart durability)
+# ============================================================================
+# A sandbox created with `acq run … --kit <ref>` (ACQ_CLI_KITS) or with
+# ACQ_EXTRA_KITS in the environment carries kits whose `startup`-phase commands
+# (e.g. a supervised daemon) are re-run on a resume ONLY by acq's heal
+# (acq_backend_ensure_kits_applied); the backend's own `start`/resume does NOT
+# replay them. But those refs previously lived ONLY in-memory: `extract_kit_flags`
+# populates ACQ_CLI_KITS in the run/create dispatch arm, and ACQ_EXTRA_KITS is a
+# bare env var. So a later `acq start`/`acq restart` (which does not re-parse
+# `--kit` and runs in a shell that may not have ACQ_EXTRA_KITS exported) healed
+# with an EMPTY CLI/extra set and never re-ran those kits' startup — the sandbox
+# came back with the create-time ports mapped but nothing listening behind them.
+#
+# To close that gap we persist the CLI/extra kit refs HOST-SIDE at provision
+# (alongside the bundle provenance record) and reload them in the start/restart
+# verbs before the heal, so kit startup services are restored deterministically
+# without the user having to re-pass `--kit` or re-export ACQ_EXTRA_KITS.
+#
+# Design mirrors the provenance record: host-side only, keyed by backend +
+# sandbox name (same sanitized-filename + raw-name-checksum scheme), a tiny
+# dependency-free record, atomic temp+mv write, fail-open on any error. One kit
+# ref per line under a `kit=` key so a ref may safely contain characters that a
+# single-line list could not (refs are newline-free by construction). The
+# record's PRESENCE is authoritative: a sandbox created with no CLI/extra kits
+# writes an empty record, so reload never resurrects a stale ref, and a legacy
+# sandbox with no record simply reloads nothing (the pre-fix behavior).
+
+# Path to one sandbox's CLI/extra kit record. Same keying as the provenance file
+# so the two records sit side by side and never collide across backends/names.
+_acq_cli_kits_file() {
+  local backend="${1:-}" name="${2:-}"
+  [ -n "$backend" ] && [ -n "$name" ] || return 1
+  local safe_backend safe_name name_sum
+  safe_backend=$(printf '%s' "$backend" | tr -c 'A-Za-z0-9._-' '_')
+  safe_name=$(printf '%s' "$name" | tr -c 'A-Za-z0-9._-' '_')
+  name_sum=$(printf '%s' "$name" | cksum 2>/dev/null | cut -d' ' -f1 2>/dev/null || echo 0)
+  printf '%s/%s/%s.%s.kits\n' "$(_acq_provenance_dir)" "$safe_backend" "$safe_name" "$name_sum"
+}
+
+# Persist the current CLI (`--kit`) and extra (ACQ_EXTRA_KITS) kit refs for a
+# sandbox. Call ONLY after a successful provision. Writes an empty record when
+# there are no such kits, so the record's presence is authoritative on reload.
+# Best-effort: a write failure warns (debug) and returns non-zero but never
+# aborts the caller (fail-open).
+# Usage: acq_cli_kits_write BACKEND SANDBOX_NAME
+acq_cli_kits_write() {
+  local backend="${1:-}" name="${2:-}"
+  [ -n "$backend" ] && [ -n "$name" ] || return 1
+  local file dir
+  file=$(_acq_cli_kits_file "$backend" "$name") || return 1
+  dir=$(dirname "$file")
+  if ! mkdir -p "$dir" 2>/dev/null; then
+    acq_debug "cli-kits: could not create state dir: $dir"
+    return 1
+  fi
+  local tmp="${file}.tmp.$$" ref
+  {
+    printf 'schema=1\n'
+    # Extra (env-supplied) kits, split on whitespace like _build_kit_list.
+    if [ -n "${ACQ_EXTRA_KITS:-}" ]; then
+      local _extra=()
+      split_noglob _extra "$ACQ_EXTRA_KITS"
+      for ref in ${_extra[@]+"${_extra[@]}"}; do
+        [ -n "$ref" ] && printf 'extra=%s\n' "$ref"
+      done
+    fi
+    # CLI (`--kit`) refs, one per array element (already un-split).
+    for ref in ${ACQ_CLI_KITS[@]+"${ACQ_CLI_KITS[@]}"}; do
+      [ -n "$ref" ] && printf 'kit=%s\n' "$ref"
+    done
+  } > "$tmp" 2>/dev/null || { acq_debug "cli-kits: write failed: $tmp"; rm -f "$tmp" 2>/dev/null; return 1; }
+  chmod 600 "$tmp" 2>/dev/null || true
+  mv -f "$tmp" "$file" 2>/dev/null || { acq_debug "cli-kits: mv failed: $file"; rm -f "$tmp" 2>/dev/null; return 1; }
+  acq_debug "cli-kits: recorded $backend/$name (kit=$(printf '%s ' ${ACQ_CLI_KITS[@]+"${ACQ_CLI_KITS[@]}"}))"
+  return 0
+}
+
+# Reload a sandbox's persisted CLI (`--kit`) and extra kit refs into ACQ_CLI_KITS
+# / ACQ_EXTRA_KITS for the CURRENT shell, so a subsequent heal re-runs their
+# startup. Called by the start/restart verbs before ensure_kits_applied. No-op
+# (leaves the in-memory values untouched) when no record exists — a legacy
+# sandbox reloads nothing, exactly the pre-fix behavior. Fail-open.
+# Usage: acq_cli_kits_load BACKEND SANDBOX_NAME
+acq_cli_kits_load() {
+  local backend="${1:-}" name="${2:-}"
+  [ -n "$backend" ] && [ -n "$name" ] || return 0
+  local file
+  file=$(_acq_cli_kits_file "$backend" "$name") || return 0
+  [ -f "$file" ] || return 0
+  # A record exists: it is authoritative for this sandbox. Reset both to reflect
+  # exactly what was persisted (an empty record clears them).
+  ACQ_CLI_KITS=()
+  local _extras="" line val
+  while IFS= read -r line; do
+    case "$line" in
+      kit=*)   ACQ_CLI_KITS+=("${line#kit=}") ;;
+      extra=*) val="${line#extra=}"; [ -n "$val" ] && _extras="${_extras:+$_extras }$val" ;;
+    esac
+  done < "$file"
+  # Only overwrite ACQ_EXTRA_KITS from the record if the record carried extras;
+  # otherwise leave any env-supplied value in place (do not clobber the env).
+  [ -n "$_extras" ] && ACQ_EXTRA_KITS="$_extras"
+  acq_debug "cli-kits: reloaded $backend/$name (${#ACQ_CLI_KITS[@]} cli kit(s))"
+  return 0
+}
+
 # Automatic stale-sandbox advisory for `acq run` on an EXISTING sandbox. Compares
 # the sandbox's recorded bundle ref against the local pinned PATTERNS_KIT_REF and,
 # when they differ (or no record exists), OFFERS an in-place refresh. Contract:

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -2407,6 +2407,14 @@ EOF
   # Best-effort: a provenance write failure never affects the
   # sandbox. Reached only when provision did not abort earlier under set -e.
   acq_provenance_write msb "$name" || true
+
+  # Persist the CLI (`--kit`) and extra (ACQ_EXTRA_KITS) kit refs so a later
+  # `acq start`/`acq restart` can reload them and re-run their startup services
+  # (see acq_cli_kits_write). Without this, a resume heals only the built-ins +
+  # whatever ACQ_EXTRA_KITS the resume shell happens to export, leaving a
+  # `--kit` kit's supervised daemon dead (ports mapped, nothing listening).
+  # Best-effort; never affects the sandbox.
+  acq_cli_kits_write msb "$name" || true
 }
 
 # ---------------------------------------------------------------------------

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -374,6 +374,9 @@ acq_backend_provision() {
   # create must not leave a record claiming the sandbox is current.
   if [ "$_rc" -eq 0 ]; then
     acq_provenance_write sbx "$name" || true
+    # Persist the CLI (`--kit`) / extra kit refs alongside provenance so a later
+    # resume heal can reload them (see acq_cli_kits_write). Best-effort.
+    acq_cli_kits_write sbx "$name" || true
   fi
   return "$_rc"
 }

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -3,7 +3,7 @@ title: "Known Failure Modes"
 description: "Real-world failure patterns when using Docker SBX + USAi + agent frameworks"
 status: canonical
 tier: 2
-last_updated: "2026-08-17"
+last_updated: "2026-08-18"
 audience: "developers"
 keywords: ["debugging", "troubleshooting", "sbx", "usai", "failures"]
 ---
@@ -1530,31 +1530,52 @@ kit's services entirely absent.
 ### Root Cause
 
 A kit's `startup`-phase commands (which, for the openchamber kit, launch the
-supervised shared `opencode serve` on :4096 and the OpenChamber UI on :3000) are
-re-run on a resume **only** by acq's heal (`acq_backend_ensure_kits_applied`) —
-`msb start` alone does not replay them (ADR-0017). The heal, however, only
-re-applied the four **built-in** kits and any `ACQ_EXTRA_KITS`; it did **not**
-fold in kits supplied on the command line via `--kit` (`ACQ_CLI_KITS`). The
-provision path *does* fold those in, so the create-time `-p` port mappings for a
-`--kit` kit are part of the persisted sandbox config and are restored by msb on
-start — but the heal skipped the kit whose `startup` phase brings the services
-up. Result: ports restored, services not — exactly the "mapped but dead" state
-above.
+supervised shared `opencode serve` on :4096 and the OpenChamber UI on :3000; for
+the paseo kit, the daemon supervisor on :6767) are re-run on a resume **only** by
+acq's heal (`acq_backend_ensure_kits_applied`) — `msb start` alone does not replay
+them (ADR-0017). Two compounding gaps kept those services dead on resume:
+
+1. **The heal skipped CLI `--kit` kits.** It re-applied only the built-in kits and
+   any `ACQ_EXTRA_KITS`; it did not fold in kits supplied on the command line via
+   `--kit` (`ACQ_CLI_KITS`). Fixed by appending `ACQ_CLI_KITS` to the heal's kit
+   list — but that only helps when the array is populated.
+
+2. **The `--kit`/extra refs were never persisted.** `ACQ_CLI_KITS` is populated by
+   `extract_kit_flags` in the `run`/`create` dispatch arm only, and
+   `ACQ_EXTRA_KITS` is a bare environment variable. A later `acq start` /
+   `acq restart` (or a name-only `acq run <sandbox>`) does not re-parse `--kit` and
+   may run in a shell that never exported `ACQ_EXTRA_KITS`, so the heal ran with an
+   **empty** CLI/extra set and re-ran only the built-ins' startup. The provision
+   path *does* fold `--kit` in, so the create-time `-p` port mappings are part of
+   the persisted sandbox config and are restored by msb on start — but the heal
+   skipped the kit whose `startup` phase brings the services up. Result: ports
+   restored, services not — exactly the "mapped but dead" state above.
 
 ### Fix
 
-`acq_backend_ensure_kits_applied` in `acq.backends/msb.sh` now appends
-`ACQ_CLI_KITS` to the heal's kit list (after the built-ins and `ACQ_EXTRA_KITS`),
-matching how `acq_backend_provision` assembles the kit set. To recover an
-existing sandbox on a fixed `acq`, resume it with the SAME `--kit` ref you
-created it with, so the heal re-runs that kit's startup:
+Both gaps are closed:
+
+- `acq_backend_ensure_kits_applied` (msb) appends `ACQ_CLI_KITS` to the heal's kit
+  list, matching how `acq_backend_provision` assembles the kit set.
+- acq now **persists** the CLI (`--kit`) and `ACQ_EXTRA_KITS` refs host-side at
+  provision (a small `*.kits` record beside the bundle-provenance record, keyed by
+  backend + sandbox name) and **reloads** them in the `acq start` / `acq restart`
+  verbs and on a name-only `acq run <sandbox>` re-attach, *before* the heal. So a
+  `msb stop` + `acq start` cycle now re-runs a `--kit` kit's startup automatically
+  — **you no longer have to re-pass `--kit`.** The record's presence is
+  authoritative: a sandbox created with no CLI/extra kits reloads nothing, and a
+  legacy sandbox with no record behaves exactly as before (reload is a no-op).
+
+To recover a **legacy** sandbox (created before this fix, so it has no persisted
+record) without recreating it, resume it once with the SAME `--kit` ref you
+created it with, which both re-runs the kit's startup and writes the record for
+next time:
 
 ```bash
 acq run opencode --kit …/acq-kits/openchamber <path>   # heals + re-runs kit startup
 # or, if you don't need to attach:
-acq restart <sandbox>       # note: acq restart heals the built-ins + extras;
-                            # pass --kit via `acq run <sandbox> --kit …` to also
-                            # re-run a CLI kit's startup
+acq restart <sandbox>       # on a sandbox created by a fixed acq, this now
+                            # restores CLI-kit startup on its own
 ```
 
 If a resumed sandbox is already up but its services are dead, the quickest manual
@@ -1562,13 +1583,17 @@ kick is to re-run the kit's startup script directly:
 
 ```bash
 acq exec <sandbox> -- sh /home/agent/openchamber-start.sh &
+# (paseo kit: sh /home/agent/paseo-start.sh)
 ```
 
 ### Prevention / Status
 
-- Fixed in `acq.backends/msb.sh`; covered by the `clikit-heal` unit test in
-  `scripts/test-acq` (asserts a CLI `--kit` ref's files are re-applied during the
-  heal).
+- Fixed in `acq.backends/msb.sh` (heal folds CLI kits), `acq.backends/common.sh`
+  (`acq_cli_kits_write`/`acq_cli_kits_load` persistence), `acq.backends/sbx.sh`
+  (parity write), and the `acq` `start`/`restart`/`run` verbs (reload before
+  heal). Covered by the `clikit-heal` and `cli-kits:*` unit tests in
+  `scripts/test-acq` (persist-then-reload round-trip; a reloaded `--kit` ref is
+  re-applied during a resume heal).
 - Note the operational fact behind the original report: a live in-VM session does
   **not** survive a host reboot — the microVM is ephemeral; only the sandbox
   definition, its port config, and your mounted repos persist. Always commit work

--- a/docs/adr/0017-msb-create-time-startup-script-staging.md
+++ b/docs/adr/0017-msb-create-time-startup-script-staging.md
@@ -94,6 +94,40 @@ therefore shared between create and resume via a single helper
 after the msb child reads them (on both success and failure). This is also the
 reason native-restart-outside-acq is infeasible (above).
 
+## Update (2026-08-18): CLI/extra kit refs must be persisted for the resume heal
+
+The resume-heal mechanism above (`acq_backend_ensure_kits_applied` re-runs the
+`startup` phase) is only as complete as the **kit set** it iterates. Two follow-on
+gaps meant a sandbox created with `acq run … --kit <ref>` — the intended path for
+a supervised-daemon kit such as `paseo` or `openchamber` — still came back from a
+`msb stop` + `acq start` with its ports mapped but its daemon dead:
+
+1. `acq_backend_ensure_kits_applied` originally iterated only the built-in kits +
+   `ACQ_EXTRA_KITS`, skipping CLI `--kit` refs (`ACQ_CLI_KITS`). Fixed by folding
+   `ACQ_CLI_KITS` into the heal's kit list, matching `acq_backend_provision`.
+
+2. More fundamentally, the CLI/extra refs were **in-memory only**: `ACQ_CLI_KITS`
+   is populated by `extract_kit_flags` in the `run`/`create` dispatch arm, and
+   `ACQ_EXTRA_KITS` is a bare env var. The `start`/`restart` verbs do not re-parse
+   `--kit` and may run in a shell that never exported `ACQ_EXTRA_KITS`, so the heal
+   iterated an **empty** CLI/extra set and re-ran only the built-ins' startup.
+
+**Resolution.** acq persists the CLI (`--kit`) and `ACQ_EXTRA_KITS` refs
+host-side at provision — a small `*.kits` record beside the bundle-provenance
+record, keyed by backend + sandbox name, using the same sanitized-filename +
+raw-name-checksum scheme (`acq_cli_kits_write` / `acq_cli_kits_load` in
+`acq.backends/common.sh`; written from both `acq_backend_provision` on msb and
+`acq_backend_create` on sbx). The `start` / `restart` verbs and the name-only
+`acq run <sandbox>` re-attach **reload** that record into `ACQ_CLI_KITS` /
+`ACQ_EXTRA_KITS` *before* the heal, so a resume re-runs a `--kit` kit's startup
+**without the user re-passing `--kit`**. The record's presence is authoritative
+(an empty record clears stale in-memory refs; a legacy sandbox with no record is a
+no-op reload, preserving pre-fix behavior), and the reload is guarded so a `--kit`
+re-passed on the same invocation stays authoritative. This is consistent with the
+"restart durability is delivered by the acq verb, not native msb replay" posture
+above: the verb now restores the *full* kit set, not just the built-ins. See
+`docs/KNOWN_FAILURE_MODES.md` §33.
+
 ---
 
 # ADR-0017: Stage msb kit startup commands as a create-time script for restart durability (original)

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -4768,6 +4768,123 @@ assert_not_contains "provision(sbx): no notice when SSH_AUTH_SOCK is unset" "$sb
 cleanup_stubs
 
 # ===========================================================================
+# 9r. CLI/extra kit-reference persistence (restart durability)
+# ===========================================================================
+# A sandbox created with `--kit <ref>` (ACQ_CLI_KITS) or ACQ_EXTRA_KITS must have
+# those refs persisted host-side at provision and reloaded on start/restart, so a
+# resume heal re-runs their startup services (the Paseo/openchamber daemon case).
+# These drive the helpers directly (host-side, no exec); ACQ_PROVENANCE_DIR is
+# isolated per-test by make_stubs.
+
+# 9r1. Round-trip: write ACQ_CLI_KITS, then a shell with an EMPTY in-memory set
+#      reloads exactly what was persisted.
+make_stubs; load_acq
+ACQ_CLI_KITS=("/kits/paseo" "git+https://example.com/x.git#dir=k")
+ACQ_EXTRA_KITS=""
+acq_cli_kits_write msb clibox
+# Simulate a fresh `acq start` shell: nothing in memory.
+ACQ_CLI_KITS=()
+acq_cli_kits_load msb clibox
+assert_eq "cli-kits: reload count" "2" "${#ACQ_CLI_KITS[@]}"
+assert_eq "cli-kits: reload ref 0" "/kits/paseo" "${ACQ_CLI_KITS[0]}"
+assert_eq "cli-kits: reload ref 1" "git+https://example.com/x.git#dir=k" "${ACQ_CLI_KITS[1]}"
+cleanup_stubs
+
+# 9r2. Empty record is authoritative: a sandbox created with NO cli/extra kits
+#      writes a record whose reload CLEARS any stale in-memory refs (never
+#      resurrects a ref from an unrelated invocation).
+make_stubs; load_acq
+ACQ_CLI_KITS=(); ACQ_EXTRA_KITS=""
+acq_cli_kits_write msb emptybox
+ACQ_CLI_KITS=("/stale/leftover")
+acq_cli_kits_load msb emptybox
+assert_eq "cli-kits: empty record clears in-memory refs" "0" "${#ACQ_CLI_KITS[@]}"
+cleanup_stubs
+
+# 9r3. Legacy sandbox (NO record at all) is a no-op: reload leaves the in-memory
+#      set untouched (pre-fix behavior; nothing to resurrect, nothing to clear).
+make_stubs; load_acq
+ACQ_CLI_KITS=("/still/here")
+acq_cli_kits_load msb legacybox     # no record written
+assert_eq "cli-kits: no record leaves memory untouched" "1" "${#ACQ_CLI_KITS[@]}"
+assert_eq "cli-kits: no record keeps the ref" "/still/here" "${ACQ_CLI_KITS[0]}"
+cleanup_stubs
+
+# 9r4. ACQ_EXTRA_KITS (env-supplied, whitespace-split) is persisted and reloaded
+#      into ACQ_EXTRA_KITS; the record does not clobber env when it has no extras.
+make_stubs; load_acq
+ACQ_CLI_KITS=(); ACQ_EXTRA_KITS="/kits/a /kits/b"
+acq_cli_kits_write msb extrabox
+ACQ_EXTRA_KITS=""; ACQ_CLI_KITS=()
+acq_cli_kits_load msb extrabox
+assert_contains "cli-kits: reloads extra kit a" "$ACQ_EXTRA_KITS" "/kits/a"
+assert_contains "cli-kits: reloads extra kit b" "$ACQ_EXTRA_KITS" "/kits/b"
+cleanup_stubs
+
+# 9r5. Backend keying: same name under msb vs sbx does not alias.
+make_stubs; load_acq
+ACQ_CLI_KITS=("/kits/msbonly"); ACQ_EXTRA_KITS=""
+acq_cli_kits_write msb dupname
+ACQ_CLI_KITS=("SENTINEL")
+acq_cli_kits_load sbx dupname        # no sbx record -> untouched
+assert_eq "cli-kits: sbx read does not see msb record" "SENTINEL" "${ACQ_CLI_KITS[0]}"
+cleanup_stubs
+
+# 9r6. Provision persists the CLI kit ref on msb (write-after-success), and a
+#      subsequent heal with an EMPTY in-memory set — after a reload — re-applies
+#      that kit (its staged file lands via `msb copy`). This is the end-to-end
+#      #33/Paseo path: create with --kit, then resume, and the kit's startup is
+#      restored WITHOUT re-passing --kit.
+make_stubs; load_acq
+printf 'clidurable\n' > "$STUBDIR/.msb_sandbox_list"
+printf 'clidurable\n' > "$STUBDIR/.msb_running_list"
+_clikit="$STUBDIR/clidurable-kit"; mkdir -p "$_clikit/files"
+cat > "$_clikit/spec.yaml" <<'CLIDURSPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: clidurable-kit
+displayName: CLI Durable Kit
+description: a CLI-supplied kit with a staged file
+files:
+  - path: /home/agent/clidurable-marker
+    mode: "0644"
+    source: files/marker
+CLIDURSPEC
+printf 'CLIDURABLE_MARKER\n' > "$_clikit/files/marker"
+# Provision with the kit in ACQ_CLI_KITS (as the run/create arm would set it).
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/clidur-secrets"
+  export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/clidur-stage"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  # shellcheck disable=SC2030
+  ACQ_CLI_KITS=("$_clikit")
+  _acq_msb_fetch_kit() { printf '%s\n' "$_clikit"; }
+  acq_backend_provision clidurable shell /tmp >/dev/null 2>&1
+)
+# The persisted record must exist and name the kit.
+_recf=$(find "$ACQ_PROVENANCE_DIR" -name '*.kits' 2>/dev/null | head -n1)
+assert_contains "cli-kits: provision persisted the --kit ref" "$(cat "$_recf" 2>/dev/null)" "$_clikit"
+# Now a fresh resume shell: empty in-memory set, reload, then heal. The kit's
+# file must be (re)applied during the heal.
+: > "$CALLS"
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/clidur-secrets"
+  export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/clidur-stage"
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  . "${REPO_ROOT}/acq.backends/msb.sh"
+  # shellcheck disable=SC2031
+  ACQ_CLI_KITS=()
+  _acq_msb_fetch_kit() { printf '%s\n' "$_clikit"; }
+  acq_cli_kits_load msb clidurable
+  acq_backend_ensure_kits_applied clidurable >/dev/null 2>&1
+)
+_heal_log=$(cat "$CALLS")
+assert_contains "cli-kits: resume heal re-applies the reloaded --kit (file copied)" \
+  "$_heal_log" "clidurable:/home/agent/clidurable-marker"
+cleanup_stubs
+
+# ===========================================================================
 # 10. kit-translate: neutral hybrid/v1 -> sbx-v2 synthesis (offline)
 # ===========================================================================
 

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -3947,6 +3947,99 @@ log=$(cat "$CALLS")
 assert_contains "msb: start -> msb start" "$log" "msb start mybox"
 cleanup_stubs
 
+# 8o1S2. Dispatch WIRING for the cli-kits reload (#320 restart durability). The
+#        `acq start` / `acq restart` verbs and the name-only `acq run <sandbox>`
+#        re-attach MUST call acq_cli_kits_load before the heal, so a sandbox
+#        created with `--kit <daemon-kit>` re-runs that kit's startup on resume
+#        WITHOUT the user re-passing --kit. Verified at the DISPATCH level (a
+#        child `acq` process — not a direct function call), which is the only
+#        place the wiring itself is exercised. Because the child cannot shadow
+#        _acq_msb_fetch_kit, the reloaded kit ref is resolved through the offline
+#        ACQ_MSB_KIT_LOCAL_DIR hatch to a local kit dir carrying one staged file;
+#        we assert that file lands via `msb copy` (i.e. the reloaded kit was
+#        healed). A CONTROL sub-case with NO record asserts no such copy happens,
+#        proving the reload — not some always-on path — is what applied it.
+#
+# The reloaded kit dir: a hybrid/v1 mixin with a single staged marker file, whose
+# in-guest path is unique per case so the assertion can key on it.
+_mk_reload_kit() {
+  local _dir="$1" _marker="$2"
+  mkdir -p "$_dir/files"
+  cat > "$_dir/spec.yaml" <<RELOADSPEC
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: reload-kit
+displayName: Reload Kit
+description: a persisted --kit whose file proves the resume reload ran
+files:
+  - path: ${_marker}
+    mode: "0644"
+    source: files/marker
+RELOADSPEC
+  printf 'RELOAD_MARKER\n' > "$_dir/files/marker"
+}
+
+# --- start: reloads the persisted --kit and heals it ---
+make_stubs; load_acq
+printf 'startreloadbox\n' > "$STUBDIR/.msb_sandbox_list"
+printf 'startreloadbox\n' > "$STUBDIR/.msb_running_list"
+_rk="$STUBDIR/reloadkit"; _mk_reload_kit "$_rk" "/home/agent/start-reload-marker"
+# Seed the persisted record the run/create arm would have written at provision,
+# using the REAL helper so the cksum-suffixed filename matches what acq looks up.
+( load_acq; ACQ_CLI_KITS=("$_rk"); ACQ_EXTRA_KITS=""; acq_cli_kits_write msb startreloadbox )
+: > "$CALLS"
+# Route the reloaded ref through the offline kit-local hatch (child acq process).
+out=$( ACQ_MSB_KIT_LOCAL_DIR="$_rk" ACQ_BACKEND=msb "$ACQ" start startreloadbox 2>&1 )
+startreload_log=$(cat "$CALLS")
+assert_contains "cli-kits(dispatch): acq start reloads + heals the persisted --kit" \
+  "$startreload_log" "startreloadbox:/home/agent/start-reload-marker"
+cleanup_stubs
+
+# --- start CONTROL: no record => no reloaded-kit copy (proves reload caused it) ---
+# NOTE: we must NOT point ACQ_MSB_KIT_LOCAL_DIR at the marker kit here — that hatch
+# diverts EVERY remote (git+) ref, including the built-ins, so it would copy the
+# marker via the built-in heal regardless of the reload and mask the very thing
+# under test. Leave the harness's default offline kit dir (an empty, file-less
+# spec) in place: with no persisted record there is no marker-bearing ref at all,
+# so the marker path must never appear.
+make_stubs; load_acq
+printf 'startnorecbox\n' > "$STUBDIR/.msb_sandbox_list"
+printf 'startnorecbox\n' > "$STUBDIR/.msb_running_list"
+: > "$CALLS"
+out=$( ACQ_BACKEND=msb "$ACQ" start startnorecbox 2>&1 )
+startnorec_log=$(cat "$CALLS")
+assert_not_contains "cli-kits(dispatch): acq start with NO record heals no extra kit" \
+  "$startnorec_log" "/home/agent/start-norec-marker"
+cleanup_stubs
+
+# --- restart: reloads the persisted --kit and heals it ---
+make_stubs; load_acq
+printf 'restartreloadbox\n' > "$STUBDIR/.msb_sandbox_list"
+printf 'restartreloadbox\n' > "$STUBDIR/.msb_running_list"
+_rk3="$STUBDIR/reloadkit3"; _mk_reload_kit "$_rk3" "/home/agent/restart-reload-marker"
+( load_acq; ACQ_CLI_KITS=("$_rk3"); ACQ_EXTRA_KITS=""; acq_cli_kits_write msb restartreloadbox )
+: > "$CALLS"
+out=$( ACQ_MSB_KIT_LOCAL_DIR="$_rk3" ACQ_BACKEND=msb "$ACQ" restart restartreloadbox 2>&1 )
+restartreload_log=$(cat "$CALLS")
+assert_contains "cli-kits(dispatch): acq restart reloads + heals the persisted --kit" \
+  "$restartreload_log" "restartreloadbox:/home/agent/restart-reload-marker"
+cleanup_stubs
+
+# --- run <sandbox> name-only re-attach: reloads the persisted --kit and heals it ---
+make_stubs; load_acq
+printf 'runreloadbox\n' > "$STUBDIR/.msb_sandbox_list"
+printf 'runreloadbox\n' > "$STUBDIR/.msb_running_list"
+_rk4="$STUBDIR/reloadkit4"; _mk_reload_kit "$_rk4" "/home/agent/run-reload-marker"
+( load_acq; ACQ_CLI_KITS=("$_rk4"); ACQ_EXTRA_KITS=""; acq_cli_kits_write msb runreloadbox )
+: > "$CALLS"
+# Name-only `acq run <existing-sandbox>` (no agent token, no --kit re-passed).
+out=$( ACQ_UPDATE_CHECK=0 ACQ_MSB_KIT_LOCAL_DIR="$_rk4" ACQ_BACKEND=msb "$ACQ" run runreloadbox 2>&1 )
+runreload_log=$(cat "$CALLS")
+assert_contains "cli-kits(dispatch): acq run <sandbox> reloads + heals the persisted --kit" \
+  "$runreload_log" "runreloadbox:/home/agent/run-reload-marker"
+cleanup_stubs
+unset -f _mk_reload_kit
+
 # 8o1T. N1 — restart is a BEST-EFFORT bounce: when `msb stop` FAILS, the dispatcher
 #        (under `set -euo pipefail`) must NOT abort — it must still proceed to
 #        `msb start` and the heal. STUB_MSB_STOP_FAIL=1 makes the stub's stop arm


### PR DESCRIPTION
## Context

A sandbox created with `acq run … --kit <ref>` (or `ACQ_EXTRA_KITS`) came back from a `msb stop` + `acq start` cycle with its create-time ports still mapped but the kit's supervised daemon **dead** — e.g. the **paseo** daemon on `:6767` (browser reports `net::ERR_EMPTY_RESPONSE`), or openchamber's shared `opencode serve`.

Root cause (two compounding gaps; the first was already partially addressed in `#320`'s sibling area, the second is the real fix here):

1. On a resume, kit `startup` is re-run **only** by acq's heal (`acq_backend_ensure_kits_applied`) — `msb start` does not replay it (ADR-0017).
2. The CLI/extra kit refs were **in-memory only**: `ACQ_CLI_KITS` is populated by `extract_kit_flags` in the `run`/`create` dispatch arm, and `ACQ_EXTRA_KITS` is a bare env var. The `start`/`restart` verbs (and a name-only `acq run <sandbox>` re-attach) never re-parse `--kit` and may run in a shell without `ACQ_EXTRA_KITS` exported — so the heal iterated an **empty** CLI/extra set and re-ran only the built-ins' startup.

This is the same class as `KNOWN_FAILURE_MODES` §33 and is **not** covered by `GSA-TTS/agentic-coding-quickstart#320` (that branch is sbx-only, cosmetic heal-loop noise).

## Plan / what changed

- `acq.backends/common.sh`: new `acq_cli_kits_write` / `acq_cli_kits_load` (+ `_acq_cli_kits_file`). Host-side `*.kits` record beside the bundle-provenance record, keyed by backend + sandbox name (same sanitized-filename + raw-name-checksum scheme), atomic temp+mv, `0600`, fail-open.
- `acq.backends/msb.sh` / `acq.backends/sbx.sh`: persist the refs at provision success (best-effort, right after the provenance write).
- `acq`: reload the persisted refs **before** the heal in the `start`, `restart`, and name-only `run <sandbox>` re-attach arms. Guarded on an empty in-memory set so a `--kit` re-passed on the same invocation stays authoritative.
- Record presence is authoritative: an empty record clears stale in-memory refs; a legacy sandbox with no record is a no-op reload (pre-fix behavior).

Net effect: a `msb stop` + `acq start` now re-runs a `--kit` kit's startup **without** re-passing `--kit`.

## Verification

- `./scripts/test-acq` → **929 passed / 0 failed** (11 new `cli-kits:*` / round-trip cases, including an end-to-end provision → reload → heal re-apply asserting the reloaded `--kit` file lands via `msb copy`).
- `shellcheck --severity=warning` (one file per invocation, per repo guidance) on `acq`, `acq.backends/common.sh`, `acq.backends/sbx.sh`, `acq.backends/msb.sh` → clean. `bash -n scripts/test-acq` → clean (the full `test-acq` is excluded from a single-shot shellcheck run by the documented dataflow blow-up; its added block lints clean in isolation).
- Docs: `KNOWN_FAILURE_MODES` §33 and ADR-0017 updated.

## Rollback

Revert this commit. The `*.kits` records are inert host-side state; leftover files are ignored by a reverted `acq` (nothing reads them) and can be removed under `${XDG_STATE_HOME:-~/.local/state}/acq/provenance/`.

## Security impact

None to auth/authorization/data handling. New host-side state file is written `0600` under the existing acq state tree; sandbox names are charset-sanitized into the filename (no traversal), matching the provenance record's existing scheme. No secrets are written to it (kit refs only).

AI-assisted: authored with OpenCode; human-owned and reviewed by @mogul.

Refs: GSA-TTS/agentic-coding-quickstart#320