### PR TITLE
docs: fix first-day default-path accuracy (USAi, backend primacy, dead links)

### DIFF
--- a/CONTEXT-GUIDE.md
+++ b/CONTEXT-GUIDE.md
@@ -6,7 +6,7 @@ tier: 1
 load_priority: "always"
 audience: "all"
 keywords: ["context", "loading", "routing", "index"]
-related_files: ["AGENTS.md", "docs/CODING_PRACTICES.md"]
+related_files: ["AGENTS.md"]
 review_cycle: "quarterly"
 ---
 
@@ -28,8 +28,8 @@ These define the behavioral contract. Load for **every task**.
 | Document | What It Covers |
 |----------|----------------|
 | `AGENTS.md` | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
-| `docs/CODING_PRACTICES.md` | Secure coding: input validation, secrets, dependencies, architecture, TDD, SOLID |
-| `~/.agentic-coding-playbook/docs/CODING_STANDARDS_COMPACT.md` | **Code generation shortcut** — load INSTEAD of full CODING_PRACTICES.md for routine code tasks (from the playbook, cloned into the sandbox by the `agentic-coding-playbook` kit) |
+| [`CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md) (GSA agentic-coding-playbook) | Secure coding: input validation, secrets, dependencies, architecture, TDD, SOLID |
+| `~/.agentic-coding-playbook/docs/CODING_STANDARDS_COMPACT.md` | **Code generation shortcut** — load INSTEAD of the full CODING_PRACTICES.md for routine code tasks (from the playbook, delivered into the sandbox by the `agentic-coding-playbook` kit) |
 
 ## Tier 2 — Load When Task Matches
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ This repo is one of three in the agentic coding ecosystem:
 This project operates under professional standards of conduct. All contributors:
 
 - Be respectful and constructive in all interactions
-- Follow security requirements outlined in `AGENTS.md` and `docs/CODING_PRACTICES.md`
+- Follow security requirements outlined in `AGENTS.md` and [`CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md) (in the GSA agentic-coding-playbook)
 - For security issues, see [SECURITY.md](SECURITY.md)
 
 ---
@@ -59,7 +59,7 @@ This project operates under professional standards of conduct. All contributors:
 
 2. Read the core documentation:
    - `AGENTS.md` — Behavioral rules for AI agents
-   - `docs/CODING_PRACTICES.md` — Secure coding standards
+   - [`CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md) (GSA agentic-coding-playbook) — Secure coding standards
    - `docs/QUICKSTART_SBX.md` — sbx CLI setup guide
 
 3. Follow the quickstart to set up your environment
@@ -279,7 +279,7 @@ squashed away), so focus on getting the PR title right.
    git checkout -b feat/your-feature-name
    ```
 
-2. **Make your changes** following the coding standards in `docs/CODING_PRACTICES.md`
+2. **Make your changes** following the coding standards in [`CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md) (GSA agentic-coding-playbook)
 
 3. **Write tests** if applicable — all new features should include tests
 
@@ -300,7 +300,7 @@ squashed away), so focus on getting the PR title right.
    - Test results (if applicable)
 
 7. **Address review feedback** — reviewers will check for:
-   - Compliance with `AGENTS.md` and `docs/CODING_PRACTICES.md`
+   - Compliance with `AGENTS.md` and [`CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md) (GSA agentic-coding-playbook)
    - Conventional commit format
    - Test coverage
    - Security implications
@@ -314,7 +314,7 @@ squashed away), so focus on getting the PR title right.
 All code must comply with:
 
 - **AGENTS.md** — Behavioral rules for AI agents
