### PR TITLE
feat(kits): add neutral volumes vocabulary (sbx v2 5.7 passthrough + msb parity)

### DIFF
--- a/acq.backends/kit-translate.sh
+++ b/acq.backends/kit-translate.sh
@@ -401,12 +401,19 @@ _kit_pp_validate() {
 # startup step instead — see ADR-0022).
 #
 # VALIDATION (SI-10): these values reach a generated sbx-v2 spec and an msb
-# create argv, so they are untrusted. path must be absolute and
-# charset-restricted ([A-Za-z0-9._/-]); type must be empty or tmpfs; size must
-# match the kit-spec v2 §5.7 byte-size grammar (e.g. 20G, 512m, 2gib).
-# Offending entries are DROPPED with a stderr warning (mirroring
-# _kit_pp_validate). Absence is a silent no-op (defensive read, ADR-0014
-# precedent: the patterns schema property may lag the translator).
+# create argv, so they are untrusted. path must be absolute, charset-restricted
+# ([A-Za-z0-9._/-]), and NORMALIZED (no . or .. segments, no //, no trailing
+# /) — a volume mounts a whole unseeded filesystem, so /. would shadow the
+# guest root and /data/../etc would mount over /etc while reading as a /data
+# path; type must be empty or tmpfs; size must
+# be a non-zero byte-size in the PORTABLE grammar (e.g. 20G, 512m, 1.5G) —
+# the intersection of sbx's units.RAMInBytes and msb's size parser. sbx also
+# accepts b/ib suffixes (256MB, 2gib) but msb REJECTS them ("invalid digit
+# found in string", verified on msb 0.6.12), so the neutral grammar excludes
+# them: a size must work on every backend. Offending entries are DROPPED with
+# a stderr warning (mirroring _kit_pp_validate). Absence is a silent no-op
+# (defensive read, ADR-0014 precedent: the patterns schema property may lag
+# the translator).
 kit_spec_volumes() {
   local spec="$1"
   [ -f "$spec" ] || return 0
@@ -446,19 +453,28 @@ _kit_vol_parse_neutral() {
 }
 
 # Validate raw `path<TAB>type<TAB>size` records on stdin (SI-10): path absolute
-# + safe charset; type "" or tmpfs; size required + byte-size grammar (integer
-# or decimal, optional k/m/g/t/p unit with optional i, optional b — the
-# units.RAMInBytes grammar kit-spec v2 uses). Drops offending records with a
-# stderr warning; emits the survivors unchanged.
+# + safe charset; type "" or tmpfs; size required, non-zero, and in the
+# PORTABLE byte-size grammar (integer or decimal + optional bare k/m/g/t/p
+# unit). Deliberately NO b/ib suffixes: sbx's units.RAMInBytes accepts 256MB /
+# 2gib but msb's parser rejects them (verified on 0.6.12), and a neutral size
+# must work on every backend. Drops offending records with a stderr warning;
+# emits the survivors unchanged.
 _kit_vol_validate() {
   awk -F'\t' '
     {
       p=$1; t=$2; s=$3
       if (p=="")                          { print "kit-translate: skipping volume with missing path (size: " s ")" > "/dev/stderr"; next }
       if (p !~ /^\/[A-Za-z0-9._\/-]+$/)   { print "kit-translate: skipping volume with unsafe path: " p > "/dev/stderr"; next }
+      # Require a NORMALIZED path: a volume mounts a whole unseeded filesystem,
+      # so /. or // would shadow the guest root outright and /data/../etc would
+      # mount over /etc while reading as a /data path in review. Reject empty
+      # (//) and pure-dot (. / ..) segments and a trailing slash; dot-PREFIXED
+      # names like /data/..hidden remain legal.
+      if (p ~ /\/\// || p ~ /\/\.\.?(\/|$)/ || p ~ /\/$/) { print "kit-translate: skipping volume with non-normalized path (no . or .. segments, no //, no trailing /): " p > "/dev/stderr"; next }
       if (t!="" && t!="tmpfs")            { print "kit-translate: skipping volume with invalid type: " t > "/dev/stderr"; next }
       if (s=="")                          { print "kit-translate: skipping volume with missing size: " p > "/dev/stderr"; next }
-      if (s !~ /^[0-9]+(\.[0-9]+)?([kKmMgGtTpP][iI]?)?[bB]?$/) { print "kit-translate: skipping volume with invalid size: " s > "/dev/stderr"; next }
+      if (s !~ /^[0-9]+(\.[0-9]+)?[kKmMgGtTpP]?$/) { print "kit-translate: skipping volume with invalid size (portable grammar: 20G, 512m; no b/ib suffix): " s > "/dev/stderr"; next }
+      if (s ~ /^0+(\.0+)?[kKmMgGtTpP]?$/) { print "kit-translate: skipping volume with zero size: " s > "/dev/stderr"; next }
       printf "%s\t%s\t%s\n", p, t, s
     }
   '
@@ -1265,8 +1281,12 @@ EOF
   # the sbx-v2 spec + msb argv they reach), so validate the RAW parsed records
   # here — otherwise a bad entry would be silently dropped rather than reported
   # by `acq kit validate`. path absolute + [A-Za-z0-9._/-]; type "" | tmpfs;
-  # size required, byte-size grammar (kit-spec v2 §5.7). (ADR-0022, SI-10)
-  local vline vp vt vs
+  # size required, non-zero, portable grammar (no b/ib suffix — msb rejects
+  # them). A valid-but-small block size additionally gets a WARNING (not an
+  # error): msb refuses ext4 disk images under 128M, so a sub-floor size
+  # passes validate for sbx-only use but will fail an msb create.
+  # (ADR-0022, SI-10)
+  local vline vp vt vs vbytes
   while IFS= read -r vline; do
     [ -n "$vline" ] || continue
     vp=$(printf '%s' "$vline" | cut -f1)
@@ -1279,6 +1299,8 @@ EOF
         /*)
           if printf '%s' "$vp" | LC_ALL=C grep -q '[^A-Za-z0-9._/-]'; then
             echo "kit: validate: volume path has illegal characters: '$vp'" >&2; errs=$((errs + 1))
+          elif printf '%s' "$vp" | LC_ALL=C grep -Eq '//|/\.\.?(/|$)|/$'; then
+            echo "kit: validate: volume path must be normalized (no . or .. segments, no //, no trailing /): '$vp'" >&2; errs=$((errs + 1))
           fi ;;
         *) echo "kit: validate: volume path must be absolute: '$vp'" >&2; errs=$((errs + 1)) ;;
       esac
@@ -1288,8 +1310,22 @@ EOF
     fi
     if [ -z "$vs" ]; then
       echo "kit: validate: volume size is required (path: '${vp:-<missing>}')" >&2; errs=$((errs + 1))
-    elif ! printf '%s' "$vs" | LC_ALL=C grep -Eq '^[0-9]+(\.[0-9]+)?([kKmMgGtTpP][iI]?)?[bB]?$'; then
-      echo "kit: validate: volume size must be a byte-size (e.g. 20G, 512m): '$vs'" >&2; errs=$((errs + 1))
+    elif ! printf '%s' "$vs" | LC_ALL=C grep -Eq '^[0-9]+(\.[0-9]+)?[kKmMgGtTpP]?$'; then
+      echo "kit: validate: volume size must be a portable byte-size (e.g. 20G, 512m; no b/ib suffix — msb rejects them): '$vs'" >&2; errs=$((errs + 1))
+    elif printf '%s' "$vs" | LC_ALL=C grep -Eq '^0+(\.0+)?[kKmMgGtTpP]?$'; then
+      echo "kit: validate: volume size must be non-zero: '$vs'" >&2; errs=$((errs + 1))
+    elif [ "$vt" != "tmpfs" ]; then
+      vbytes=$(printf '%s' "$vs" | awk '{
+        n=$0; u=""
+        if (n ~ /[kKmMgGtTpP]$/) { u=tolower(substr(n,length(n),1)); n=substr(n,1,length(n)-1) }
+        m=1
+        if (u=="k") m=1024; else if (u=="m") m=1048576; else if (u=="g") m=1073741824
+        else if (u=="t") m=1099511627776; else if (u=="p") m=1125899906842624
+        printf "%.0f", n*m
+      }')
+      if [ -n "$vbytes" ] && [ "$vbytes" -lt 134217728 ] 2>/dev/null; then
+        echo "kit: validate: warning: block volume '$vp' size '$vs' is below msb's 128M ext4 floor (fails msb create; fine for sbx-only kits)" >&2
+      fi
     fi
   done <<EOF
 $(_kit_vol_parse_neutral "$spec")

--- a/acq.backends/kit-translate.sh
+++ b/acq.backends/kit-translate.sh
@@ -34,6 +34,7 @@
 #   kit_spec_field       SPEC KEY            -> top-level scalar (name, kind, …)
 #   kit_spec_net_allow   SPEC                -> one host[:port] per line
 #   kit_spec_published_ports SPEC            -> one "guest<TAB>proto<TAB>name<TAB>host" per line
+#   kit_spec_volumes     SPEC                -> one "path<TAB>type<TAB>size" per line
 #   kit_spec_files       SPEC                -> one "path|mode|phase|source" per line
 #   kit_spec_commands    SPEC                -> command records (see format below)
 #   kit_spec_env         SPEC                -> one "NAME<TAB>value" per line
@@ -370,6 +371,95 @@ _kit_pp_validate() {
       if (p!="" && p!="tcp" && p!="udp")  { print "kit-translate: skipping published port with invalid protocol: " p > "/dev/stderr"; next }
       if (n!="" && n !~ /^[A-Za-z0-9._-]+$/) { print "kit-translate: skipping published port with unsafe name: " n > "/dev/stderr"; next }
       printf "%s\t%s\t%s\t%s\n", g, p, n, h
+    }
+  '
+}
+
+# ---------------------------------------------------------------------------
+# kit_spec_volumes SPEC
+# ---------------------------------------------------------------------------
+# Echo one record per volumes[] entry, tab-separated:
+#   path <TAB> type <TAB> size
+# type is empty for the default (block-backed) volume; the only other value is
+# tmpfs. size is REQUIRED — the neutral schema deliberately does not inherit
+# sbx's unsized-volume default, which is still settling upstream (0.39-rc moved
+# it 50G -> 512M). The neutral top-level `volumes:` list is the ONLY source (the
+# field is brand new, so there is no backend_extras fallback to carry):
+#
+#   volumes:
+#     - path: /var/lib/docker   # required, absolute
+#       size: 20G               # required
+#     - path: /scratch
+#       type: tmpfs             # "" (block, default) | tmpfs
+#       size: 2G
+#
+# Volumes are CREATION-TIME ONLY on both backends (`sbx kit add` skips them; msb
+# mounts at create) and mount UNSEEDED: an empty filesystem shadows any image
+# content at the path, so a kit needing seeded content ships its own first-boot
+# copy step. Multiple kits union by path, last wins — sbx resolves that itself.
+# The neutral schema carries no `mode` (msb has no equivalent; kits chmod in a
+# startup step instead — see ADR-0022).
+#
+# VALIDATION (SI-10): these values reach a generated sbx-v2 spec and an msb
+# create argv, so they are untrusted. path must be absolute and
+# charset-restricted ([A-Za-z0-9._/-]); type must be empty or tmpfs; size must
+# match the kit-spec v2 §5.7 byte-size grammar (e.g. 20G, 512m, 2gib).
+# Offending entries are DROPPED with a stderr warning (mirroring
+# _kit_pp_validate). Absence is a silent no-op (defensive read, ADR-0014
+# precedent: the patterns schema property may lag the translator).
+kit_spec_volumes() {
+  local spec="$1"
+  [ -f "$spec" ] || return 0
+  _kit_vol_parse_neutral "$spec" | _kit_vol_validate
+}
+
+# Parse the neutral top-level `volumes:` list into raw (unvalidated)
+# tab-separated `path<TAB>type<TAB>size` records. Reads only the top-level
+# block (dedent ends it). A record is emitted when ANY field is present so a
+# pathless entry still reaches the validator (and `acq kit validate`) instead
+# of vanishing silently.
+_kit_vol_parse_neutral() {
+  awk '
+    function trim(s){ sub(/^[[:space:]]+/,"",s); sub(/[[:space:]]+$/,"",s); gsub(/^"|"$/,"",s); return s }
+    function flush(){ if (cur_p != "" || cur_t != "" || cur_s != "") printf "%s\t%s\t%s\n", cur_p, cur_t, cur_s; cur_p=""; cur_t=""; cur_s="" }
+    /^volumes:[[:space:]]*$/ { in_v=1; flush(); next }
+    /^[A-Za-z]/ { if (in_v) { flush(); in_v=0 } }
+    in_v {
+      if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*#/) next
+      if ($0 ~ /^[[:space:]]+-[[:space:]]/) {
+        flush()
+        line=$0; sub(/^[[:space:]]*-[[:space:]]*/,"",line)
+        k=line; sub(/:.*/,"",k); k=trim(k)
+        v=line; sub(/^[^:]*:[[:space:]]*/,"",v); sub(/[[:space:]]*#.*/,"",v); v=trim(v)
+        if (k=="path") cur_p=v; else if (k=="type") cur_t=v; else if (k=="size") cur_s=v
+        next
+      }
+      if ($0 ~ /^[[:space:]]+[A-Za-z]/) {
+        k=$0; sub(/:.*/,"",k); k=trim(k)
+        v=$0; sub(/^[^:]*:[[:space:]]*/,"",v); sub(/[[:space:]]*#.*/,"",v); v=trim(v)
+        if (k=="path") cur_p=v; else if (k=="type") cur_t=v; else if (k=="size") cur_s=v
+        next
+      }
+    }
+    END { if (in_v) flush() }
+  ' "$1"
+}
+
+# Validate raw `path<TAB>type<TAB>size` records on stdin (SI-10): path absolute
+# + safe charset; type "" or tmpfs; size required + byte-size grammar (integer
+# or decimal, optional k/m/g/t/p unit with optional i, optional b — the
+# units.RAMInBytes grammar kit-spec v2 uses). Drops offending records with a
+# stderr warning; emits the survivors unchanged.
+_kit_vol_validate() {
+  awk -F'\t' '
+    {
+      p=$1; t=$2; s=$3
+      if (p=="")                          { print "kit-translate: skipping volume with missing path (size: " s ")" > "/dev/stderr"; next }
+      if (p !~ /^\/[A-Za-z0-9._\/-]+$/)   { print "kit-translate: skipping volume with unsafe path: " p > "/dev/stderr"; next }
+      if (t!="" && t!="tmpfs")            { print "kit-translate: skipping volume with invalid type: " t > "/dev/stderr"; next }
+      if (s=="")                          { print "kit-translate: skipping volume with missing size: " p > "/dev/stderr"; next }
+      if (s !~ /^[0-9]+(\.[0-9]+)?([kKmMgGtTpP][iI]?)?[bB]?$/) { print "kit-translate: skipping volume with invalid size: " s > "/dev/stderr"; next }
+      printf "%s\t%s\t%s\n", p, t, s
     }
   '
 }
@@ -743,6 +833,7 @@ kit_spec_agent_context() {
 #   agentContext                    -> agentInstructions.content
 #   publishedPorts (neutral, top-level; or deprecated backend_extras.sbx) ->
 #                                      ports[]                  (top-level, sbx-v2)
+#   volumes (neutral, top-level)    -> volumes[]                (top-level, sbx-v2 §5.7)
 #   backend_shortcuts.sbx           -> (none defined for the four kits; ignored)
 #
 # Usage: kit_translate_to_sbx NEUTRAL_KIT_DIR OUT_DIR
@@ -817,16 +908,40 @@ kit_translate_to_sbx() {
     portrecs=$(kit_spec_published_ports "$spec")
     if [ -n "$portrecs" ]; then
       printf 'ports:\n'
-      printf '%s\n' "$portrecs" | while IFS="$(printf '\t')" read -r pguest pproto pname phost; do
+      # Parse each field with cut, NOT `IFS=<tab> read`: tab is IFS whitespace,
+      # so a bare read COLLAPSES adjacent empty fields — an entry with guest +
+      # host but no protocol/name ("3000<TAB><TAB><TAB>8080") would read the
+      # host column into pproto and emit `protocol: 8080` (same pitfall as the
+      # kit_spec_files consumer in msb.sh).
+      printf '%s\n' "$portrecs" | while IFS= read -r prec; do
+        pguest=$(printf '%s' "$prec" | cut -f1)
+        pproto=$(printf '%s' "$prec" | cut -f2)
+        pname=$(printf '%s' "$prec" | cut -f3)
         [ -n "$pguest" ] || continue
-        # phost (the neutral host column) is intentionally NOT re-emitted: sbx-v2
-        # keys on `container` (the guest port) and assigns the host port itself,
-        # matching the pre-neutral observable shape. Reference it so the field is
-        # consumed by `read` without tripping shellcheck SC2034.
-        : "${phost:-}"
+        # The neutral host column (field 4) is intentionally NOT re-emitted:
+        # sbx-v2 keys on `container` (the guest port) and assigns the host port
+        # itself, matching the pre-neutral observable shape.
         printf '  - container: %s\n' "$pguest"
         [ -n "$pproto" ] && printf '    protocol: %s\n' "$pproto"
         [ -n "$pname" ]  && printf '    name: %s\n' "$(_kit_yaml_quote "$pname")"
+      done
+    fi
+
+    # volumes -> sbx-v2 top-level volumes (kit-spec v2 §5.7), fields passed
+    # through 1:1. Creation-time only (`sbx kit add` skips them); sbx unions
+    # multiple kits by path itself (last wins), so no merging happens here.
+    local volrecs
+    volrecs=$(kit_spec_volumes "$spec")
+    if [ -n "$volrecs" ]; then
+      printf 'volumes:\n'
+      printf '%s\n' "$volrecs" | while IFS= read -r vrec; do
+        vpath=$(printf '%s' "$vrec" | cut -f1)
+        vtype=$(printf '%s' "$vrec" | cut -f2)
+        vsize=$(printf '%s' "$vrec" | cut -f3)
+        [ -n "$vpath" ] || continue
+        printf '  - path: %s\n' "$vpath"
+        [ -n "$vtype" ] && printf '    type: %s\n' "$vtype"
+        printf '    size: %s\n' "$vsize"
       done
     fi
   } > "$sbxspec"
@@ -1144,6 +1259,41 @@ EOF
 $bad_ports
 EOF
   fi
+
+  # volumes[] (neutral top-level). kit_spec_volumes DROPS entries with a
+  # missing/unsafe path, bad type, or missing/invalid size (defense-in-depth for
+  # the sbx-v2 spec + msb argv they reach), so validate the RAW parsed records
+  # here — otherwise a bad entry would be silently dropped rather than reported
+  # by `acq kit validate`. path absolute + [A-Za-z0-9._/-]; type "" | tmpfs;
+  # size required, byte-size grammar (kit-spec v2 §5.7). (ADR-0022, SI-10)
+  local vline vp vt vs
+  while IFS= read -r vline; do
+    [ -n "$vline" ] || continue
+    vp=$(printf '%s' "$vline" | cut -f1)
+    vt=$(printf '%s' "$vline" | cut -f2)
+    vs=$(printf '%s' "$vline" | cut -f3)
+    if [ -z "$vp" ]; then
+      echo "kit: validate: volume path is required" >&2; errs=$((errs + 1))
+    else
+      case "$vp" in
+        /*)
+          if printf '%s' "$vp" | LC_ALL=C grep -q '[^A-Za-z0-9._/-]'; then
+            echo "kit: validate: volume path has illegal characters: '$vp'" >&2; errs=$((errs + 1))
+          fi ;;
+        *) echo "kit: validate: volume path must be absolute: '$vp'" >&2; errs=$((errs + 1)) ;;
+      esac
+    fi
+    if [ -n "$vt" ] && [ "$vt" != "tmpfs" ]; then
+      echo "kit: validate: volume type must be \"\" (block) or tmpfs: '$vt'" >&2; errs=$((errs + 1))
+    fi
+    if [ -z "$vs" ]; then
+      echo "kit: validate: volume size is required (path: '${vp:-<missing>}')" >&2; errs=$((errs + 1))
+    elif ! printf '%s' "$vs" | LC_ALL=C grep -Eq '^[0-9]+(\.[0-9]+)?([kKmMgGtTpP][iI]?)?[bB]?$'; then
+      echo "kit: validate: volume size must be a byte-size (e.g. 20G, 512m): '$vs'" >&2; errs=$((errs + 1))
+    fi
+  done <<EOF
+$(_kit_vol_parse_neutral "$spec")
+EOF
 
   # commands[].background must be a boolean. kit_spec_commands coerces a
   # non-boolean to false (defense-in-depth), so scan the RAW spec to REPORT it.

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -1231,29 +1231,34 @@ $(kit_spec_published_ports "$_spec")
 EOF
 }
 
-# Emit the create-time storage flags for a kit's neutral `volumes:` entries into
-# the named array. Usage: _acq_msb_volume_flags_into ARRVAR SPEC SANDBOX
+# Emit create-time storage flags from `path<TAB>type<TAB>size` volume records
+# on STDIN into the named array. Usage:
+#   _acq_msb_volume_flags_from_records ARRVAR SANDBOX <<EOF ... records ... EOF
 #
-# ADR-0022: kit_spec_volumes emits validated `path<TAB>type<TAB>size` records
-# (path absolute + charset-safe, type ""|tmpfs, size byte-size grammar).
-# Mapping, mirroring the sbx kit-spec v2 §5.7 semantics:
-#   block (type "")  -> --mount-named acq-<sandbox>-<pathslug>:<path>:kind=disk,size=<size>
+# ADR-0022: records come from kit_spec_volumes (path absolute + charset-safe,
+# type ""|tmpfs, size byte-size grammar), UNIONED across kits by
+# _acq_msb_volume_records_dedupe before reaching here. Mapping, mirroring the
+# sbx kit-spec v2 §5.7 semantics:
+#   block (type "")  -> --mount-named acq-<sandbox>-<pathslug>-<crc>:<path>:kind=disk,size=<size>
 #   tmpfs            -> --tmpfs <path>:<size>
-# The named volume is derived DETERMINISTICALLY from sandbox name + path slug so
-# acq_backend_terminate can find and remove it by prefix — msb named volumes
-# otherwise persist independently under ~/.microsandbox/volumes/ and would
-# silently accumulate (sbx kit volumes die with `sbx rm`; the derived name +
-# terminate cleanup restores that lifecycle). --mount-named is create-or-reuse:
-# a leftover same-name volume with incompatible settings fails the create loudly
-# rather than silently changing the volume. Mounts land at boot, before any exec
-# is possible — the same no-race-with-startup guarantee as sbx volumes. Like the
-# sbx side, mounts land UNSEEDED (msb named volumes shadow image content at the
-# path). Records are parsed with cut, not `IFS=<tab> read` (tab is IFS
-# whitespace, so a bare read collapses the empty type field into size). Uses the
-# eval-by-name array pattern (macOS bash 3.2 compat), like
-# _acq_msb_port_flags_into. Absence is a silent no-op (defensive neutral read).
-_acq_msb_volume_flags_into() {
-  local _arr="$1" _spec="$2" _name="$3" _rec _path _type _size _slug
+# The named volume is derived DETERMINISTICALLY from sandbox name + path slug +
+# a POSIX-cksum CRC of the raw path, so acq_backend_terminate can find and
+# remove it by prefix — msb named volumes otherwise persist independently under
+# ~/.microsandbox/volumes/ and would silently accumulate (sbx kit volumes die
+# with `sbx rm`; the derived name + terminate cleanup restores that lifecycle).
+# The CRC is required for identity, not just readability: the slug is LOSSY
+# (/data/app and /data.app both slug to data-app), so without it two distinct
+# volumes could derive the same name and silently share one disk. --mount-named
+# is create-or-reuse: a leftover same-name volume with incompatible settings
+# fails the create loudly rather than silently changing the volume. Mounts land
+# at boot, before any exec is possible — the same no-race-with-startup
+# guarantee as sbx volumes. Like the sbx side, mounts land UNSEEDED (msb named
+# volumes shadow image content at the path). Records are parsed with cut, not
+# `IFS=<tab> read` (tab is IFS whitespace, so a bare read collapses the empty
+# type field into size). Uses the eval-by-name array pattern (macOS bash 3.2
+# compat), like _acq_msb_port_flags_into.
+_acq_msb_volume_flags_from_records() {
+  local _arr="$1" _name="$2" _rec _path _type _size _slug _ck
   eval "$_arr=()"
   while IFS= read -r _rec; do
     [ -n "$_rec" ] || continue
@@ -1278,14 +1283,39 @@ _acq_msb_volume_flags_into() {
       eval "$_arr+=(--tmpfs \"\${_path}:\${_size}\")"
     else
       # Slug: strip the leading /, map everything outside [A-Za-z0-9] to '-',
-      # squeeze runs (e.g. /var/lib/docker -> var-lib-docker).
+      # squeeze runs (e.g. /var/lib/docker -> var-lib-docker); the CRC suffix
+      # disambiguates paths the lossy slug would collapse together.
       _slug=$(printf '%s' "${_path#/}" | tr -c 'A-Za-z0-9' '-' | tr -s '-')
       _slug="${_slug%-}"
-      eval "$_arr+=(--mount-named \"acq-\${_name}-\${_slug}:\${_path}:kind=disk,size=\${_size}\")"
+      _ck=$(printf '%s' "$_path" | cksum | cut -d' ' -f1)
+      eval "$_arr+=(--mount-named \"acq-\${_name}-\${_slug}-\${_ck}:\${_path}:kind=disk,size=\${_size}\")"
     fi
-  done <<EOF
+  done
+}
+
+# Spec-based convenience wrapper: emit one kit's volume flags. Usage:
+#   _acq_msb_volume_flags_into ARRVAR SPEC SANDBOX
+# Provision does NOT use this — it unions records across ALL kits first (see
+# _acq_msb_volume_records_dedupe) so same-path declarations cannot emit
+# conflicting flags.
+_acq_msb_volume_flags_into() {
+  local _spec="$2"
+  _acq_msb_volume_flags_from_records "$1" "$3" <<EOF
 $(kit_spec_volumes "$_spec")
 EOF
+}
+
+# Union volume records by path, LAST WINS — the same composition rule sbx
+# applies to its own volumes (kit-spec v2 §5.7), so a kit combination that
+# works on sbx works identically on msb instead of emitting two conflicting
+# --mount-named flags for one path (create-or-reuse would fail the create on
+# the size mismatch). stdin -> stdout; blank lines dropped; surviving records
+# keep the position of their LAST occurrence.
+_acq_msb_volume_records_dedupe() {
+  awk -F'\t' '
+    $1 != "" { recs[NR]=$0; last[$1]=NR }
+    END { for (i=1;i<=NR;i++) if (i in recs) { split(recs[i],f,"\t"); if (last[f[1]]==i) print recs[i] } }
+  '
 }
 
 # Remove the named volumes acq derived for SANDBOX's kit `volumes:` entries
@@ -2172,6 +2202,7 @@ acq_backend_provision() {
   local create_flags=()
   local trust_host_cas=0
   local kitdirs=()
+  local _volrecs=""
 
   # Create-time startup-script staging (ADR-0017, increment 1). Reset the
   # per-provision guard + staged-file list so a prior provision in the same
@@ -2230,15 +2261,13 @@ acq_backend_provision() {
     _acq_msb_port_flags_into pp "$spec"
     [ "${#pp[@]}" -gt 0 ] && create_flags+=("${pp[@]}")
 
-    # Volumes (ADR-0022) → create-time storage flags: a block entry becomes a
-    # derived named disk volume (--mount-named acq-<name>-<pathslug>:<path>:
-    # kind=disk,size=<size>, removed again in acq_backend_terminate), a tmpfs
-    # entry becomes --tmpfs <path>:<size>. Mounts land at boot, before any exec
-    # is possible (the same no-race guarantee as sbx kit volumes). Absence is a
-    # silent no-op.
-    local vf=()
-    _acq_msb_volume_flags_into vf "$spec" "$name"
-    [ "${#vf[@]}" -gt 0 ] && create_flags+=("${vf[@]}")
+    # Volumes (ADR-0022): ACCUMULATE this kit's validated records; they are
+    # unioned across all kits (last wins by path, matching sbx's own
+    # composition rule) and emitted as create flags AFTER the loop — emitting
+    # per kit here would produce conflicting --mount-named flags when two kits
+    # declare the same path.
+    _volrecs="${_volrecs}
+$(kit_spec_volumes "$spec")"
 
     # Startup-phase commands → a create-time `--script-path acq-startup:<file>`
     # (ADR-0017). The script is REGISTERED at create; a bare registration is
@@ -2249,6 +2278,18 @@ acq_backend_provision() {
     # stakes the fixed script name (see _acq_msb_stage_startup_script).
     _acq_msb_stage_startup_script "$spec" create_flags
   done
+
+  # Volumes (ADR-0022) → create-time storage flags, from the union of every
+  # kit's records (last wins by path): a block entry becomes a derived named
+  # disk volume (--mount-named acq-<name>-<pathslug>-<crc>:<path>:kind=disk,
+  # size=<size>, removed again in acq_backend_terminate), a tmpfs entry becomes
+  # --tmpfs <path>:<size>. Mounts land at boot, before any exec is possible
+  # (the same no-race guarantee as sbx kit volumes). Absence is a silent no-op.
+  local vf=()
+  _acq_msb_volume_flags_from_records vf "$name" <<EOF
+$(printf '%s\n' "$_volrecs" | _acq_msb_volume_records_dedupe)
+EOF
+  [ "${#vf[@]}" -gt 0 ] && create_flags+=("${vf[@]}")
 
   [ "$trust_host_cas" -eq 1 ] && create_flags+=(--trust-host-cas)
 
@@ -3522,10 +3563,19 @@ acq_backend_terminate() {
   # before removing the sandbox (ADR-0015). Killing a dead PID / missing state
   # file is a no-op.
   _acq_msb_ports_teardown "$1"
-  # On a failed remove the sandbox still exists (and may still use its derived
-  # volumes), so only clean the volumes up after a successful remove.
-  msb remove --force "$1" || return $?
+  # Clean up derived volumes (ADR-0022) whenever the sandbox is GONE after the
+  # remove attempt — not merely when remove succeeded. A failed remove of a
+  # still-existing sandbox must not touch volumes that may be in use, but a
+  # failed remove of an already-gone sandbox (removed via `msb rm` directly, or
+  # a half-failed create that never registered) must still reach the cleanup,
+  # or the volumes orphan forever under ~/.microsandbox/volumes/.
+  local _rc=0
+  msb remove --force "$1" || _rc=$?
+  if [ "$_rc" -ne 0 ] && acq_backend_exists "$1"; then
+    return "$_rc"
+  fi
   _acq_msb_remove_derived_volumes "$1"
+  return "$_rc"
 }
 
 acq_backend_list() {
@@ -3950,6 +4000,14 @@ acq_backend_apply_kit() {
     echo "acq(msb): error: could not fetch kit: $kitref" >&2
     return 1
   }
+  # Volumes are creation-time only (ADR-0022): a mid-life apply cannot attach
+  # them, so say so instead of leaving the kit's storage requirement silently
+  # unmet. (Provision-time applies do not pass here — their volumes were
+  # mounted at create.)
+  if [ -n "$(kit_spec_volumes "${kitdir}/spec.yaml" 2>/dev/null)" ]; then
+    echo "acq(msb): note: this kit declares volumes:, which apply at CREATE time only —" >&2
+    echo "acq(msb):   this apply skips them. Recreate the sandbox (acq rm && acq run) to mount them." >&2
+  fi
   _acq_msb_apply_kit_dir "$name" "$kitdir"
 }
 

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -27,6 +27,15 @@
 #   - `msb list|ls [-q] [--running]`, `msb stop`, `msb remove|rm [-f]`,
 #     `msb copy|cp SRC DST`, `msb ssh [SANDBOX] [-- CMD…]`, `msb ssh authorize`,
 #     `msb run … -p HOST:GUEST` (published ports), `msb doctor`.
+#   - Volume surface (ADR-0022): `msb create … --mount-named
+#     NAME:PATH:kind=disk,size=SIZE` (create-or-reuse disk-backed named volume),
+#     `--tmpfs PATH:SIZE`, and `msb volume ls -q` / `msb volume rm NAME` for the
+#     terminate-time cleanup of derived volumes. LIVE-VERIFIED end-to-end on
+#     msb 0.6.12 (macOS HVF) via `scripts/verify-backends --only msb` (17/17):
+#     the derived disk volume mounts at boot on a dedicated virtio-blk device
+#     of the declared size, and is removed again on `acq rm`. NOTE: msb refuses
+#     tiny ext4 disk images ("image size is too small for ext4 formatting";
+#     floor 128M on 0.6.12) — kits should stay well above it (~256m floor).
 # net-rule grammar (verified from --help): `<action>[:<direction>]@<target>
 #   [:<proto>[:<ports>]]`. For a literal hostname the target is the BARE FQDN,
 #   e.g. `allow@api.gsa.usai.gov` (per the msb --help example
@@ -1197,7 +1206,15 @@ _acq_msb_balanced_rules_into() {
 _acq_msb_port_flags_into() {
   local _arr="$1" _spec="$2" _rec _guest _host
   eval "$_arr=()"
-  while IFS="$(printf '\t')" read -r _guest _ _ _host; do
+  # Parse fields with cut, NOT `IFS=<tab> read`: tab is IFS whitespace, so a
+  # bare read COLLAPSES adjacent empty fields — an entry with guest + host but
+  # no protocol/name ("3000<TAB><TAB><TAB>8080") would read the host column
+  # into the protocol position and emit `-p 3000:3000` instead of `-p 8080:3000`
+  # (same pitfall as the kit_spec_files consumer in _acq_msb_apply_kit_dir).
+  while IFS= read -r _rec; do
+    [ -n "$_rec" ] || continue
+    _guest=$(printf '%s' "$_rec" | cut -f1)
+    _host=$(printf '%s' "$_rec" | cut -f4)
     [ -n "$_guest" ] || continue
     [ -n "$_host" ] || _host="$_guest"
     # Defense-in-depth: the validator already guarantees integer ports, but
@@ -1212,6 +1229,91 @@ _acq_msb_port_flags_into() {
   done <<EOF
 $(kit_spec_published_ports "$_spec")
 EOF
+}
+
+# Emit the create-time storage flags for a kit's neutral `volumes:` entries into
+# the named array. Usage: _acq_msb_volume_flags_into ARRVAR SPEC SANDBOX
+#
+# ADR-0022: kit_spec_volumes emits validated `path<TAB>type<TAB>size` records
+# (path absolute + charset-safe, type ""|tmpfs, size byte-size grammar).
+# Mapping, mirroring the sbx kit-spec v2 §5.7 semantics:
+#   block (type "")  -> --mount-named acq-<sandbox>-<pathslug>:<path>:kind=disk,size=<size>
+#   tmpfs            -> --tmpfs <path>:<size>
+# The named volume is derived DETERMINISTICALLY from sandbox name + path slug so
+# acq_backend_terminate can find and remove it by prefix — msb named volumes
+# otherwise persist independently under ~/.microsandbox/volumes/ and would
+# silently accumulate (sbx kit volumes die with `sbx rm`; the derived name +
+# terminate cleanup restores that lifecycle). --mount-named is create-or-reuse:
+# a leftover same-name volume with incompatible settings fails the create loudly
+# rather than silently changing the volume. Mounts land at boot, before any exec
+# is possible — the same no-race-with-startup guarantee as sbx volumes. Like the
+# sbx side, mounts land UNSEEDED (msb named volumes shadow image content at the
+# path). Records are parsed with cut, not `IFS=<tab> read` (tab is IFS
+# whitespace, so a bare read collapses the empty type field into size). Uses the
+# eval-by-name array pattern (macOS bash 3.2 compat), like
+# _acq_msb_port_flags_into. Absence is a silent no-op (defensive neutral read).
+_acq_msb_volume_flags_into() {
+  local _arr="$1" _spec="$2" _name="$3" _rec _path _type _size _slug
+  eval "$_arr=()"
+  while IFS= read -r _rec; do
+    [ -n "$_rec" ] || continue
+    _path=$(printf '%s' "$_rec" | cut -f1)
+    _type=$(printf '%s' "$_rec" | cut -f2)
+    _size=$(printf '%s' "$_rec" | cut -f3)
+    [ -n "$_path" ] || continue
+    # Defense-in-depth: the validator already guarantees an absolute path and
+    # safe charsets, but re-check before the values reach an argv via eval.
+    case "$_path" in
+      /*) ;;
+      *)
+        echo "acq(msb): warning: skipping volume with non-absolute path: ${_path}" >&2
+        continue
+        ;;
+    esac
+    if printf '%s%s' "$_path" "$_size" | LC_ALL=C grep -q '[^A-Za-z0-9._/-]'; then
+      echo "acq(msb): warning: skipping volume with unsafe path/size: ${_path}:${_size}" >&2
+      continue
+    fi
+    if [ "$_type" = "tmpfs" ]; then
+      eval "$_arr+=(--tmpfs \"\${_path}:\${_size}\")"
+    else
+      # Slug: strip the leading /, map everything outside [A-Za-z0-9] to '-',
+      # squeeze runs (e.g. /var/lib/docker -> var-lib-docker).
+      _slug=$(printf '%s' "${_path#/}" | tr -c 'A-Za-z0-9' '-' | tr -s '-')
+      _slug="${_slug%-}"
+      eval "$_arr+=(--mount-named \"acq-\${_name}-\${_slug}:\${_path}:kind=disk,size=\${_size}\")"
+    fi
+  done <<EOF
+$(kit_spec_volumes "$_spec")
+EOF
+}
+
+# Remove the named volumes acq derived for SANDBOX's kit `volumes:` entries
+# (acq-<sandbox>-<pathslug>, see _acq_msb_volume_flags_into). Best-effort and
+# always returns 0: a host with no derived volumes is a quiet no-op. Volume
+# names are read into an array FIRST — `msb volume rm` inside a piped while
+# would drain the loop's stdin (the recorded loop-stdin-consumption pitfall).
+# NOTE: prefix-matched, so a sandbox name that is itself a prefix of another
+# sandbox's name + '-' (e.g. `web` vs `web-2`) could match the longer sandbox's
+# volumes; accepted for now — see ADR-0022.
+_acq_msb_remove_derived_volumes() {
+  local _name="$1" _vol _vols=()
+  while IFS= read -r _vol; do
+    case "$_vol" in
+      "acq-${_name}-"*) _vols+=("$_vol") ;;
+    esac
+  done <<EOF
+$(msb volume ls -q 2>/dev/null)
+EOF
+  local _i
+  for _i in ${_vols[@]+"${!_vols[@]}"}; do
+    if msb volume rm "${_vols[$_i]}" >/dev/null 2>&1 </dev/null; then
+      acq_debug "removed derived volume ${_vols[$_i]}"
+    else
+      echo "acq(msb): warning: could not remove derived volume: ${_vols[$_i]}" >&2
+    fi
+  done
+  return 0
 }
 
 # Apply a single fetched kit directory to a running sandbox NAME.
@@ -2127,6 +2229,16 @@ acq_backend_provision() {
     local pp=()
     _acq_msb_port_flags_into pp "$spec"
     [ "${#pp[@]}" -gt 0 ] && create_flags+=("${pp[@]}")
+
+    # Volumes (ADR-0022) → create-time storage flags: a block entry becomes a
+    # derived named disk volume (--mount-named acq-<name>-<pathslug>:<path>:
+    # kind=disk,size=<size>, removed again in acq_backend_terminate), a tmpfs
+    # entry becomes --tmpfs <path>:<size>. Mounts land at boot, before any exec
+    # is possible (the same no-race guarantee as sbx kit volumes). Absence is a
+    # silent no-op.
+    local vf=()
+    _acq_msb_volume_flags_into vf "$spec" "$name"
+    [ "${#vf[@]}" -gt 0 ] && create_flags+=("${vf[@]}")
 
     # Startup-phase commands → a create-time `--script-path acq-startup:<file>`
     # (ADR-0017). The script is REGISTERED at create; a bare registration is
@@ -3410,7 +3522,10 @@ acq_backend_terminate() {
   # before removing the sandbox (ADR-0015). Killing a dead PID / missing state
   # file is a no-op.
   _acq_msb_ports_teardown "$1"
-  msb remove --force "$1"
+  # On a failed remove the sandbox still exists (and may still use its derived
+  # volumes), so only clean the volumes up after a successful remove.
+  msb remove --force "$1" || return $?
+  _acq_msb_remove_derived_volumes "$1"
 }
 
 acq_backend_list() {

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -612,6 +612,7 @@ rationale, the fixed vsock port (3552), and the trust-boundary discussion.
 | Secret binding breadth | 7 built-in services + any custom `--host/--env` endpoint | usai + github + **any** custom `--host/--env` endpoint bound generically via `--secret ENV@HOST` (shipped) |
 | Snapshots | not supported (`SUPPORTS_SNAPSHOTS=0`) | `msb snapshot` verb exists but **not surfaced by `acq`** (beyond-parity; `SUPPORTS_SNAPSHOTS=0`) |
 | Port forwarding | `acq ports` (post-hoc) | create/run (`-p`) via neutral `publishedPorts` now (shipped); **plus** post-hoc `acq ports --publish` via `msb ssh serve` + `ssh -L` now implemented (ADR-0015) — live end-to-end verification pending a KVM host |
+| Kit volumes | neutral `volumes:` passed through 1:1 to kit-spec v2 §5.7 (sized block device / tmpfs, mounted at create; dies with the sandbox) | neutral `volumes:` mapped to a derived named disk volume (`--mount-named acq-<sandbox>-<pathslug>:<path>:kind=disk,size=<size>`) or `--tmpfs <path>:<size>`; derived volumes removed on `acq rm` (ADR-0022) |
 | Agent binary | supplied by the sbx agent template | installed at provision on a plain base (`npm install -g opencode-ai`), then launched on attach |
 | OpenCode web UI | `openchamber` acq kit (publishes port 4096) | same kit once it declares `backends: [sbx, msb]` against the released patterns schema (neutral port/background vocab consumed by both backends; the patterns repo's openchamber kit) |
 | In-place kit heal | `sbx kit add` (state-preserving, 0.35.0+; **no startup-bearing kits on 0.38+ — recreate to extend/refresh**) | re-apply kits idempotently (no state-preserving add) |
@@ -772,7 +773,8 @@ under `integrations/isolation/acq-kits/`) and translated per backend by
   native primitive instead.
 
 The neutral vocabulary is: `caps.network.allow`, `files[]`, `commands[]`,
-`environment`, `agentContext`, `backend_shortcuts`, and `backend_extras`.
+`environment`, `publishedPorts`, `volumes`, `agentContext`,
+`backend_shortcuts`, and `backend_extras`.
 
 **`environment` (guest env vars).** A flat map of `NAME → value` for
 **non-secret** guest environment variables (e.g. `OPENCODE_CONFIG`,
@@ -789,6 +791,33 @@ the kit spec never carries a secret value.
 > **v1.7.0**. `PATTERNS_KIT_REF` is pinned to the patterns **v1.8.0**
 > release commit (`f5fb887`); the pin is only advanced to a tagged release,
 > per the fail-closed cross-repo gating.
+
+**`volumes` (sized guest storage, [ADR-0022](adr/0022-neutral-volumes-kit-vocabulary.md)).**
+A top-level list of `{path, type?, size}` entries — `path` required and
+absolute, `type` empty (block-backed, the default) or `tmpfs`, `size` required
+(byte-size string, e.g. `20G`, `512m`). Volumes are **creation-time only** and
+mount **at boot, before any exec is possible**, so storage layout never races
+startup commands or early agent use. On sbx entries pass through 1:1 to the
+kit-spec v2 §5.7 `volumes` block (a dedicated ext4 block device of the declared
+size); on msb a block entry becomes a derived named disk volume
+(`acq-<sandbox>-<pathslug>`, removed again on `acq rm`) and a tmpfs entry
+becomes `--tmpfs`. Invalid entries are dropped with a warning and reported by
+`acq kit validate`. Don't declare tiny block volumes: msb refuses ext4 disk
+images below a minimum size (128M on msb 0.6.12, "image size is too small for
+ext4 formatting") — treat ~256m as a practical floor.
+
+> **Kit-authoring caveat: volumes mount UNSEEDED (both backends).** The mount
+> is an empty filesystem that shadows any image content at the path. A kit that
+> needs the image's content there (e.g. relocating a baked-in `/nix` store)
+> ships its own first-boot copy step; the shadowed content stays reachable
+> through a non-recursive bind mount of `/` (e.g.
+> `mount --bind / /mnt/rootfs`, then copy from `/mnt/rootfs/<path>`).
+>
+> **Note (cross-repo, open):** the authoritative `volumes` schema property is
+> not yet in the patterns repo's `kit-hybrid-v1.schema.json`. The field is read
+> defensively here (absence is a silent no-op), per the ADR-0014 gating
+> discipline; it lights up for the pinned kits once the patterns schema gains
+> the property and `PATTERNS_KIT_REF` advances past it.
 
 Manage kits with `acq kit list | validate PATH | apply NAME KITREF`.
 
@@ -841,6 +870,14 @@ See [ADR-0016](adr/0016-kit-bundle-provenance-and-stale-refresh.md).
   ([ADR-0015](adr/0015-msb-post-hoc-port-publish-via-ssh.md)). **Implemented,
   not yet live-verified** — live end-to-end run needs a KVM host per the ADR-0011
   `scripts/verify-backends` cadence
+- Neutral top-level `volumes` vocab consumed by **both** backends (sbx: 1:1
+  into kit-spec v2 §5.7; msb: derived named disk volume / `--tmpfs`, with
+  derived-volume cleanup on `acq rm`)
+  ([ADR-0022](adr/0022-neutral-volumes-kit-vocabulary.md)). **Live-verified on
+  both backends** (`verify-backends`: msb 0.6.12 macOS HVF 17/17 — dedicated
+  virtio-blk mount at boot + derived-volume removal on rm; sbx 0.39.0 9/9 —
+  dedicated block-device mount of the declared size); the patterns schema
+  property is still pending, so the field is read defensively (absence a no-op)
 
 ## Shipped later
 

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -612,7 +612,7 @@ rationale, the fixed vsock port (3552), and the trust-boundary discussion.
 | Secret binding breadth | 7 built-in services + any custom `--host/--env` endpoint | usai + github + **any** custom `--host/--env` endpoint bound generically via `--secret ENV@HOST` (shipped) |
 | Snapshots | not supported (`SUPPORTS_SNAPSHOTS=0`) | `msb snapshot` verb exists but **not surfaced by `acq`** (beyond-parity; `SUPPORTS_SNAPSHOTS=0`) |
 | Port forwarding | `acq ports` (post-hoc) | create/run (`-p`) via neutral `publishedPorts` now (shipped); **plus** post-hoc `acq ports --publish` via `msb ssh serve` + `ssh -L` now implemented (ADR-0015) — live end-to-end verification pending a KVM host |
-| Kit volumes | neutral `volumes:` passed through 1:1 to kit-spec v2 §5.7 (sized block device / tmpfs, mounted at create; dies with the sandbox) | neutral `volumes:` mapped to a derived named disk volume (`--mount-named acq-<sandbox>-<pathslug>:<path>:kind=disk,size=<size>`) or `--tmpfs <path>:<size>`; derived volumes removed on `acq rm` (ADR-0022) |
+| Kit volumes | neutral `volumes:` passed through 1:1 to kit-spec v2 §5.7 (sized block device / tmpfs, mounted at create; dies with the sandbox) | neutral `volumes:` unioned across kits (last wins by path) and mapped to a derived named disk volume (`--mount-named acq-<sandbox>-<pathslug>-<crc>:<path>:kind=disk,size=<size>`) or `--tmpfs <path>:<size>`; derived volumes removed on `acq rm` (ADR-0022) |
 | Agent binary | supplied by the sbx agent template | installed at provision on a plain base (`npm install -g opencode-ai`), then launched on attach |
 | OpenCode web UI | `openchamber` acq kit (publishes port 4096) | same kit once it declares `backends: [sbx, msb]` against the released patterns schema (neutral port/background vocab consumed by both backends; the patterns repo's openchamber kit) |
 | In-place kit heal | `sbx kit add` (state-preserving, 0.35.0+; **no startup-bearing kits on 0.38+ — recreate to extend/refresh**) | re-apply kits idempotently (no state-preserving add) |
@@ -793,18 +793,24 @@ the kit spec never carries a secret value.
 > per the fail-closed cross-repo gating.
 
 **`volumes` (sized guest storage, [ADR-0022](adr/0022-neutral-volumes-kit-vocabulary.md)).**
-A top-level list of `{path, type?, size}` entries — `path` required and
-absolute, `type` empty (block-backed, the default) or `tmpfs`, `size` required
-(byte-size string, e.g. `20G`, `512m`). Volumes are **creation-time only** and
-mount **at boot, before any exec is possible**, so storage layout never races
-startup commands or early agent use. On sbx entries pass through 1:1 to the
-kit-spec v2 §5.7 `volumes` block (a dedicated ext4 block device of the declared
-size); on msb a block entry becomes a derived named disk volume
-(`acq-<sandbox>-<pathslug>`, removed again on `acq rm`) and a tmpfs entry
-becomes `--tmpfs`. Invalid entries are dropped with a warning and reported by
-`acq kit validate`. Don't declare tiny block volumes: msb refuses ext4 disk
-images below a minimum size (128M on msb 0.6.12, "image size is too small for
-ext4 formatting") — treat ~256m as a practical floor.
+A top-level list of `{path, type?, size}` entries — `path` required, absolute,
+and normalized (no `.`/`..` segments, no `//`, no trailing `/` — a volume
+mounts a whole filesystem, so `/.` would shadow the guest root), `type` empty
+(block-backed, the default) or `tmpfs`, `size` required
+and non-zero, in the portable byte-size grammar (`20G`, `512m`, `1.5G` — no
+`b`/`ib` suffixes like `256MB`/`2gib`; msb's parser rejects those even though
+sbx accepts them). Volumes are **creation-time only** and mount **at boot,
+before any exec is possible**, so storage layout never races startup commands
+or early agent use; a mid-life `acq kit apply` warns that it cannot attach
+them. Multiple kits union by path, last wins, on both backends. On sbx entries
+pass through 1:1 to the kit-spec v2 §5.7 `volumes` block (a dedicated ext4
+block device of the declared size); on msb a block entry becomes a derived
+named disk volume (`acq-<sandbox>-<pathslug>-<crc>`, removed again on
+`acq rm`) and a tmpfs entry becomes `--tmpfs`. Invalid entries are dropped
+with a warning and reported by `acq kit validate`. Don't declare tiny block
+volumes: msb refuses ext4 disk images below a minimum size (128M on msb
+0.6.12, "image size is too small for ext4 formatting") — treat ~256m as a
+practical floor (`acq kit validate` warns below it).
 
 > **Kit-authoring caveat: volumes mount UNSEEDED (both backends).** The mount
 > is an empty filesystem that shadows any image content at the path. A kit that

--- a/docs/adr/0022-neutral-volumes-kit-vocabulary.md
+++ b/docs/adr/0022-neutral-volumes-kit-vocabulary.md
@@ -88,16 +88,25 @@ volumes:
 - **sbx.** `kit_translate_to_sbx` passes entries through 1:1 into the
   synthesized sbx-v2 `volumes:` block. Creation-time only (`sbx kit add` skips
   volumes); multiple kits union by path, last wins — sbx resolves that itself.
-- **msb.** `_acq_msb_volume_flags_into` maps a block entry to
-  `--mount-named acq-<sandbox>-<pathslug>:<path>:kind=disk,size=<size>` and a
-  tmpfs entry to `--tmpfs <path>:<size>` at create. The named volume is derived
-  **deterministically** from sandbox name + path slug so
-  `acq_backend_terminate` can find and remove it (`msb volume ls -q` +
-  `msb volume rm`, prefix `acq-<sandbox>-`) after a successful `msb remove` —
-  without the cleanup, named volumes would silently accumulate under
-  `~/.microsandbox/volumes/`. `--mount-named` is create-or-reuse: a leftover
-  same-name volume with incompatible settings fails the create loudly rather
-  than silently changing it.
+- **msb.** Provision UNIONS every kit's records by path (last wins,
+  `_acq_msb_volume_records_dedupe` — the same composition rule sbx applies),
+  then maps a block entry to
+  `--mount-named acq-<sandbox>-<pathslug>-<crc>:<path>:kind=disk,size=<size>`
+  and a tmpfs entry to `--tmpfs <path>:<size>` at create. The named volume is
+  derived **deterministically** from sandbox name + path slug + a POSIX-cksum
+  CRC of the raw path — the CRC is identity, not decoration: the slug is lossy
+  (`/data/app` and `/data.app` both slug to `data-app`), so without it two
+  distinct volumes could derive the same name and silently share one disk.
+  `acq_backend_terminate` finds and removes the derived volumes
+  (`msb volume ls -q` + `msb volume rm`, prefix `acq-<sandbox>-`) whenever the
+  sandbox is GONE after the remove attempt — including a failed remove of an
+  already-gone sandbox (removed out of band), which would otherwise orphan the
+  volumes forever under `~/.microsandbox/volumes/`; a failed remove of a
+  still-existing sandbox leaves its volumes untouched. A mid-life
+  `acq kit apply` cannot attach volumes (creation-time only) and says so with
+  a stderr note instead of silently skipping them. `--mount-named` is
+  create-or-reuse: a leftover same-name volume with incompatible settings
+  fails the create loudly rather than silently changing it.
 
 ### Unseeded mounts (both backends, by design)
 
@@ -114,10 +123,21 @@ from `/mnt/rootfs/<path>`).
 Volume fields are untrusted kit input that reach a generated YAML spec and an
 msb argv:
 
-- `path` MUST be absolute and charset-restricted (`[A-Za-z0-9._/-]`); `type`
-  MUST be empty or `tmpfs`; `size` MUST match the kit-spec v2 §5.7 byte-size
-  grammar (`units.RAMInBytes`, e.g. `20G`, `512m`, `2gib`). Offending entries
-  are dropped with a warning and reported by `acq kit validate`.
+- `path` MUST be absolute, charset-restricted (`[A-Za-z0-9._/-]`), and
+  NORMALIZED — no `.`/`..` segments, no `//`, no trailing `/` (dot-prefixed
+  names like `..hidden` stay legal). Normalization matters more for volumes
+  than for `files[].path`: a volume mounts a whole unseeded filesystem, so
+  `/.` or `//` would shadow the guest root outright and `/data/../etc` would
+  mount over `/etc` while reading as a `/data` path in human review. `type`
+  MUST be empty or `tmpfs`; `size` MUST be non-zero and match the PORTABLE
+  byte-size grammar (integer or decimal + optional bare `k/m/g/t/p` unit, e.g.
+  `20G`, `512m`, `1.5G`) — the intersection of sbx's `units.RAMInBytes` and
+  msb's size parser. sbx also accepts `b`/`ib` suffixes (`256MB`, `2gib`) but
+  msb rejects them ("invalid digit found in string", verified on 0.6.12), so
+  the neutral grammar excludes them: a declared size must work on every
+  backend. Offending entries are dropped with a warning and reported by
+  `acq kit validate`; a valid block size below msb's 128M ext4 floor gets a
+  validate-time WARNING (legitimate for sbx-only kits, fails msb create).
 - The msb adapter re-checks the charset before values reach the create argv
   (defense-in-depth, mirroring `_acq_msb_port_flags_into`).
 
@@ -142,7 +162,9 @@ released commit that includes it.
   of another sandbox's name + `-` (e.g. `web` vs `web-2`) could match the
   longer name's volumes at `rm` time. Accepted for now: acq's `derive_name`
   produces distinct agent-workspace slugs, and an exact-match cleanup would
-  require re-fetching kit specs at terminate.
+  require re-fetching kit specs at terminate. (The related CREATE-time hazard —
+  two distinct volumes deriving the same name via the lossy slug — is solved
+  outright by the CRC suffix, not accepted.)
 - **Tradeoff:** on msb a volume's contents do NOT survive `acq rm` (they die
   with the sandbox, like sbx). A user who wants sandbox-independent persistent
   storage manages a named volume outside acq.

--- a/docs/adr/0022-neutral-volumes-kit-vocabulary.md
+++ b/docs/adr/0022-neutral-volumes-kit-vocabulary.md
@@ -1,0 +1,194 @@
+---
+title: "Neutral Volumes Kit Vocabulary"
+status: accepted
+date: 2026-08-19
+decision_makers: ["Bret Mogilefsky"]
+category: architecture
+nist_controls: ["CM-2", "CM-3", "CM-6", "SA-8", "SA-15", "SA-17", "SI-10"]
+impact_level: low
+ato_relevance: no
+risk_treatment: accept
+supersedes: []
+---
+
+# ADR-0022: Neutral Volumes Kit Vocabulary
+
+## Context and Problem Statement
+
+sbx kit-spec v2 §5.7 supports `volumes:` — sized, block-backed (or tmpfs)
+volumes mounted at any absolute path, applied at sandbox creation. This is
+verified fully wired on sbx 0.38.0: a mixin declaring a 2G volume gets a
+dedicated ext4 block device of the declared size mounted at the path.
+
+Hybrid/v1 kits cannot reach this: `kit-translate.sh` has no `volumes`
+vocabulary, so a neutral kit has no way to declare storage. Teams that need it
+script around the fixed disk layout in `commands.startup` instead — which runs
+*after* the sandbox already accepts execs, so any storage rearrangement races
+the user and the agent. The concrete driver
+([#329](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/329),
+login.gov Team Data): a kit that relocates a multi-GB `/nix` store onto larger
+storage hit exactly that race in production (a first `direnv allow` died with
+ENOENT mid-swap), and an unfixable ~1 s empty-`/nix` window per restart
+remained — the startup step itself is what races. A create-time volume mounts
+before any exec is possible, eliminating the race class entirely.
+
+msb parity was researched in the #329 thread against the v0.6.8 tag (flags
+exist at acq's `MIN_MSB_VERSION` floor): msb's storage primitives are a
+superset of what the vocabulary needs — disk-backed named volumes
+(`--mount-named NAME:PATH:kind=disk,size=SIZE`, raw ext4 via virtio-blk) and
+`--tmpfs PATH:SIZE`.
+
+## Decision Drivers
+
+- **Kill the startup-storage race class** — volumes mount at boot, before any
+  exec, on BOTH backends (the same ordering guarantee that motivated #329).
+- **Backend-neutral by construction** — a kit expresses "give this path sized
+  storage" once, not per backend (ADR-0011 doctrine).
+- **No new runtime dependency** — parse with `awk`, consistent with ADR-0011.
+- **Fail closed on untrusted input (SI-10)** — volume fields reach a generated
+  sbx-v2 spec and an msb create argv.
+- **No orphaned host state** — msb named volumes persist independently under
+  `~/.microsandbox/volumes/`; sbx kit volumes die with the sandbox. Parity
+  includes the lifecycle, not just the mount.
+
+## Considered Options
+
+1. **Neutral top-level `volumes:` consumed by both backends; msb derives a
+   per-sandbox named volume and removes it on `rm`.** Chosen.
+2. **sbx-only (`backend_extras.sbx`), warn-and-skip on msb.** Rejected:
+   perpetuates the per-backend drift ADR-0011 exists to avoid, and msb has
+   full-parity primitives at the current version floor.
+3. **Keep scripting storage in `commands.startup`.** Rejected: the race class
+   is unfixable from inside a startup step (#329).
+
+## Decision Outcome
+
+**Chosen: Option 1.** Add one neutral field to `hybrid/v1`, mirroring kit-spec
+v2 §5.7 minus `mode`:
+
+```yaml
+volumes:
+  - path: /var/lib/docker   # required, absolute
+    size: 20G               # required
+  - path: /scratch
+    type: tmpfs             # optional; "" (block, default) | tmpfs
+    size: 2G
+```
+
+- `size` is **required** — the neutral schema does not inherit sbx's
+  unsized-volume default, which is still settling upstream (0.39-rc moved it
+  50G → 512M between rcs).
+- `mode` is **excluded** from the neutral vocabulary: msb's mount-option
+  grammar has no equivalent (verified at 0.6.8: `ro/rw/noexec/nosuid/nodev`,
+  `kind=`, `size=`, `quota=`), and a kit can `chmod` in a startup step. Keeping
+  the vocabulary backend-uniform beats exposing every sbx knob.
+
+### Translation
+
+- **sbx.** `kit_translate_to_sbx` passes entries through 1:1 into the
+  synthesized sbx-v2 `volumes:` block. Creation-time only (`sbx kit add` skips
+  volumes); multiple kits union by path, last wins — sbx resolves that itself.
+- **msb.** `_acq_msb_volume_flags_into` maps a block entry to
+  `--mount-named acq-<sandbox>-<pathslug>:<path>:kind=disk,size=<size>` and a
+  tmpfs entry to `--tmpfs <path>:<size>` at create. The named volume is derived
+  **deterministically** from sandbox name + path slug so
+  `acq_backend_terminate` can find and remove it (`msb volume ls -q` +
+  `msb volume rm`, prefix `acq-<sandbox>-`) after a successful `msb remove` —
+  without the cleanup, named volumes would silently accumulate under
+  `~/.microsandbox/volumes/`. `--mount-named` is create-or-reuse: a leftover
+  same-name volume with incompatible settings fails the create loudly rather
+  than silently changing it.
+
+### Unseeded mounts (both backends, by design)
+
+Volumes mount **unseeded**: an empty filesystem shadows any image content at
+the path (verified empirically on sbx 0.38; msb named volumes behave the
+same). This is documented, backend-uniform behavior — the translator does not
+try to fix it. A kit that needs the image's content at the path ships its own
+first-boot copy step; content shadowed by the mount stays reachable through a
+non-recursive bind mount of `/` (e.g. `mount --bind / /mnt/rootfs`, then copy
+from `/mnt/rootfs/<path>`).
+
+### Validation (SI-10)
+
+Volume fields are untrusted kit input that reach a generated YAML spec and an
+msb argv:
+
+- `path` MUST be absolute and charset-restricted (`[A-Za-z0-9._/-]`); `type`
+  MUST be empty or `tmpfs`; `size` MUST match the kit-spec v2 §5.7 byte-size
+  grammar (`units.RAMInBytes`, e.g. `20G`, `512m`, `2gib`). Offending entries
+  are dropped with a warning and reported by `acq kit validate`.
+- The msb adapter re-checks the charset before values reach the create argv
+  (defense-in-depth, mirroring `_acq_msb_port_flags_into`).
+
+### Cross-repo gate (open)
+
+The authoritative `hybrid/v1` schema lives in the patterns repo
+(`schemas/kit-hybrid-v1.schema.json`, `validate-kits.py`), which does not yet
+carry a `volumes` property. Per the ADR-0011/0014 discipline the neutral field
+is read **defensively** here (absence is a silent no-op, never an error), so
+this lands safely ahead of the schema; the field lights up end-to-end once the
+patterns schema gains the property and `PATTERNS_KIT_REF` advances to a
+released commit that includes it.
+
+## Consequences
+
+- **Better:** kits declare sized storage once, neutrally; the
+  startup-storage-rearrangement race class disappears on both backends; the
+  `/nix` relocation workaround (and its per-restart window) becomes a plain
+  volume + seed step.
+- **Tradeoff (accepted, flagged):** msb derived-volume cleanup is
+  prefix-matched (`acq-<sandbox>-`), so a sandbox name that is itself a prefix
+  of another sandbox's name + `-` (e.g. `web` vs `web-2`) could match the
+  longer name's volumes at `rm` time. Accepted for now: acq's `derive_name`
+  produces distinct agent-workspace slugs, and an exact-match cleanup would
+  require re-fetching kit specs at terminate.
+- **Tradeoff:** on msb a volume's contents do NOT survive `acq rm` (they die
+  with the sandbox, like sbx). A user who wants sandbox-independent persistent
+  storage manages a named volume outside acq.
+- **Compliance:** no new external services or data classification change
+  (CM-2/CM-3/CM-6); the new fields are validated before reaching a spec/argv
+  (SI-10). Structural translator + adapter change (SA-8/SA-15/SA-17).
+
+## Validation
+
+- `bash -n acq acq.backends/*.sh` clean; `scripts/test-acq` gains cases
+  (§10a5): neutral parse → sbx-v2 `volumes:` block + msb `--mount-named`/
+  `--tmpfs`; invalid path/type/size dropped + warned and reported by
+  `acq kit validate`; absence a no-op; `acq_backend_terminate` removes the
+  sandbox's derived volumes and leaves other volumes alone.
+- `scripts/verify-backends` gains a live check: a fixture kit declaring a 256m
+  block volume is appended to every create; the guest must show
+  `/acq-verify-vol` as a mountpoint on a dedicated `/dev` block device of
+  roughly the declared size, and on msb the derived volume must be gone after
+  `acq rm`. Live end-to-end runs need a sandbox-capable host per ADR-0011.
+- Live-confirmed on msb 0.6.12 (macOS, no sandbox needed): the `--mount-named`/
+  `--tmpfs` flag grammar, and a `msb volume create --kind disk --size 256M` →
+  `ls -q` → `rm` round-trip (the exact verbs the terminate cleanup drives).
+  Finding: msb refuses ext4 disk images below 128M ("image size is too small
+  for ext4 formatting"), so the fixture — and kit authors — should stay well
+  above it (~256m practical floor).
+- **Live end-to-end PASSED on both backends** (`scripts/verify-backends` with
+  the fixture kit):
+  - msb 0.6.12 (macOS HVF), `--only msb` 17/17 — the derived disk volume
+    mounted at boot on a dedicated virtio-blk device (`/dev/vdc`, 190432 kB
+    usable for the declared 256m), and was removed again on `acq rm`.
+  - sbx 0.39.0, `--only sbx` 9/9 — the synthesized v2 `volumes` block was
+    accepted and mounted at boot on a dedicated block device (`/dev/vde`,
+    235431 kB usable for the declared 256m). Notably one release past the
+    0.38.0 the driver issue verified against, so 0.39's volume rework kept the
+    sized-volume path intact.
+
+## Links
+
+- Driver: [#329](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/329)
+  (neutral `volumes:` vocabulary; msb parity research in-thread)
+- Builds on: [ADR-0011](0011-msb-backend-and-neutral-kits.md) (neutral
+  vocabulary), [ADR-0014](0014-neutral-port-publish-and-background-vocab.md)
+  (neutral-field promotion pattern + defensive read),
+  [ADR-0010](0010-acq-pluggable-backends.md) (adapter contract)
+- Upstream surfaces: sbx kit-spec v2 §5.7 (docker/sbx-kits-contrib
+  `spec/SPEC-v2.md`); msb named/disk volumes + `msb volume` verbs
+  (superradcompany/microsandbox docs, v0.6.8/0.6.9)
+- Related upstream feature request (not acq's to fix): runtime-side seeding of
+  volume content from the image (docker named-volume style)

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -371,7 +371,10 @@ case "$_msb_sub" in
     { [ -n "${USAI_API_KEY:-}" ] && printf 'USAI_API_KEY=present\n' >>"$CALLS"; } || true
     { [ -n "${GITHUB_TOKEN:-}" ] && printf 'GITHUB_TOKEN=present\n' >>"$CALLS"; } || true
     : ;;
-  remove|rm) : ;;
+  remove|rm)
+    # STUB_MSB_RM_FAIL=1 models a failed `msb remove` (e.g. sandbox not found)
+    # for the ADR-0022 terminate volume-cleanup matrix.
+    [ "${STUB_MSB_RM_FAIL:-0}" = "1" ] && exit 1 || : ;;
   copy|cp) : ;;
   modify) : ;;
   volume)
@@ -6049,7 +6052,10 @@ v_flags=$(
   arr=(); _acq_msb_volume_flags_into arr "$vkit/spec.yaml" volbox; printf '%s\n' "${arr[@]}"
 )
 assert_contains "vol: msb emits --mount-named flag token" "$v_flags" "--mount-named"
-assert_contains "vol: msb block entry derives per-sandbox disk volume" "$v_flags" "acq-volbox-var-lib-docker:/var/lib/docker:kind=disk,size=20G"
+# The derived name carries a POSIX-cksum CRC of the raw path (the slug alone is
+# lossy); cksum's CRC algorithm is POSIX-specified, so this is portable.
+vck=$(printf '%s' "/var/lib/docker" | cksum | cut -d' ' -f1)
+assert_contains "vol: msb block entry derives per-sandbox disk volume" "$v_flags" "acq-volbox-var-lib-docker-${vck}:/var/lib/docker:kind=disk,size=20G"
 assert_contains "vol: msb emits --tmpfs flag token" "$v_flags" "--tmpfs"
 assert_contains "vol: msb tmpfs entry emits path:size" "$v_flags" "/scratch:2G"
 vout="$STUBDIR/vout"
@@ -6085,6 +6091,22 @@ volumes:
   - path: /badsize
     size: 2G; rm -rf /
   - size: 1G
+  - path: /nonportable-ib
+    size: 2gib
+  - path: /nonportable-b
+    size: 256MB
+  - path: /zero
+    size: "0"
+  - path: /normdot/.
+    size: 1G
+  - path: //normslash
+    size: 1G
+  - path: /normup/../etc
+    size: 1G
+  - path: /normtrail/
+    size: 1G
+  - path: /norm/..hidden
+    size: 1G
   - path: /ok
     size: 512m
 SPEC
@@ -6096,18 +6118,49 @@ assert_not_contains "vol: unsafe path dropped" "$badv_out" "/has space"
 assert_not_contains "vol: bad type entry dropped" "$badv_out" "/badtype"
 assert_not_contains "vol: missing-size entry dropped" "$badv_out" "/nosize"
 assert_not_contains "vol: metacharacter size dropped" "$badv_out" "rm -rf"
+assert_not_contains "vol: sbx-only ib-suffix size dropped (msb rejects it)" "$badv_out" "nonportable-ib"
+assert_not_contains "vol: sbx-only b-suffix size dropped (msb rejects it)" "$badv_out" "nonportable-b"
+assert_not_contains "vol: zero size dropped" "$badv_out" "/zero"
+assert_not_contains "vol: dot-segment path dropped (would shadow guest root)" "$badv_out" "normdot"
+assert_not_contains "vol: empty-segment path dropped" "$badv_out" "normslash"
+assert_not_contains "vol: dot-dot traversal path dropped" "$badv_out" "normup"
+assert_not_contains "vol: trailing-slash path dropped" "$badv_out" "normtrail"
+assert_contains "vol: dot-PREFIXED segment name stays legal" "$badv_out" "/norm/..hidden"
 assert_contains "vol: warns unsafe path" "$badv_warn" "unsafe path"
 assert_contains "vol: warns invalid type" "$badv_warn" "invalid type"
 assert_contains "vol: warns missing size" "$badv_warn" "missing size"
 assert_contains "vol: warns invalid size" "$badv_warn" "invalid size"
+assert_contains "vol: warns zero size" "$badv_warn" "zero size"
+assert_contains "vol: warns non-normalized path" "$badv_warn" "non-normalized path"
 assert_contains "vol: warns missing path" "$badv_warn" "missing path"
 val_vol=$( . "${REPO_ROOT}/acq.backends/kit-translate.sh"; kit_validate "$badvkit/spec.yaml" 2>&1 )
 assert_contains "vol: kit validate reports non-absolute path" "$val_vol" "volume path must be absolute"
 assert_contains "vol: kit validate reports illegal path characters" "$val_vol" "volume path has illegal characters"
 assert_contains "vol: kit validate reports bad type" "$val_vol" "volume type must be"
 assert_contains "vol: kit validate reports missing size" "$val_vol" "volume size is required"
-assert_contains "vol: kit validate reports invalid size" "$val_vol" "volume size must be a byte-size"
+assert_contains "vol: kit validate reports non-portable size" "$val_vol" "volume size must be a portable byte-size"
+assert_contains "vol: kit validate reports zero size" "$val_vol" "volume size must be non-zero"
+assert_contains "vol: kit validate reports non-normalized path" "$val_vol" "volume path must be normalized"
 assert_contains "vol: kit validate reports missing path" "$val_vol" "volume path is required"
+cleanup_stubs
+
+# 10a5b2. A valid-but-small block size passes validate (sbx-only kits are
+#         legitimate) but WARNS about msb's 128M ext4 floor.
+make_stubs; load_acq
+smallvkit="$STUBDIR/smallvkit"; mkdir -p "$smallvkit"
+cat >"$smallvkit/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: small-vol-kit
+displayName: Small Vol Kit
+description: sub-floor block volume warns but validates
+volumes:
+  - path: /small
+    size: 64m
+SPEC
+val_small=$( . "${REPO_ROOT}/acq.backends/kit-translate.sh"; kit_validate "$smallvkit/spec.yaml" 2>&1 )
+assert_contains "vol: sub-floor block size still validates OK" "$val_small" "kit: validate: OK"
+assert_contains "vol: sub-floor block size warns about msb 128M floor" "$val_small" "below msb's 128M ext4 floor"
 cleanup_stubs
 
 # 10a5c. Absence of volumes is a NO-OP (empty output, no error) — the neutral
@@ -6145,6 +6198,96 @@ assert_contains "vol: terminate still removes the sandbox" "$term_log" "msb remo
 assert_contains "vol: terminate removes the derived volume" "$term_log" "msb volume rm acq-volbox-var-lib-docker"
 assert_not_contains "vol: terminate leaves other sandboxes' derived volumes" "$term_log" "volume rm acq-other-nix"
 assert_not_contains "vol: terminate leaves user volumes" "$term_log" "volume rm user-data"
+cleanup_stubs
+
+# 10a5e. Slug-collision hardening: the path slug is LOSSY (/data/app and
+#        /data.app both slug to data-app), so the derived name carries a CRC of
+#        the raw path — two colliding-slug volumes must get DISTINCT names.
+make_stubs; load_acq
+coll_flags=$(
+  . "${REPO_ROOT}/acq.backends/msb.sh" 2>/dev/null
+  arr=(); _acq_msb_volume_flags_from_records arr volbox <<EOF
+$(printf '/data/app\t\t1G\n/data.app\t\t1G')
+EOF
+  printf '%s\n' "${arr[@]}"
+)
+ck_a=$(printf '%s' "/data/app" | cksum | cut -d' ' -f1)
+ck_b=$(printf '%s' "/data.app" | cksum | cut -d' ' -f1)
+assert_contains "vol: colliding slug /data/app gets its own CRC name" "$coll_flags" "acq-volbox-data-app-${ck_a}:/data/app:"
+assert_contains "vol: colliding slug /data.app gets its own CRC name" "$coll_flags" "acq-volbox-data-app-${ck_b}:/data.app:"
+if [ "$ck_a" != "$ck_b" ]; then
+  pass "vol: CRC disambiguates lossy-slug collisions"
+else
+  fail "vol: CRC disambiguates lossy-slug collisions" "cksum collision for /data/app vs /data.app"
+fi
+cleanup_stubs
+
+# 10a5f. Union by path, LAST WINS (sbx's own composition rule): two kits
+#        declaring the same path must yield ONE --mount-named flag carrying the
+#        later size, not two conflicting flags that fail msb's create-or-reuse.
+make_stubs; load_acq
+union_flags=$(
+  . "${REPO_ROOT}/acq.backends/msb.sh" 2>/dev/null
+  arr=(); _acq_msb_volume_flags_from_records arr volbox <<EOF
+$(printf '/var/lib/docker\t\t20G\n/scratch\ttmpfs\t2G\n/var/lib/docker\t\t40G' | _acq_msb_volume_records_dedupe)
+EOF
+  printf '%s\n' "${arr[@]}"
+)
+assert_contains "vol: union keeps the LAST size for a repeated path" "$union_flags" "size=40G"
+assert_not_contains "vol: union drops the earlier size for a repeated path" "$union_flags" "size=20G"
+assert_contains "vol: union leaves distinct paths alone" "$union_flags" "/scratch:2G"
+_mn_count=$(printf '%s\n' "$union_flags" | grep -c -- "--mount-named")
+assert_eq "vol: exactly one --mount-named for the repeated path" "1" "$_mn_count"
+cleanup_stubs
+
+# 10a5g. Terminate volume-cleanup matrix on a FAILED `msb remove`: volumes are
+#        cleaned only when the sandbox is confirmed GONE (already removed out
+#        of band) — a failed remove of a still-existing sandbox must not touch
+#        volumes that may be in use, but the gone case must still clean up or
+#        the volumes orphan forever.
+make_stubs; load_acq
+# (a) remove fails AND the sandbox still exists -> volumes untouched.
+: > "$CALLS"
+printf 'acq-volbox-var-lib-docker\n' > "$STUBDIR/.msb_volume_list"
+printf 'volbox\n' > "$STUBDIR/.msb_sandbox_list"
+(
+  . "${REPO_ROOT}/acq.backends/msb.sh" 2>/dev/null
+  export STUB_MSB_RM_FAIL=1
+  acq_backend_terminate volbox
+) >/dev/null 2>&1
+term_fail_log=$(cat "$CALLS")
+assert_not_contains "vol: failed remove of an EXISTING sandbox keeps its volumes" "$term_fail_log" "volume rm"
+# (b) remove fails but the sandbox is GONE (removed out of band) -> clean up.
+: > "$CALLS"
+rm -f "$STUBDIR/.msb_sandbox_list"
+(
+  . "${REPO_ROOT}/acq.backends/msb.sh" 2>/dev/null
+  export STUB_MSB_RM_FAIL=1
+  acq_backend_terminate volbox
+) >/dev/null 2>&1
+term_gone_log=$(cat "$CALLS")
+assert_contains "vol: failed remove of a GONE sandbox still cleans its volumes" "$term_gone_log" "msb volume rm acq-volbox-var-lib-docker"
+cleanup_stubs
+
+# 10a5h. Mid-life `acq kit apply` cannot attach volumes (creation-time only) —
+#        the msb apply verb must SAY so instead of silently skipping them.
+make_stubs; load_acq
+avkit="$STUBDIR/avkit"; mkdir -p "$avkit"
+cat >"$avkit/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: apply-vol-kit
+displayName: Apply Vol Kit
+description: volumes on mid-life apply warn
+volumes:
+  - path: /late
+    size: 1G
+SPEC
+apply_out=$(
+  . "${REPO_ROOT}/acq.backends/msb.sh" 2>/dev/null
+  acq_backend_apply_kit volbox "$avkit" 2>&1
+)
+assert_contains "vol: mid-life apply warns volumes are creation-time only" "$apply_out" "CREATE time only"
 cleanup_stubs
 
 

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -374,6 +374,13 @@ case "$_msb_sub" in
   remove|rm) : ;;
   copy|cp) : ;;
   modify) : ;;
+  volume)
+    # ADR-0022 derived-volume cleanup: `msb volume ls -q` lists names from the
+    # fixture a test plants; `msb volume rm NAME` is logged (above) and no-ops.
+    if [ "${2:-}" = "ls" ]; then
+      [ -f "$STUBDIR/.msb_volume_list" ] && cat "$STUBDIR/.msb_volume_list"
+    fi
+    : ;;
   *) : ;;
 esac
 # Drain piped stdin ONLY for subcommands a real `msb` actually reads it on
@@ -5973,6 +5980,171 @@ assert_not_contains "bg(sbx): translator does NOT wrap in nohup" "$sbgspec" "noh
 assert_not_contains "bg(sbx): translator does NOT emit a double-background & &" "$sbgspec" "& &"
 _amp_count=$(printf '%s\n' "$sbgspec" | grep -cE '(^|[^&])&([^&]|$)')
 assert_eq "bg(sbx): exactly one backgrounding & survives translation" "1" "$_amp_count"
+cleanup_stubs
+
+# 10a4i. REGRESSION: an entry with guest + host but NO protocol/name must keep
+#        the host column in place. Tab is IFS whitespace, so the former
+#        `IFS=<tab> read` consumers COLLAPSED the empty middle fields of the
+#        "3000<TAB><TAB><TAB>8080" record: msb emitted `-p 3000:3000` (explicit
+#        host silently lost) and the sbx-v2 spec gained `protocol: 8080`. Both
+#        consumers now cut fields positionally.
+make_stubs; load_acq
+hokit="$STUBDIR/hokit"; mkdir -p "$hokit"
+cat >"$hokit/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: host-only-kit
+displayName: Host Only Kit
+description: guest plus host with no protocol or name
+publishedPorts:
+  - guest: 3000
+    host: 8080
+SPEC
+ho_flags=$(
+  . "${REPO_ROOT}/acq.backends/msb.sh" 2>/dev/null
+  arr=(); _acq_msb_port_flags_into arr "$hokit/spec.yaml"; printf '%s\n' "${arr[@]}"
+)
+assert_contains "pp: msb keeps explicit host with no protocol/name" "$ho_flags" "8080:3000"
+assert_not_contains "pp: msb does not collapse to guest:guest" "$ho_flags" "3000:3000"
+hoout="$STUBDIR/hoout"
+( . "${REPO_ROOT}/acq.backends/kit-translate.sh"; kit_translate_to_sbx "$hokit" "$hoout" >/dev/null ) 2>/dev/null
+hospec=$(cat "$hoout/spec.yaml" 2>/dev/null || true)
+assert_contains "pp: sbx-v2 emits container with no protocol/name" "$hospec" "- container: 3000"
+assert_not_contains "pp: sbx-v2 does not leak host column into protocol" "$hospec" "protocol: 8080"
+cleanup_stubs
+
+# ===========================================================================
+# 10a5. ADR-0022: neutral volumes vocabulary
+# ===========================================================================
+# Adds a neutral top-level `volumes:` list ({path, type?(""|tmpfs), size}),
+# consumed by BOTH backends: sbx-v2 passes entries through 1:1 (kit-spec v2
+# §5.7); msb maps a block entry to a derived named disk volume (--mount-named
+# acq-<sandbox>-<pathslug>:<path>:kind=disk,size=<size>, removed again on
+# terminate) and a tmpfs entry to `--tmpfs <path>:<size>`. Invalid entries are
+# dropped+warned and reported by kit validate; absence is a no-op.
+
+# 10a5a. Neutral volumes parse to path/type/size records; msb emits
+#        --mount-named (block, derived name) + --tmpfs flags; sbx-v2 emits the
+#        volumes block with the fields passed through 1:1.
+make_stubs; load_acq
+vkit="$STUBDIR/vkit"; mkdir -p "$vkit"
+cat >"$vkit/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: vol-kit
+displayName: Vol Kit
+description: neutral volumes
+volumes:
+  - path: /var/lib/docker
+    size: 20G
+  - path: /scratch
+    type: tmpfs
+    size: 2G
+SPEC
+v_parse=$( . "${REPO_ROOT}/acq.backends/kit-translate.sh"; kit_spec_volumes "$vkit/spec.yaml" 2>/dev/null )
+assert_contains "vol: neutral parse emits block record" "$v_parse" "$(printf '/var/lib/docker\t\t20G')"
+assert_contains "vol: neutral parse emits tmpfs record" "$v_parse" "$(printf '/scratch\ttmpfs\t2G')"
+v_flags=$(
+  . "${REPO_ROOT}/acq.backends/msb.sh" 2>/dev/null
+  arr=(); _acq_msb_volume_flags_into arr "$vkit/spec.yaml" volbox; printf '%s\n' "${arr[@]}"
+)
+assert_contains "vol: msb emits --mount-named flag token" "$v_flags" "--mount-named"
+assert_contains "vol: msb block entry derives per-sandbox disk volume" "$v_flags" "acq-volbox-var-lib-docker:/var/lib/docker:kind=disk,size=20G"
+assert_contains "vol: msb emits --tmpfs flag token" "$v_flags" "--tmpfs"
+assert_contains "vol: msb tmpfs entry emits path:size" "$v_flags" "/scratch:2G"
+vout="$STUBDIR/vout"
+( . "${REPO_ROOT}/acq.backends/kit-translate.sh"; kit_translate_to_sbx "$vkit" "$vout" >/dev/null ) 2>/dev/null
+vspec=$(cat "$vout/spec.yaml" 2>/dev/null || true)
+assert_contains "vol: sbx-v2 emits volumes block" "$vspec" "volumes:"
+assert_contains "vol: sbx-v2 passes block path through" "$vspec" "- path: /var/lib/docker"
+assert_contains "vol: sbx-v2 passes size through" "$vspec" "    size: 20G"
+assert_contains "vol: sbx-v2 passes tmpfs type through" "$vspec" "    type: tmpfs"
+cleanup_stubs
+
+# 10a5b. Validation (SI-10): a relative path, unsafe path, bad type, missing
+#        size, metacharacter size, and pathless entry are DROPPED with a stderr
+#        warning; the valid entry survives; `acq kit validate` REPORTS each
+#        (not silently dropped).
+make_stubs; load_acq
+badvkit="$STUBDIR/badvkit"; mkdir -p "$badvkit"
+cat >"$badvkit/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: bad-vol-kit
+displayName: Bad Vol Kit
+description: invalid volumes dropped and reported
+volumes:
+  - path: relative/path
+    size: 2G
+  - path: /has space
+    size: 2G
+  - path: /badtype
+    type: bind
+    size: 2G
+  - path: /nosize
+  - path: /badsize
+    size: 2G; rm -rf /
+  - size: 1G
+  - path: /ok
+    size: 512m
+SPEC
+badv_out=$( . "${REPO_ROOT}/acq.backends/kit-translate.sh"; kit_spec_volumes "$badvkit/spec.yaml" 2>/dev/null )
+badv_warn=$( . "${REPO_ROOT}/acq.backends/kit-translate.sh"; kit_spec_volumes "$badvkit/spec.yaml" 2>&1 >/dev/null )
+assert_contains "vol: valid entry survives validation" "$badv_out" "/ok"
+assert_not_contains "vol: relative path dropped" "$badv_out" "relative/path"
+assert_not_contains "vol: unsafe path dropped" "$badv_out" "/has space"
+assert_not_contains "vol: bad type entry dropped" "$badv_out" "/badtype"
+assert_not_contains "vol: missing-size entry dropped" "$badv_out" "/nosize"
+assert_not_contains "vol: metacharacter size dropped" "$badv_out" "rm -rf"
+assert_contains "vol: warns unsafe path" "$badv_warn" "unsafe path"
+assert_contains "vol: warns invalid type" "$badv_warn" "invalid type"
+assert_contains "vol: warns missing size" "$badv_warn" "missing size"
+assert_contains "vol: warns invalid size" "$badv_warn" "invalid size"
+assert_contains "vol: warns missing path" "$badv_warn" "missing path"
+val_vol=$( . "${REPO_ROOT}/acq.backends/kit-translate.sh"; kit_validate "$badvkit/spec.yaml" 2>&1 )
+assert_contains "vol: kit validate reports non-absolute path" "$val_vol" "volume path must be absolute"
+assert_contains "vol: kit validate reports illegal path characters" "$val_vol" "volume path has illegal characters"
+assert_contains "vol: kit validate reports bad type" "$val_vol" "volume type must be"
+assert_contains "vol: kit validate reports missing size" "$val_vol" "volume size is required"
+assert_contains "vol: kit validate reports invalid size" "$val_vol" "volume size must be a byte-size"
+assert_contains "vol: kit validate reports missing path" "$val_vol" "volume path is required"
+cleanup_stubs
+
+# 10a5c. Absence of volumes is a NO-OP (empty output, no error) — the neutral
+#        field is read DEFENSIVELY, like publishedPorts (ADR-0014 precedent).
+make_stubs; load_acq
+novkit="$STUBDIR/novkit"; mkdir -p "$novkit"
+cat >"$novkit/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: no-vol-kit
+displayName: No Vol Kit
+description: no volumes at all
+SPEC
+nov_out=$( . "${REPO_ROOT}/acq.backends/kit-translate.sh"; kit_spec_volumes "$novkit/spec.yaml" 2>&1 )
+assert_eq "vol: absence of volumes is a no-op" "" "$nov_out"
+nov_flags=$(
+  . "${REPO_ROOT}/acq.backends/msb.sh" 2>/dev/null
+  arr=(); _acq_msb_volume_flags_into arr "$novkit/spec.yaml" volbox 2>&1; printf '%s' "${arr[@]:-}"
+)
+assert_eq "vol: msb emits no volume flags when absent" "" "$nov_flags"
+cleanup_stubs
+
+# 10a5d. acq_backend_terminate removes the sandbox's DERIVED volumes
+#        (acq-<name>-*) after a successful `msb remove`, and leaves other
+#        sandboxes' derived volumes and user-created volumes alone.
+make_stubs; load_acq
+: > "$CALLS"
+printf 'acq-volbox-var-lib-docker\nacq-other-nix\nuser-data\n' > "$STUBDIR/.msb_volume_list"
+(
+  . "${REPO_ROOT}/acq.backends/msb.sh" 2>/dev/null
+  acq_backend_terminate volbox
+) >/dev/null 2>&1
+term_log=$(cat "$CALLS")
+assert_contains "vol: terminate still removes the sandbox" "$term_log" "msb remove --force volbox"
+assert_contains "vol: terminate removes the derived volume" "$term_log" "msb volume rm acq-volbox-var-lib-docker"
+assert_not_contains "vol: terminate leaves other sandboxes' derived volumes" "$term_log" "volume rm acq-other-nix"
+assert_not_contains "vol: terminate leaves user volumes" "$term_log" "volume rm user-data"
 cleanup_stubs
 
 

--- a/scripts/verify-backends
+++ b/scripts/verify-backends
@@ -199,6 +199,25 @@ export ACQ_PROVENANCE_DIR="$VERIFY_STATE/provenance"
 export ACQ_SECRET_NO_LIVE_REFEED=1
 mkdir -p "$XDG_CONFIG_HOME" "$ACQ_SECRET_STORE_DIR" "$ACQ_STATE_DIR" "$ACQ_PROVENANCE_DIR"
 
+# Fixture kit for the neutral `volumes:` vocabulary (ADR-0022): a tiny local kit
+# declaring a 256m block volume. Appended to ACQ_EXTRA_KITS so every create below
+# carries it; the volumes check inside verify_backend asserts the mount landed.
+# 256m, not smaller: msb refuses tiny ext4 disk images ("image size is too small
+# for ext4 formatting"; floor is 128M on msb 0.6.12), so stay well above it.
+VOLKIT_DIR="$VERIFY_STATE/verify-volumes-kit"
+mkdir -p "$VOLKIT_DIR"
+cat >"$VOLKIT_DIR/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: verify-volumes
+displayName: Verify Volumes
+description: verify-backends fixture exercising the neutral volumes vocabulary
+volumes:
+  - path: /acq-verify-vol
+    size: 256m
+SPEC
+export ACQ_EXTRA_KITS="${ACQ_EXTRA_KITS:+${ACQ_EXTRA_KITS} }${VOLKIT_DIR}"
+
 # Run an acq command, capturing combined stdout+stderr into LAST_OUT and
 # returning its exit status. The first arg is a short label for the step; in
 # verbose mode it and the exact command line are streamed live.
@@ -681,11 +700,49 @@ verify_backend() {
   # 5) OCI engine (podman) usable — msb only (ADR-0020).
   _verify_oci_checks "$backend" "$name"
 
+  # 6) Neutral kit volumes (ADR-0022): the verifier's fixture kit (appended to
+  #    ACQ_EXTRA_KITS at setup) declares a 256m block volume at /acq-verify-vol.
+  #    Assert the path is a MOUNTPOINT on a dedicated /dev block device of
+  #    roughly the declared size — df is used (not findmnt) because it is
+  #    present in every base image; the size window is wide because ext4
+  #    metadata + reserved blocks shrink the visible total.
+  local vol_line vol_dev vol_kb vol_mp vol_dev_ok
+  if run_acq "exec volume-df" --backend "$backend" exec "$name" -- sh -c \
+      "df -Pk /acq-verify-vol | sed -n 2p"; then
+    vol_line=$(printf '%s\n' "$LAST_OUT" | grep '/acq-verify-vol' | tail -1)
+    vol_dev=$(printf '%s' "$vol_line" | awk '{print $1}')
+    vol_kb=$(printf '%s' "$vol_line" | awk '{print $2}')
+    vol_mp=$(printf '%s' "$vol_line" | awk '{print $6}')
+    vol_dev_ok=0
+    case "$vol_dev" in /dev/*) vol_dev_ok=1 ;; esac
+    if [ "$vol_mp" = "/acq-verify-vol" ] && [ "$vol_dev_ok" = 1 ] && \
+       [ -n "$vol_kb" ] && [ "$vol_kb" -ge 180000 ] 2>/dev/null && [ "$vol_kb" -le 270000 ] 2>/dev/null; then
+      pass "${backend}: kit volumes: 256m block volume mounted at /acq-verify-vol (${vol_dev}, ${vol_kb} kB)"
+    else
+      fail "${backend}: kit volumes: /acq-verify-vol is not a dedicated ~256m block mountpoint" \
+           "dev='${vol_dev}' kb='${vol_kb}' mountpoint='${vol_mp}'"
+      dump "df output" "$LAST_OUT"
+    fi
+  else
+    fail "${backend}: kit volumes: df probe failed for /acq-verify-vol (volume not mounted?)"
+    dump "exec output" "$LAST_OUT"
+  fi
+
   # Clean up the throwaway sandbox.
   if [ -n "$KEEP" ] && [ "$FAIL" -gt 0 ]; then
     printf '        (keeping sandbox %s; --keep set)\n' "$name"
   else
     run_acq "rm" --backend "$backend" rm "$name" >/dev/null 2>&1 || true
+    # ADR-0022: on msb the derived kit volumes (acq-<name>-*) must not outlive
+    # the sandbox — acq_backend_terminate removes them by prefix after a
+    # successful `msb remove`.
+    if [ "$backend" = "msb" ]; then
+      if msb volume ls -q 2>/dev/null | grep -q "^acq-${name}-"; then
+        fail "${backend}: kit volumes: derived volumes not removed on rm (acq-${name}-*)"
+      else
+        pass "${backend}: kit volumes: derived volumes removed on rm"
+      fi
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

Adds the neutral `volumes:` vocabulary proposed in #329 to the hybrid/v1 kit schema's executable side: a top-level list of `{path, type?("" | tmpfs), size}` entries, parsed and validated once in `kit-translate.sh` and consumed by both backends ([ADR-0022](docs/adr/0022-neutral-volumes-kit-vocabulary.md)):

- **sbx** — entries pass through 1:1 into the synthesized kit-spec v2 §5.7 `volumes` block (dedicated block device, mounted at create).
- **msb** — a block entry becomes a per-sandbox derived named disk volume (`--mount-named acq-<sandbox>-<pathslug>:<path>:kind=disk,size=<size>`), a tmpfs entry becomes `--tmpfs <path>:<size>`; derived volumes are removed in `acq_backend_terminate` so they cannot accumulate under `~/.microsandbox`.

Volumes mount at boot, before any exec is possible, which eliminates the startup-storage race class that motivated #329 (the `/nix` relocation workaround). Validation is SI-10 fail-closed: unsafe path / bad type / missing-or-invalid size entries are dropped with a warning and reported by `acq kit validate`.

Also fixes a latent bug in the shared ports path: tab-separated records were consumed with `IFS=<tab> read`, which collapses adjacent empty fields — a `publishedPorts` entry with `guest`+`host` but no `protocol`/`name` emitted `protocol: <host>` into the sbx spec and dropped the explicit host on msb (`-p guest:guest`). Both consumers now cut fields positionally (regression-tested).

## Related Issues

Fixes #329. Sister PR: GSA-TTS/agentic-coding-patterns#353 adds the matching `volumes` property to the authoritative hybrid/v1 schema (`kit-hybrid-v1.schema.json` + `validate-kits.py`), with the same path/size rules so the two gates stay identical. Merge order is free: the neutral field is read defensively here — absence is a no-op — per the ADR-0014 gating discipline, so this merges safely ahead of the schema; the field lights up for pinned kits once patterns#353 ships in a tagged release and `PATTERNS_KIT_REF` advances past it.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (the ports record mis-parse)
- [x] Documentation update (ADR-0022, BACKEND_GUIDE)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits format](../CONTRIBUTING.md#commit-message-guidelines) (e.g., `feat:`, `fix:`, `docs:`)
- [x] I have tested my changes locally
- [x] I have updated documentation as needed
- [x] I have not included any secrets, API keys, or sensitive information

## Test Results

Live end-to-end (`scripts/verify-backends`, macOS host — full transcripts in the commit message):

- **msb 0.6.12 (HVF), `--only msb`: 17/17** — incl. `256m block volume mounted at /acq-verify-vol (/dev/vdc, 190432 kB)` and `derived volumes removed on rm`.
- **sbx 0.39.0, `--only sbx`: 9/9** — incl. `256m block volume mounted at /acq-verify-vol (/dev/vde, 235431 kB)`. Note this is one release past the 0.38 the issue verified against.

Offline: `scripts/test-acq` 1019 passed / 3 failed — the same 3 failures reproduce on `main` (pre-existing, unrelated); this PR adds 37 passing assertions. `bash -n` (bash 5 + macOS 3.2), `shellcheck --severity=warning`, and pinned markdownlint all clean.

Live finding folded in: msb refuses ext4 disk images under 128M, so the verify fixture declares 256m and kit guidance documents a ~256m floor.

## Additional Notes

Review points (design stances adopted, flagged rather than relitigated):

1. **`mode` is excluded** from the neutral schema — msb has no equivalent; kits chmod in a startup step. Backend-uniform vocabulary over exposing every sbx knob.
2. **msb volume lifecycle** (the one open question from #329): deterministic derived names + prefix-matched cleanup on rm. Caveat documented in ADR-0022: a sandbox name that prefixes another sandbox's name + `-` could match the longer name's volumes at cleanup; exact matching would require re-fetching kit specs at terminate.
3. **ADR-0022 frontmatter** says `status: accepted` — set optimistically in the ADR-0014 mold; happy to adjust.
4. `size` is **required** in the neutral schema (sbx's unsized default moved 50G → 512M between 0.39 rcs; we don't inherit that instability).

