### PR TITLE
docs: repoint the last local CODING_PRACTICES.md refs to the playbook URL (#337)

### DIFF
--- a/checklists/pre-deployment.md
+++ b/checklists/pre-deployment.md
@@ -8,7 +8,7 @@ nist_controls: ["SA-11", "SR-3", "CM-2", "SI-10", "IA-5", "SC-13", "AU-2"]
 frameworks: ["NIST SP 800-53 Rev 5.2", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026"]
 audience: "developers"
 keywords: ["checklist", "pre-deployment", "security-review", "sign-off"]
-related_files: ["docs/CODING_PRACTICES.md", "AGENTS.md"]
+related_files: ["https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md", "AGENTS.md"]
 load_priority: "reference-only"
 review_cycle: "semi-annually"
 ---

--- a/docs/adr/0002-version-management-and-release-automation.md
+++ b/docs/adr/0002-version-management-and-release-automation.md
@@ -236,4 +236,4 @@ Migration guide: docs/migration/oauth-migration.md
 - [release-please-action](https://github.com/googleapis/release-please-action)
 - [NIST SP 800-53 Rev 5 — CM-2 Baseline Configuration](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final)
 - [NIST SP 800-53 Rev 5 — CM-3 Configuration Change Control](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final)
-- Related: `AGENTS.md`, `docs/CODING_PRACTICES.md`
+- Related: `AGENTS.md`, [`CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md) (GSA agentic-coding-playbook)


### PR DESCRIPTION
Closes #337 — the residual tail deferred from merged PR #345.

That file lives in the **agentic-coding-playbook**, not here ("reference, don't restate"). #345 fixed most refs but deferred the `pre-deployment.md` one because it collided with open PR #344 (SA-12→SR-3), which has since merged. Two live local refs remained:

- `checklists/pre-deployment.md:11` — `related_files` entry → full playbook URL
- `docs/adr/0002-...:239` — the "Related:" prose ref → linked playbook URL

**Left as-is (correctly):** `AGENTS.md:229` and `ADR-0002:186/206` mention `CODING_PRACTICES.md` as **prose** describing what a section adds to the playbook doc — not links/paths to a local file. No remaining local `docs/CODING_PRACTICES.md` path references (verified). markdownlint + gitleaks + secrets-scan pre-commit hooks pass.

Closes #337

AI-assisted (OpenCode).