-- **docs/CODING_PRACTICES.md** — Secure coding standards including:
+- **[`CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md)** (GSA agentic-coding-playbook) — Secure coding standards including:
   - Input validation and output encoding
   - Secrets management (no secrets in code!)
   - Dependency security (exact version pinning)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Agentic Coding Quickstart
 
 > **Audience:** Federal teams using AI coding agents \
-> **Purpose:** Get AI coding agents running safely inside isolated sandboxes, connected to USAi
+> **Purpose:** Get AI coding agents running safely inside isolated sandboxes, connected to USAi (the GSA-hosted LLM gateway at `api.gsa.usai.gov`)
 
 **In one sentence:** this quickstart gets you running an AI coding agent connected to USAi in under 5 minutes, using `acq`, a CLI tool provided here.
 
@@ -50,7 +50,7 @@ and GitHub access interactively on first run (see [Step 3](#step-3-create-and-ru
 | --------------- | ---------------------------------------------------------- |
 | A supported host for microVMs | msb uses hardware virtualization. You need one of:<ul><li>**macOS** — Apple Silicon (Intel Macs are not supported)</li><li>**Windows 11** — with the Windows Hypervisor Platform enabled (preview)</li><li>**Linux** — glibc-based, with KVM enabled (`/dev/kvm` present)</li></ul>If you need more detail than this, see [msb host setup](docs/QUICKSTART.md#msb-host-setup) for per-platform particulars. |
 | `git`           | Already installed on macOS and on the supported Linux hosts — **nothing to do**. (On macOS, the first time you run a `git` command the system may offer to install the Command Line Tools; accept it.) Check with `git --version`. |
-| USAi API key    | **Nothing to get in advance** — `acq` prompts you for a key and validates it on first run. <p>(Optional) If you'd rather set it up ahead of time, [create one](https://console.gsa.usai.gov/key-management) and keep it handy; note that USAi keys expire every 7 days.</p> |
+| USAi API key    | **Required, but `acq` guides you** — on first run `acq` prompts you to paste a key and validates it, so you need not configure anything beforehand. You will need to [create a key](https://console.gsa.usai.gov/key-management) (do it now or when prompted); USAi keys expire every 7 days. <p>Running **non-interactively** (CI/piped) has no prompt, so the key must be set in advance — see [Secrets](docs/QUICKSTART.md#secrets).</p> |
 | GitHub token | **Nothing to get in advance** — `acq` offers to walk you through creating a repo-scoped token on first run, when your project contains GitHub repos. You can decline and add one later. <p>(A token lets the agent authenticate to GitHub, work with private repositories, and act on your behalf — open PRs, push to branches, etc.)</p> |
 
 ### Step 1: Install microsandbox (msb)
@@ -315,8 +315,9 @@ repo) when it creates a sandbox:
   and, at startup, merges it into OpenCode's global config at
   `~/.config/opencode/opencode.jsonc` (allow-listing USAi egress). It composes
   with, rather than clobbers, any existing global config.
-- **`agentic-coding-playbook`** — clones the playbook at startup into
-  `~/.agentic-coding-playbook` and symlinks its `AGENTS.md` into each agent's
+- **`agentic-coding-playbook`** — installs the playbook at startup into
+  `~/.agentic-coding-playbook` (a pinned REST tarball on patterns v1.8.0+; older
+  bundles cloned it) and symlinks its `AGENTS.md` into each agent's
   rules path and its skills into `~/.agents/skills` (+ per-agent roots).
 - **`zscaler-ca-certificate`** — installs the public Zscaler Root CA into the
   sandbox trust store (harmless if Zscaler isn't in use).
@@ -416,9 +417,10 @@ git fetch && git pull
 The playbook provides reusable **agent skills** — step-by-step procedures for
 common tasks. Skills follow the [agentskills.io](https://agentskills.io)
 standard. When you launch a sandbox with `acq`, the `agentic-coding-playbook`
-kit clones the playbook at startup and symlinks these into `~/.agents/skills`
+kit installs the playbook at startup (a pinned tarball on patterns v1.8.0+) and
+symlinks these into `~/.agents/skills`
 (and per-agent roots) so your agent discovers them automatically; no separate
-clone is needed.
+checkout is needed.
 
 | Source       | Skills                       | Examples                                                                            |
 | ------------ | ---------------------------- | ----------------------------------------------------------------------------------- |

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -644,6 +644,12 @@ rationale, the fixed vsock port (3552), and the trust-boundary discussion.
   stays TCP + loopback for sbx parity.)
 - **No state-preserving in-place kit add.** `acq_backend_ensure_kits_applied`
   re-applies kits idempotently; for a clean rebuild use `acq rm && acq run`.
+- **`acq` can auto-install only `opencode` on msb.** On the msb base image `acq`
+  installs the agent at provision time, and today only `opencode` has an install
+  recipe (`shell` needs no binary). Any other agent must be pre-baked into your
+  own `ACQ_MSB_IMAGE`; `acq` warns at attach if the requested agent has no recipe.
+  (On sbx the agent is supplied by the sbx template, so this constraint is
+  msb-specific.)
 - **Snapshots not surfaced.** `msb snapshot` is a full CLI verb, but `acq`
   exposes no `snapshot` verb, so `SUPPORTS_SNAPSHOTS=0`. Wiring it is beyond sbx
   parity (sbx has no snapshots), so the flag reflects what `acq` surfaces rather

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -196,9 +196,15 @@ backend (`ppp` — Podman-Plus-Proxy) is deferred.
 curl -fsSL https://install.microsandbox.dev | sh
 msb doctor          # checks KVM/HVF/WHP; msb doctor --fix to set up
 
-# 2. Export the USAi key (msb binds it from a host env var at create; the real
-#    value never enters the guest)
-export USAI_API_KEY=<your-usai-key>
+# 2. Provide the USAi key.
+#    INTERACTIVE (recommended): skip this line — `acq run` prompts you for the
+#    key on first run, or set it once with:  ./acq secret set -g usai
+#    (prompts for the value; it never lands in argv or your shell history).
+#
+#    NON-INTERACTIVE / scripting / CI only: msb binds the key from a host env var
+#    at create (the real value never enters the guest). Read it WITHOUT echoing
+#    so it does not leak into shell history:
+read -rs -p 'USAi API key: ' USAI_API_KEY; export USAI_API_KEY; echo
 
 # 3. Run — acq auto-detects msb, or force it with --backend msb
 ./acq --backend msb run opencode /path/to/your/project

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -1,6 +1,9 @@
 # sbx CLI Quickstart Guide
 
-> **Recommended for federal users** — Better automation, audit trails, and secure credential storage.
+> **Note:** `msb` (microsandbox) is `acq`'s **default** backend. Use this `sbx`
+> guide when you specifically want the Docker Sandboxes backend (for example, you
+> already run Docker Sandboxes, or want its proxy-based credential store). See the
+> [Backend Guide](BACKEND_GUIDE.md) to choose between backends.
 
 This guide walks you through setting up Docker Sandboxes using the `sbx` command-line interface to run AI coding agents with USAi.
 

--- a/docs/risk-assessment.md
+++ b/docs/risk-assessment.md
@@ -145,13 +145,13 @@ Rate each threat for your specific deployment. **Likelihood**: 1 (Rare) to 5 (Al
 > - *Supply chain (T3):* the SHA pin means sbx verifies the fetched kit content
 >   against a specific commit, so substitution — even via the trusted ZScaler
 >   TLS-inspecting proxy — is detected. Bumping `PATTERNS_KIT_REF` is a
->   reviewable change. The playbook kit further SHA-verifies its own runtime
->   clone (`PLAYBOOK_SHA`).
+>   reviewable change. The playbook kit further SHA-verifies its own delivered
+>   runtime tree (`PLAYBOOK_SHA`).
 > - *Availability:* sandbox creation now requires network access to GitHub, and —
 >   while the playbook repo is private — a GitHub token
 >   (`sbx secret set -g github`). Offline/airgapped creation yields a sandbox
 >   without the kits rather than falling back to a vendored copy.
-> - *Trust model:* the playbook is cloned into a **writable** home dir, so an
+> - *Trust model:* the playbook is delivered (as a tarball) into a **writable** home dir, so an
 >   agent can modify its own rules/skills in-session (accepted at FIPS-Low; blast
 >   radius is one ephemeral sandbox). See `docs/adr/0005`.
 


### PR DESCRIPTION
First-day default-path (**msb**) doc-accuracy batch from the audit epic #335. **Docs only** — no `acq`/backend/config change.

## #337 — dead `docs/CODING_PRACTICES.md` links
That file lives in the **playbook**, not here ("reference, don't restate"). Repointed the broken local refs to the canonical playbook URL already used by `AGENTS.md`/`QUICKSTART_SBX.md`: 5 in `CONTRIBUTING.md` + the `CONTEXT-GUIDE.md` table row; dropped the non-existent path from `CONTEXT-GUIDE.md` `related_files`.
> Scope: the audit said 7 refs; there were **9** across 5 files. The 9th (`checklists/pre-deployment.md:11`) is **deferred** — it collides with open PR #344 (which also edits that file). Folding it in after #344 merges (noted on #337).

## #336 — USAi undefined + contradictory key claim
Defined USAi on first mention (README: "the GSA-hosted LLM gateway at `api.gsa.usai.gov`"). The code **hard-aborts** without a key (`common.sh`), so the misleading "Nothing to get in advance" row is now "**Required, but `acq` guides you**" and flags that non-interactive/CI has no prompt → key must be set in advance.

## #338 — competing backend-primacy claims
`QUICKSTART_SBX`'s "Recommended for federal users" steered readers to the **non-default** backend. Replaced with a note that **msb is the default** and this guide is for when you specifically want sbx. Surfaced the real msb constraint where a reader chooses (`BACKEND_GUIDE` Known limitations): `acq` can auto-install only `opencode` on msb; other agents must be pre-baked into `ACQ_MSB_IMAGE`.

## #343 — stale "clones" prose
After #327 moved the heal-probe to an `AGENTS.md` marker, delivery is a pinned **REST tarball** (patterns v1.8.0+), not a clone. Fixed the stale "clones" wording at **4** user-facing sites (the audit's 2 cites missed README ×2 extra + risk-assessment).

## #340 — QUICKSTART export leaked the key into shell history
Marked the block interactive-vs-non-interactive, cross-linked the safe `acq secret set -g usai` flow, and replaced inline `export KEY=<...>` with a `read -rs` prompt that never lands in history/argv.

## Verification
markdownlint clean (10 files); new/changed external URLs verified 200; pre-commit (gitleaks + secrets) green.

Refs #335 #336 #337 #338 #340 #343

AI-assisted (OpenCode).