### PR TITLE
feat(acq): add backend-agnostic --image/ACQ_IMAGE base image override

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,7 @@ Focused live checks for specific fixes (also require a sandbox-capable host):
 ./scripts/verify-issue-320          # sbx 0.38 re-attach heal loop (#320)
 ./scripts/verify-ports-live         # msb post-hoc port publish (ADR-0015)
 ./scripts/verify-net-default-egress # msb create-time published port (ADR-0019)
+./scripts/verify-image-override     # backend-neutral --image/ACQ_IMAGE (ADR-0022)
 ```
 
 ### Quick pre-push check

--- a/acq
+++ b/acq
@@ -78,7 +78,9 @@ Subcommands:
                                            an existing one, and launch AGENT
                                            (e.g. opencode) or a shell.
                                            (--no-update-check skips the stale-
-                                           bundle check for this run.)
+                                           bundle check for this run;
+                                           --image REF sets a custom base image,
+                                           see ACQ_IMAGE below.)
   create AGENT PATH [...]                  Create a sandbox (detached).
   ls                                       List sandboxes.
   stop NAME                                Stop a sandbox (without removing).
@@ -122,11 +124,21 @@ Global flags (before the subcommand):
                        Default: the persisted backend (`acq backend set`),
                        else msb. `msb` runs microVMs via the microsandbox (msb)
                        CLI; `sbx` runs Docker sandboxes via the sbx CLI.
+  --image REF          Custom base image (ADR-0022). Also accepted after the
+                       run/create subcommand (see below). Backend-agnostic: on
+                       msb it sets the OCI image (like ACQ_MSB_IMAGE); on sbx it
+                       maps to `sbx create --template REF`. Equivalent env var:
+                       ACQ_IMAGE. Precedence: --image > ACQ_IMAGE > backend
+                       var/default (a set ACQ_MSB_IMAGE wins, with a notice). The
+                       image must satisfy the base-image contract in
+                       docs/BACKEND_GUIDE.md.
 
-run/create flag:
+run/create flags:
   --kit REF            Apply an extra kit (repeatable). REF is a local dir or a
                        git+https ref (like an ACQ_EXTRA_KITS entry); acq
                        translates it to the backend — it is NOT forwarded raw.
+  --image REF          Same as the global --image above; accepted here too so
+                       `acq create AGENT --image REF PATH` works.
 
 See docs/QUICKSTART.md and docs/BACKEND_GUIDE.md for more.
 HELP
@@ -257,7 +269,17 @@ _acq_backend_passthrough() {
 if [ -n "${ACQ_SOURCE_ONLY:-}" ]; then return 0 2>/dev/null || exit 0; fi
 
 # ---------------------------------------------------------------------------
-# Pre-parse global --backend flag (must appear before the subcommand).
+# Pre-parse global flags that may appear BEFORE the subcommand.
+#   --backend sbx|msb   pick the backend for this invocation
+#   --image REF         neutral base image (ADR-0022). Accepted here as a
+#                       convenience so `acq --backend msb --image REF create …`
+#                       works, mirroring --backend's global position. It is ALSO
+#                       accepted after the subcommand (`acq create … --image REF`)
+#                       by the run|create arm below; either position sets
+#                       ACQ_IMAGE. `--image` must never reach the backend CLI
+#                       (neither `sbx`/`msb` accepts it), so we strip it here too.
+# Only --backend/--image are consumed as pre-subcommand globals; the loop stops
+# at the first other token (the subcommand).
 # ---------------------------------------------------------------------------
 explicit_backend=""
 while [ "$#" -gt 0 ]; do
@@ -269,6 +291,19 @@ while [ "$#" -gt 0 ]; do
     --backend)
       shift
       explicit_backend="${1:-}"
+      shift
+      ;;
+    --image=*)
+      export ACQ_IMAGE="${1#--image=}"
+      shift
+      ;;
+    --image)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "acq: --image given with no value" >&2
+        exit 2
+      fi
+      export ACQ_IMAGE="$1"
       shift
       ;;
     *)
@@ -598,6 +633,17 @@ case "$subcommand" in
       esac
     done
     set -- ${_acq_run_args[@]+"${_acq_run_args[@]}"}
+    # Extract acq-owned `--image <ref>` (ADR-0022) BEFORE kit extraction and
+    # dispatch, so it never reaches the backend CLI (neither `sbx create` nor
+    # `msb create` accepts a bare `--image`). It selects the neutral base image;
+    # the backend adapters read it via acq_resolve_neutral_image. Exporting
+    # ACQ_IMAGE lets the flag take the same code path as the env var and honors
+    # the ADR-0022 precedence (flag > env). Only honored BEFORE `--`.
+    extract_image_flag "$@"
+    if [ -n "${ACQ_IMAGE_FLAG:-}" ]; then
+      export ACQ_IMAGE="$ACQ_IMAGE_FLAG"
+    fi
+    set -- ${ACQ_IMAGE_REMAINING[@]+"${ACQ_IMAGE_REMAINING[@]}"}
     extract_kit_flags "$@"
     [ "${#ACQ_CLI_KITS[@]}" -gt 0 ] && _build_kit_list   # re-fold with CLI kits
     # Rebuild positional args as: <subcommand> <remaining args w/o --kit>.
@@ -686,6 +732,15 @@ case "$subcommand" in
       fi
 
       if acq_backend_exists "$local_name"; then
+        # A neutral --image / ACQ_IMAGE only takes effect at CREATE (ADR-0022);
+        # a re-attach to an existing sandbox does not re-image it. Say so once,
+        # rather than silently ignoring the flag, so the user isn't misled into
+        # thinking the running sandbox was rebuilt on the requested image.
+        if [ -n "${ACQ_IMAGE:-}" ]; then
+          echo "acq: note: --image/ACQ_IMAGE is ignored when re-attaching an existing" \
+               "sandbox ('$local_name'); it applies only at create (ADR-0022). Remove the" \
+               "sandbox first ('acq $ACQ_RESOLVED_BACKEND rm $local_name') to recreate on a new image." >&2
+        fi
         # Capture staleness BEFORE the heal — ensure_kits_applied rewrites the
         # provenance record to "current", so reading status after it would never
         # see stale/unknown and the offer below would be dead.

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -909,6 +909,60 @@ acq_resolve_neutral_image() {
   return 0
 }
 
+# _acq_image_registry_host IMAGE — echo the registry host of an OCI image
+# reference, or nothing if the reference has no explicit registry (Docker Hub
+# short names like `ubuntu` or `library/ubuntu` carry no host). A leading path
+# component is a registry only when it looks like a host: it contains a `.` or a
+# `:` (port), or is exactly `localhost`. This mirrors the Docker/containers
+# reference grammar closely enough to decide whether pull creds are plausibly
+# needed. Used to make registry-auth hints precise instead of hardcoding a few
+# known hosts.
+_acq_image_registry_host() {
+  local ref="${1:-}"
+  [ -n "$ref" ] || return 0
+  local first="${ref%%/*}"
+  # No slash at all -> a bare Docker Hub name (e.g. `ubuntu`, `ubuntu:22.04`).
+  [ "$first" = "$ref" ] && return 0
+  case "$first" in
+    localhost|localhost:*) printf '%s\n' "$first" ;;
+    *.*|*:*)               printf '%s\n' "$first" ;;   # has a dot or a :port
+    *)                     return 0 ;;                 # `library/…` etc. -> Docker Hub
+  esac
+}
+
+# acq_registry_auth_hint BACKEND IMAGE — print, to stderr, a targeted hint for a
+# failed image pull, telling the user how to store registry credentials (or
+# import a local image) for the SPECIFIC registry the image came from. Backend
+# argument selects the correct command surface (msb vs sbx). Emits nothing for a
+# Docker Hub short name (host unknown) beyond the generic path, so callers should
+# still print the raw backend error alongside. Registry-agnostic: works for any
+# private host, not just a hardcoded few.
+acq_registry_auth_hint() {
+  local backend="$1" image="${2:-}"
+  local host
+  host=$(_acq_image_registry_host "$image")
+  case "$backend" in
+    msb)
+      if [ -n "$host" ] && [ "${host%%:*}" != "localhost" ]; then
+        echo "acq(msb):   hint: if the pull was denied, store credentials for this registry:" >&2
+        echo "acq(msb):           msb registry login ${host} -u <user> --password-stdin" >&2
+      fi
+      echo "acq(msb):   hint: for a locally-built image (no registry), import it first and skip the pull:" >&2
+      echo "acq(msb):           <docker|podman> save ${image:-<image>} -o /tmp/img.tar" >&2
+      echo "acq(msb):           msb image load -i /tmp/img.tar -t ${image:-<image>}" >&2
+      echo "acq(msb):           ACQ_MSB_PULL=never ./acq --backend msb --image ${image:-<image>} create <agent> <path>" >&2
+      ;;
+    sbx)
+      if [ -n "$host" ] && [ "${host%%:*}" != "localhost" ]; then
+        echo "acq(sbx):   hint: if the pull was denied, store credentials for this registry:" >&2
+        echo "acq(sbx):           sbx secret set --registry ${host} -u <user>" >&2
+      fi
+      echo "acq(sbx):   hint: for a locally-built image (no registry), import it first:" >&2
+      echo "acq(sbx):           <docker|podman> save ${image:-<image>} -o /tmp/img.tar && sbx template load /tmp/img.tar" >&2
+      ;;
+  esac
+}
+
 # ============================================================================
 # Backend resolution
 # ============================================================================

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -527,7 +527,7 @@ slugify() {
 # True if PREV is a flag that consumes the next argument as its value.
 _takes_value() {
   case "$1" in
-    --name|--template|-t|--profile|--cpus|--memory|-m|--kit|--backend) return 0 ;;
+    --name|--template|-t|--profile|--cpus|--memory|-m|--kit|--backend|--image) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -848,6 +848,65 @@ extract_kit_flags() {
   if [ "$expect_kit" -eq 1 ]; then
     echo "acq: --kit given with no value; ignoring" >&2
   fi
+}
+
+# Extract a user-supplied `--image <ref>` / `--image=<ref>` flag from a run/create
+# arg list (ADR-0022). Populates two things IN THE CURRENT SHELL (so callers must
+# not run this in a subshell/pipeline):
+#   ACQ_IMAGE_FLAG        — the image ref if `--image` was given (else empty)
+#   ACQ_IMAGE_REMAINING   — the arg list with the --image flag removed
+#
+# Like extract_kit_flags, scanning STOPS at the first `--` separator: everything
+# after it is agent args and is forwarded verbatim. `--image` is an acq-owned
+# neutral flag (ADR-0022); it must NOT reach the backend CLI (neither `sbx create`
+# nor `msb create` accepts a bare `--image`). The resolved value is exported as
+# ACQ_IMAGE so the backend adapters read it through acq_resolve_neutral_image.
+#
+# A last-wins policy applies if `--image` is repeated (matches how most CLIs treat
+# a repeated scalar flag).
+extract_image_flag() {
+  ACQ_IMAGE_FLAG=""
+  ACQ_IMAGE_REMAINING=()
+  local expect_image=0 arg
+  while [ "$#" -gt 0 ]; do
+    arg="$1"
+    if [ "$expect_image" -eq 1 ]; then
+      ACQ_IMAGE_FLAG="$arg"
+      expect_image=0
+      shift
+      continue
+    fi
+    case "$arg" in
+      --)        ACQ_IMAGE_REMAINING+=("$@"); break ;;
+      --image)   expect_image=1 ;;
+      --image=*) ACQ_IMAGE_FLAG="${arg#--image=}" ;;
+      *)         ACQ_IMAGE_REMAINING+=("$arg") ;;
+    esac
+    shift
+  done
+  # A trailing `--image` with no value: warn but don't crash.
+  if [ "$expect_image" -eq 1 ]; then
+    echo "acq: --image given with no value; ignoring" >&2
+  fi
+}
+
+# Resolve the effective NEUTRAL base image per ADR-0022 precedence:
+#   --image flag  >  ACQ_IMAGE env  >  (empty)
+# The `--image` flag value is captured by extract_image_flag into ACQ_IMAGE_FLAG.
+# Backend-specific vars (e.g. ACQ_MSB_IMAGE) are NOT consulted here — a backend
+# adapter decides whether its own var out-ranks this neutral value (ADR-0022 says
+# the most-specific backend var wins, with a one-time notice). Echoes the neutral
+# image (or nothing if none was requested).
+acq_resolve_neutral_image() {
+  if [ -n "${ACQ_IMAGE_FLAG:-}" ]; then
+    printf '%s\n' "$ACQ_IMAGE_FLAG"
+    return 0
+  fi
+  if [ -n "${ACQ_IMAGE:-}" ]; then
+    printf '%s\n' "$ACQ_IMAGE"
+    return 0
+  fi
+  return 0
 }
 
 # ============================================================================

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -89,7 +89,45 @@ MIN_MSB_VERSION="0.6.9"
 # install. Override with ACQ_MSB_IMAGE to bring your own (e.g. a lighter or
 # org-internal image, or a plain OCI base) — a custom image must still provide
 # the prerequisites; see the prerequisite contract below.
-ACQ_MSB_IMAGE="${ACQ_MSB_IMAGE:-docker.io/docker/sandbox-templates:shell-docker}"
+#
+# ADR-0022 (neutral --image / ACQ_IMAGE): the backend-agnostic image knob resolves
+# to this variable when ACQ_MSB_IMAGE is not itself set. Precedence: an explicitly
+# set ACQ_MSB_IMAGE (the most-specific, backend-scoped var) WINS over the neutral
+# ACQ_IMAGE, with a one-time notice, so a user who deliberately set the msb var is
+# never silently overridden. The resolution runs at provision time (not here at
+# source time) via _acq_msb_resolve_image, because the neutral value may be set by
+# the `--image` flag after this file is sourced.
+ACQ_MSB_IMAGE="${ACQ_MSB_IMAGE:-}"
+_ACQ_MSB_DEFAULT_IMAGE="docker.io/docker/sandbox-templates:shell-docker"
+_ACQ_MSB_IMAGE_NOTICE_SHOWN=0
+
+# _acq_msb_resolve_image — echo the OCI image `msb create` should use, applying
+# the ADR-0022 precedence: explicit ACQ_MSB_IMAGE > neutral --image/ACQ_IMAGE >
+# built-in default. Prints a one-time notice if BOTH the backend var and the
+# neutral image are set (backend var wins). Idempotent notice (once per process).
+_acq_msb_resolve_image() {
+  local neutral=""
+  if command -v acq_resolve_neutral_image >/dev/null 2>&1; then
+    neutral=$(acq_resolve_neutral_image)
+  fi
+  if [ -n "${ACQ_MSB_IMAGE:-}" ]; then
+    if [ -n "$neutral" ] && [ "$neutral" != "$ACQ_MSB_IMAGE" ] \
+       && [ "${_ACQ_MSB_IMAGE_NOTICE_SHOWN:-0}" != "1" ]; then
+      _ACQ_MSB_IMAGE_NOTICE_SHOWN=1
+      echo "acq(msb): both ACQ_MSB_IMAGE and a neutral image (--image/ACQ_IMAGE) are set;" >&2
+      echo "acq(msb):   using the backend-specific ACQ_MSB_IMAGE='$ACQ_MSB_IMAGE'" >&2
+      echo "acq(msb):   (most-specific wins; see ADR-0022). Unset ACQ_MSB_IMAGE to use the" >&2
+      echo "acq(msb):   neutral image '$neutral'." >&2
+    fi
+    printf '%s\n' "$ACQ_MSB_IMAGE"
+    return 0
+  fi
+  if [ -n "$neutral" ]; then
+    printf '%s\n' "$neutral"
+    return 0
+  fi
+  printf '%s\n' "$_ACQ_MSB_DEFAULT_IMAGE"
+}
 
 # Prerequisite tools the pinned four kits need at runtime, expected to be
 # PRESENT IN THE BASE IMAGE (the default sandbox-templates:shell-docker provides
@@ -2071,6 +2109,30 @@ acq_backend_provision() {
   local trust_host_cas=0
   local kitdirs=()
 
+  # Resolve the OCI image ONCE per provision (ADR-0022): explicit ACQ_MSB_IMAGE
+  # wins over the neutral --image/ACQ_IMAGE, which wins over the built-in default.
+  # Use this local everywhere below instead of $ACQ_MSB_IMAGE so the neutral knob
+  # and the one-time precedence notice are honored consistently.
+  local _msb_image
+  _msb_image=$(_acq_msb_resolve_image)
+
+  # Optional pull policy (ACQ_MSB_PULL): forwarded to `msb create --pull`.
+  # `msb create` reads an image REF and by default pulls if-missing from a
+  # registry — it does NOT read a locally-built image unless that image has been
+  # imported into msb's cache with `msb image load` first. When a caller has
+  # pre-loaded a local image (e.g. a locally-built tag like `localhost/…` that
+  # has no registry behind it), they set ACQ_MSB_PULL=never so msb uses the cache
+  # instead of attempting to pull the un-pullable ref. Accepted values match
+  # msb's own: always | if-missing | never. An unset var keeps msb's default.
+  case "${ACQ_MSB_PULL:-}" in
+    "") : ;;  # unset — leave msb's default (if-missing)
+    always|if-missing|never) create_flags+=(--pull "$ACQ_MSB_PULL") ;;
+    *)
+      echo "acq(msb): ignoring invalid ACQ_MSB_PULL='$ACQ_MSB_PULL'" \
+           "(expected: always | if-missing | never)" >&2
+      ;;
+  esac
+
   # Create-time startup-script staging (ADR-0017, increment 1). Reset the
   # per-provision guard + staged-file list so a prior provision in the same
   # process does not leak into this one; the files are cleaned up after create.
@@ -2416,11 +2478,11 @@ EOF
   # `|| _create_rc=$?` — a bare `msb create; local rc=$?` would abort the
   # function on failure BEFORE the error block and the transient-secret scrub
   # below ever run.
-  acq_debug "msb create --name $name ${create_flags[*]} $ACQ_MSB_IMAGE"
+  acq_debug "msb create --name $name ${create_flags[*]} $_msb_image"
   local _create_rc=0
   acq_debug "msb create: invoking (this returns fast; guest boots in background)"
   acq_spin_start "Creating sandbox '$name'"
-  msb create --name "$name" "${create_flags[@]}" "$ACQ_MSB_IMAGE" || _create_rc=$?
+  msb create --name "$name" "${create_flags[@]}" "$_msb_image" || _create_rc=$?
   acq_spin_stop "Creating sandbox '$name'"
   acq_debug "msb create: returned rc=${_create_rc}"
   # Clear the transient secret env vars immediately after create reads them
@@ -2443,11 +2505,13 @@ EOF
   if [ "$_create_rc" -ne 0 ]; then
     echo "acq(msb): error: 'msb create' failed for '$name'." >&2
     echo "acq(msb):   flags: ${create_flags[*]}" >&2
-    echo "acq(msb):   image: $ACQ_MSB_IMAGE" >&2
-    case "$ACQ_MSB_IMAGE" in
+    echo "acq(msb):   image: $_msb_image" >&2
+    case "$_msb_image" in
       ghcr.io/*|*.azurecr.io/*|*private*)
-        echo "acq(msb):   hint: the image may require registry auth. Set ACQ_MSB_IMAGE to a" >&2
-        echo "acq(msb):         pullable image (default: docker.io/docker/sandbox-templates:shell-docker)." >&2
+        echo "acq(msb):   hint: the image may require registry auth, or (for a locally-built" >&2
+        echo "acq(msb):         image) be imported first with 'msb image load' and created with" >&2
+        echo "acq(msb):         ACQ_MSB_PULL=never. Set the image via --image / ACQ_IMAGE (neutral)" >&2
+        echo "acq(msb):         or ACQ_MSB_IMAGE (default: docker.io/docker/sandbox-templates:shell-docker)." >&2
         ;;
     esac
     echo "acq(msb):   (re-run with ACQ_DEBUG=1 for the full command trace)" >&2

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -2506,14 +2506,12 @@ EOF
     echo "acq(msb): error: 'msb create' failed for '$name'." >&2
     echo "acq(msb):   flags: ${create_flags[*]}" >&2
     echo "acq(msb):   image: $_msb_image" >&2
-    case "$_msb_image" in
-      ghcr.io/*|*.azurecr.io/*|*private*)
-        echo "acq(msb):   hint: the image may require registry auth, or (for a locally-built" >&2
-        echo "acq(msb):         image) be imported first with 'msb image load' and created with" >&2
-        echo "acq(msb):         ACQ_MSB_PULL=never. Set the image via --image / ACQ_IMAGE (neutral)" >&2
-        echo "acq(msb):         or ACQ_MSB_IMAGE (default: docker.io/docker/sandbox-templates:shell-docker)." >&2
-        ;;
-    esac
+    # Targeted registry-auth / local-import hint for the SPECIFIC image host
+    # (registry-agnostic — not limited to a few hardcoded hosts). The raw msb
+    # stderr above is printed by msb itself; this adds the acq remediation.
+    if command -v acq_registry_auth_hint >/dev/null 2>&1; then
+      acq_registry_auth_hint msb "$_msb_image"
+    fi
     echo "acq(msb):   (re-run with ACQ_DEBUG=1 for the full command trace)" >&2
     return 1
   fi

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -422,6 +422,13 @@ acq_backend_provision() {
     # Persist the CLI (`--kit`) / extra kit refs alongside provenance so a later
     # resume heal can reload them (see acq_cli_kits_write). Best-effort.
     acq_cli_kits_write sbx "$name" || true
+  elif [ -n "$_neutral_image" ] && command -v acq_registry_auth_hint >/dev/null 2>&1; then
+    # A custom --image/--template create failed. sbx already printed its raw
+    # error (e.g. "unauthorized"); add the acq remediation for THIS image's
+    # registry (store creds) or a locally-built image (import first), so the
+    # user is not left with only the backend's bare denial. ADR-0022.
+    echo "acq(sbx): 'sbx create' failed for '$name' with custom image '$_neutral_image'." >&2
+    acq_registry_auth_hint sbx "$_neutral_image"
   fi
   return "$_rc"
 }

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -59,6 +59,10 @@ KNOWN_AGENTS=" claude codex copilot cursor docker-agent droid gemini kiro openco
 # printed, so it appears at most once per process. See ADR-0021.
 _ACQ_SBX_SSH_AGENT_NOTICE_SHOWN=0
 
+# Module-scope flag: set to 1 once the ADR-0022 custom-image (--template) notice
+# has been printed, so it appears at most once per process.
+_ACQ_SBX_IMAGE_NOTICE_SHOWN=0
+
 # ---------------------------------------------------------------------------
 # Version comparison
 # ---------------------------------------------------------------------------
@@ -347,26 +351,66 @@ acq_backend_provision() {
          "is set. Guest code can use every key the agent holds while the sandbox runs;" \
          "unset SSH_AUTH_SOCK to opt out, or run 'ssh-add -c' to confirm each use. See ADR-0021." >&2
   fi
-  # Strip any user-supplied --name since we pass it explicitly.
-  local _stripped=(); local skip=0
+  # Strip any user-supplied --name (and its value) since we pass --name
+  # explicitly. While scanning, note whether the user passed their own
+  # --template/-t: if so, we must NOT inject a neutral --image (ADR-0022) on top
+  # of it (the explicit flag wins and double --template would be ambiguous).
+  #
+  # NOTE the `skip` branch must `continue` WITHOUT re-adding the arg: it is the
+  # value of a dropped `--name`, so appending it would leave a stray positional
+  # (e.g. `shell <name> <ws>` — sbx then reads <name> as the workspace and the
+  # real workspace as an extra mount, so the intended workspace looks "missing"
+  # and acq prompts to create it; the piped decline then cancels the create).
+  local _stripped=(); local skip=0; local _user_template=0
   for arg in "$@"; do
     if [ "$skip" -eq 1 ]; then skip=0; continue; fi
     case "$arg" in
       --name) skip=1; continue ;;
       --name=*) continue ;;
+      --template|-t) _user_template=1 ;;
+      --template=*|-t=*) _user_template=1 ;;
     esac
     _stripped+=("$arg")
   done
 
+  # Neutral base image (ADR-0022): map --image/ACQ_IMAGE to `sbx create --template
+  # <ref>`. sbx's --template accepts any OCI image ref that satisfies the published
+  # base-image contract (see docs/BACKEND_GUIDE.md). Only inject when the user did
+  # NOT already pass their own --template/-t. Surface the one-time caveats sbx
+  # cannot handle for the user: the agent token must match the image's agent
+  # variant; a private/non-Docker-Hub image needs `sbx secret set --registry`; a
+  # locally-built image needs `sbx template load` first.
+  local _tf=()
+  local _neutral_image=""
+  if command -v acq_resolve_neutral_image >/dev/null 2>&1; then
+    _neutral_image=$(acq_resolve_neutral_image)
+  fi
+  if [ -n "$_neutral_image" ]; then
+    if [ "$_user_template" -eq 1 ]; then
+      echo "acq(sbx): both --image ('$_neutral_image') and an explicit --template were given;" >&2
+      echo "acq(sbx):   honoring your --template and ignoring --image (ADR-0022)." >&2
+    else
+      _tf=(--template "$_neutral_image")
+      if [ "${_ACQ_SBX_IMAGE_NOTICE_SHOWN:-0}" != "1" ]; then
+        _ACQ_SBX_IMAGE_NOTICE_SHOWN=1
+        echo "acq(sbx): using custom base image via 'sbx create --template $_neutral_image' (ADR-0022)." >&2
+        echo "acq(sbx):   Ensure the AGENT matches the image's agent variant, the image meets the" >&2
+        echo "acq(sbx):   base-image contract (docs/BACKEND_GUIDE.md), and — for a private/non-Docker-Hub" >&2
+        echo "acq(sbx):   image — that pull creds are stored ('sbx secret set --registry <host>'), or a" >&2
+        echo "acq(sbx):   locally-built image is imported first ('sbx template load <tar>')." >&2
+      fi
+    fi
+  fi
+
   local kf=()
   while IFS= read -r line; do kf+=("$line"); done < <(_acq_sbx_kit_flags)
 
-  acq_debug "sbx create --name $name ${kf[*]} ${_stripped[*]:-}"
+  acq_debug "sbx create --name $name ${_tf[*]:-} ${kf[*]} ${_stripped[*]:-}"
   acq_spin_start "Creating sandbox '$name'"
   if [ "${#_stripped[@]}" -gt 0 ]; then
-    sbx create --name "$name" "${kf[@]}" "${_stripped[@]}"
+    sbx create --name "$name" ${_tf[@]+"${_tf[@]}"} "${kf[@]}" "${_stripped[@]}"
   else
-    sbx create --name "$name" "${kf[@]}"
+    sbx create --name "$name" ${_tf[@]+"${_tf[@]}"} "${kf[@]}"
   fi
   local _rc=$?
   acq_spin_stop "Creating sandbox '$name'"

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -175,7 +175,9 @@ Tunables:
 
 | Env var | Default | Meaning |
 |---------|---------|---------|
-| `ACQ_MSB_IMAGE` | `docker.io/docker/sandbox-templates:shell-docker` | Base OCI image (the sbx agent-template: ships the `agent` user + passwordless sudo, node/git/curl/ca-certificates, and an agent-writable npm global prefix). A custom override must be pullable and ship these prerequisites. |
+| `ACQ_MSB_IMAGE` | `docker.io/docker/sandbox-templates:shell-docker` | Base OCI image (the sbx agent-template: ships the `agent` user + passwordless sudo, node/git/curl/ca-certificates, and an agent-writable npm global prefix). A custom override must be pullable and ship these prerequisites. **Precedence (ADR-0022):** an explicitly set `ACQ_MSB_IMAGE` wins over the backend-neutral `--image`/`ACQ_IMAGE` (a one-time notice is printed); if only the neutral knob is set, it is used; otherwise this default. |
+| `ACQ_IMAGE` | (unset) | Backend-**neutral** base image (ADR-0022). On msb it feeds `ACQ_MSB_IMAGE` (above); on sbx it maps to `sbx create --template <ref>`. Equivalent to the `acq run/create --image <ref>` flag (the flag wins over the env var). See [Custom base image](#custom-base-image---image--acq_image). |
+| `ACQ_MSB_PULL` | (unset → msb default `if-missing`) | Image pull policy forwarded to `msb create --pull` (`always` \| `if-missing` \| `never`). `msb create` treats the image as a **registry** reference; a locally-built/registry-less image must first be imported with `msb image load -i <tar> -t <ref>`, then created with `ACQ_MSB_PULL=never` so msb uses the cache instead of trying to pull it. |
 | `ACQ_MSB_SKIP_PREREQ_CHECK` | (unset) | Skip the base-image prerequisite presence check |
 | `ACQ_SKIP_MSB_DOCTOR` | (unset) | Skip the automatic host-readiness check (`msb doctor`, and the `msb doctor --fix` it runs when the host is not ready). Set when the check is unreliable in your environment or you prefer to run it yourself. |
 | `ACQ_OPENCODE_POSTINSTALL_TIMEOUT` | `120` | Seconds to bound opencode's in-guest `postinstall.mjs` (which fetches a platform binary) so a wedged registry can't hang `acq run`; used only when the guest provides `timeout` |
@@ -342,6 +344,123 @@ Note the async-boot caveat:
 > provision failure** and points you at `msb logs --source system <name>` —
 > rather than proceeding against a sandbox that never came up.
 
+### Custom base image (`--image` / `ACQ_IMAGE`)
+
+`acq` exposes one **backend-neutral** way to select a custom base image
+([ADR-0022](adr/0022-neutral-image-override.md)), so the same reference works
+whichever backend is active:
+
+```bash
+# flag form (run or create)
+./acq run --image ghcr.io/your-org/agent-base:v1 opencode .
+# env form
+export ACQ_IMAGE=ghcr.io/your-org/agent-base:v1
+```
+
+**How each backend applies it:**
+
+| Backend | Neutral image becomes | Notes |
+|---------|-----------------------|-------|
+| msb | the OCI image positional on `msb create` (same slot as `ACQ_MSB_IMAGE`) | msb resolves it as a **registry** reference |
+| sbx | `sbx create --template <ref>` | injected only if you did **not** pass your own `--template`/`-t` |
+
+**Precedence:** `--image` flag **>** `ACQ_IMAGE` env **>** backend var/default. If
+you also set the backend-specific `ACQ_MSB_IMAGE`, the **backend var wins** (a
+one-time notice is printed) — a deliberately-set backend var is never silently
+overridden by the neutral knob.
+
+**Local (registry-less) images on msb.** `msb create` pulls the image from a
+registry (policy `if-missing` by default) and does **not** read the host
+engine's local store, so a locally-built tag like `localhost/foo:test` fails.
+Import it into msb's cache first, then disable the pull:
+
+```bash
+docker save localhost/foo:test -o /tmp/foo.tar   # or: podman save …
+msb image load -i /tmp/foo.tar -t localhost/foo:test
+ACQ_MSB_PULL=never ./acq --backend msb --image localhost/foo:test create shell .
+```
+
+Registry-hosted images (Docker Hub, ghcr.io, …) need no import; on sbx a local
+image is imported with `sbx template load` instead (see the caveats below).
+
+**Portable image contract.** To keep one reference usable on **both** backends,
+build an image that satisfies the stricter (sbx) form of the base-image contract
+([Docker Sandboxes kit reference](https://docs.docker.com/ai/sandboxes/customize/kit-reference/#sandbox-block)):
+
+- a non-root **`agent` user at UID 1000** with passwordless sudo;
+- a **`/home/agent`** home owned by `agent`;
+- **`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`** preserved across sudo;
+- **`node`, `git`, `curl`, `update-ca-certificates`** present (+ `socat` for git
+  signing);
+- the **agent binary** baked in or installable at provision.
+
+You do **not** have to build `FROM docker/sandbox-templates:shell` — the image
+only has to *meet* the contract — but building `FROM
+docker/sandbox-templates:shell` (or `shell-docker`) satisfies every point for
+free. `acq`'s msb adapter is more lenient (it addresses `agent` by name and can
+synthesize the user/sudo/proxy on a plain OCI base — see below), so an image that
+is portable by the sbx rule always works on msb; the reverse is not guaranteed.
+
+> **Building a derived image:** the contract sets `USER=agent`, so Dockerfile
+> `RUN` steps in a derived image execute as the non-root `agent`. Writing to
+> root-owned paths (e.g. `/etc`) needs `sudo` (the contract grants `agent`
+> passwordless sudo) or a temporary `USER root`; prefer writing under the
+> agent-owned `/home/agent`, where no elevation is required.
+
+**sbx caveats `acq` surfaces (but cannot handle for you):**
+
+- The **agent token must match the image's agent variant** (run `opencode`
+  against an `opencode`-derived template, `shell` against a `shell` one).
+- A **private or non-Docker-Hub** image needs pull creds first:
+  `sbx secret set --registry <host> …`.
+- A **locally-built** image (not in a registry) must be imported first:
+  `sbx template load <tar>` (the tar can come from `docker save` **or** `podman
+  save`).
+
+**Registry auth.** A private image (the common case for `ghcr.io`) needs
+credentials stored on the backend BEFORE `--image` can pull it:
+
+```bash
+# msb: store registry creds in the OS credential store
+msb registry login ghcr.io -u <username> --password-stdin   # paste a PAT, then Ctrl-D
+# sbx: the equivalent registry-credential step
+sbx secret set --registry ghcr.io -u <username>
+```
+
+A public image needs none of this.
+
+**Using a devcontainer image.** A `.devcontainer` image is a normal OCI image, so
+`--image ghcr.io/org/img:tag` works — **but only if it also meets the portable
+contract above.** Most devcontainer bases do **not** out of the box: they commonly
+run as a `vscode` (or `node`) user rather than `agent` at UID 1000, and may lack
+`socat` or the CA tooling. Two ways to reconcile:
+
+- **On msb (lenient):** the msb adapter addresses the agent user *by name* and
+  synthesizes the `agent` user / sudo / proxy contract on a plain base, and
+  installs `opencode` at provision — so a devcontainer image often works as-is on
+  msb provided `node`, `git`, `curl`, and `ca-certificates` are present. Missing
+  tools are the usual failure; add them to the image.
+- **For portability (works on sbx too):** add a thin wrapper layer that satisfies
+  the contract explicitly:
+
+  ```dockerfile
+  FROM ghcr.io/your-org/your-devcontainer:tag
+  USER root
+  RUN command -v useradd && useradd -m -u 1000 -s /bin/bash agent || adduser -D -u 1000 agent; \
+      mkdir -p /home/agent && chown agent /home/agent; \
+      (apt-get update && apt-get install -y sudo git curl ca-certificates socat nodejs || \
+       apk add --no-cache sudo git curl ca-certificates socat nodejs); \
+      printf 'agent ALL=(ALL) NOPASSWD:ALL\n' > /etc/sudoers.d/agent
+  USER agent
+  ```
+
+  Then `--image` that wrapper. (If the devcontainer already provides a UID-1000
+  sudo user and the four tools, you can skip the wrapper.)
+
+Verify the whole path live on a sandbox-capable host with
+`./scripts/verify-image-override` (builds a tiny marked image, creates a sandbox
+on each installed backend with `--image`, and confirms the custom image booted).
+
 ### Base image and prerequisites
 
 Unlike sbx (whose agent templates supply the image via a template mechanism),
@@ -422,7 +541,8 @@ default interactive shell (the base image's Node REPL) — for a `shell` sandbox
 if the agent binary is somehow missing.
 
 To use your own image, set `ACQ_MSB_IMAGE` to one that also provides node, git,
-curl, and ca-certificates:
+curl, and ca-certificates (or use the backend-neutral `--image`/`ACQ_IMAGE`, see
+[Custom base image](#custom-base-image---image--acq_image)):
 
 ```bash
 export ACQ_MSB_IMAGE=ghcr.io/your-org/agent-base:latest   # must have node/git/curl/ca-certificates

--- a/docs/adr/0022-neutral-image-override.md
+++ b/docs/adr/0022-neutral-image-override.md
@@ -1,0 +1,200 @@
+---
+title: "Backend-Neutral Custom Base Image (--image / ACQ_IMAGE)"
+status: accepted
+date: 2026-08-20
+decision_makers: ["Bret Mogilefsky"]
+category: architecture
+nist_controls: ["CM-2", "CM-3", "CM-6", "SA-8", "SA-15", "SR-3"]
+impact_level: low
+ato_relevance: no
+risk_treatment: accept
+supersedes: []
+---
+
+# ADR-0022: Backend-Neutral Custom Base Image (`--image` / `ACQ_IMAGE`)
+
+## Context and Problem Statement
+
+The `acq` neutral adapter contract ([ADR-0010](0010-acq-pluggable-backends.md))
+passes an *agent*, *workspace paths*, *kits*, *secrets*, and *ports* to each
+backend — it deliberately does **not** carry a base image. As a result, choosing
+a custom base image has been per-backend and asymmetric:
+
+- **msb** already exposes `ACQ_MSB_IMAGE` — it runs a plain OCI image directly
+  and layers the kits on top ([ADR-0011](0011-msb-backend-and-neutral-kits.md)).
+- **sbx** has **no** `acq`-level knob. Its agent templates supply the image via
+  Docker's template mechanism; a user who wanted a custom template had to reach
+  around `acq` to `sbx create --template` themselves.
+
+A user asked for the straightforward, backend-agnostic thing: "let me point
+`acq` at a custom base image, once, and have it work regardless of backend." No
+neutral vocabulary existed for that.
+
+## Decision Drivers
+
+- **One neutral knob** — a single `--image` / `ACQ_IMAGE` that both backends
+  honor, so a workspace/team can pin a base image without caring which backend
+  is active.
+- **No regression to the existing per-backend knob** — `ACQ_MSB_IMAGE` and the
+  msb prerequisite/synthesis logic must keep working unchanged.
+- **Portability of the image itself** — the same image reference should be
+  usable on both backends, which means documenting one image *contract* that
+  satisfies the stricter of the two.
+- **Least surprise on precedence** — a user who set a backend-specific var
+  deliberately should not have it silently overridden by the neutral one.
+- **Reversibility / auditability (CM-3, CM-6)** — the choice must be visible
+  (a one-time notice) and confined to sandbox creation.
+
+## Considered Options
+
+1. **Neutral `--image` / `ACQ_IMAGE`; msb → `ACQ_MSB_IMAGE` path, sbx → `sbx
+   create --template <ref>`.** Chosen. sbx's `--template` already accepts any OCI
+   image reference that satisfies the published base-image contract, so no
+   generated artifact is required.
+2. **Neutral knob on msb only; error on sbx.** Rejected — it contradicts the
+   stated "backend-agnostic" goal and leaves sbx users where they started.
+3. **Synthesize a throwaway sbx *sandbox kit* (`kind: sandbox`,
+   `sandbox.image: <ref>`) at run time and inject it via `--kit`.** Rejected as
+   heavier with no benefit over `--template`: sandbox kits define a whole agent
+   (image + entrypoint + command), the neutral→sbx translator today only emits
+   *mixin* kits, and a sandbox kit would collide with `acq`'s four built-in mixin
+   kits. `--template` is the purpose-built primitive.
+
+## Decision Outcome
+
+**Chosen: Option 1.** Add a backend-neutral image selector surfaced two ways:
+
+- **CLI flag:** `--image <ref>`, accepted BOTH as a pre-subcommand global
+  (`acq --backend msb --image <ref> create shell …`) and after the run/create
+  subcommand (`acq create shell --image <ref> <path>`). Either position sets the
+  same value; `--image` is acq-owned and is never forwarded to the backend CLI
+  (neither `sbx` nor `msb` accepts a bare `--image`).
+- **Environment:** `ACQ_IMAGE=<ref>`.
+
+Both are resolved by a single helper, `acq_resolve_neutral_image` (in
+`acq.backends/common.sh`), so the precedence rule lives in one place.
+
+### Precedence
+
+`--image` flag **>** `ACQ_IMAGE` env **>** backend-specific var / default.
+
+When a backend-specific var is **also** set (today only `ACQ_MSB_IMAGE`), the
+**most-specific backend var wins**, and `acq` prints a one-time notice so the
+override is not silent. Rationale: a user who set `ACQ_MSB_IMAGE` did so
+deliberately for that backend; the neutral knob is the broader default and
+should yield to the narrower one.
+
+### Per-backend mapping
+
+| Backend | Neutral image maps to | Mechanism |
+|---------|-----------------------|-----------|
+| msb | `ACQ_MSB_IMAGE` (if that var is unset) | trailing OCI image positional on `msb create` |
+| sbx | `sbx create --template <ref>` | injected **only** if the user did not already pass their own `--template`/`-t` |
+
+**Local (registry-less) images.** `msb create` treats the image argument as a
+**registry reference** and pulls it (policy `if-missing` by default) — it does
+**not** read the host container engine's local image store. A locally-built tag
+such as `localhost/foo:test` therefore fails (`msb` tries to reach a registry at
+`localhost`). To use a local image on msb, import it into msb's own cache first
+(`msb image load -i <tar> -t <ref>`, the analogue of sbx's `sbx template load`)
+and create with pull disabled. acq exposes that pull policy as **`ACQ_MSB_PULL`**
+(`always` | `if-missing` | `never`), forwarded to `msb create --pull`; set
+`ACQ_MSB_PULL=never` alongside a pre-loaded `--image`. Registry-hosted images
+(Docker Hub, ghcr.io, …) need no such step — the default pull path applies.
+
+### The portable base-image contract
+
+To keep a single image reference usable on **both** backends, an `--image`
+target should satisfy the **stricter (sbx) form** of the base-image contract, as
+published in the Docker Sandboxes kit reference
+(<https://docs.docker.com/ai/sandboxes/customize/kit-reference/#sandbox-block> —
+"The agent's container image must provide"):
+
+- A non-root **`agent` user at UID 1000** with passwordless sudo.
+- A **`/home/agent`** home directory owned by `agent`.
+- **HTTP proxy env** (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) preserved across
+  sudo.
+- The four kit prerequisites present in the image: **`node`, `git`, `curl`,
+  `update-ca-certificates`** (plus **`socat`** if git commit signing / ssh-agent
+  forwarding is used).
+- The **agent binary** baked in, or installable at provision (for `opencode`,
+  `acq` runs `npm install -g opencode-ai` on msb; sbx's agent templates bake it).
+
+The image does **not** have to be built `FROM docker/sandbox-templates:shell`
+— it only has to *meet* the contract. Building `FROM
+docker/sandbox-templates:shell` (or `shell-docker`) is the recommended shortcut
+because it satisfies every point above for free.
+
+**Build-time note (`RUN` runs as `USER=agent`).** Because the contract sets the
+image `USER` to the non-root `agent`, a Dockerfile `RUN` step in a *derived*
+image also runs as `agent`. Writes to root-owned paths (e.g. `/etc`) therefore
+fail with `Permission denied` unless you `sudo` (the contract grants `agent`
+passwordless sudo) or temporarily `USER root`. Prefer writing under the
+agent-owned `/home/agent` where no elevation is needed. The
+`scripts/verify-image-override` marker follows this rule (writes to
+`/home/agent/.acq-image-marker`, no sudo) so it works whether a custom base
+leaves `USER=agent` or `USER=root`.
+
+**One documented divergence (a relaxation, not a conflict):** `acq`'s msb adapter
+addresses the `agent` user **by name**, not by the literal UID 1000, and will
+*synthesize* the user/sudo/proxy contract on a plain-OCI base that lacks it
+([ADR-0011](0011-msb-backend-and-neutral-kits.md)). So an image that is portable
+by the sbx rule above always works on msb; an image that works only on msb (e.g.
+`agent` at a non-1000 UID, or no `agent` user at all) is **not** guaranteed on
+sbx. Authoring to the sbx form keeps the reference portable.
+
+### sbx operational caveats (surfaced, not automated)
+
+`acq` prints a one-time notice on sbx when a neutral image is injected, covering
+the three things `acq` cannot do for the user:
+
+- The **agent token must match the image's agent variant** (e.g. run `opencode`
+  against an `opencode`-derived template), or sbx warns and the sandbox may not
+  work.
+- A **private or non-Docker-Hub image** needs pull credentials stored first:
+  `sbx secret set --registry <host> …`.
+- A **locally-built image** that is not in a registry must be imported first:
+  `sbx template load <tar>` (the tar can come from `docker save` **or** `podman
+  save`).
+
+## Consequences
+
+- **Positive:** one neutral image knob; sbx gains custom-template support through
+  `acq` for the first time; the existing `ACQ_MSB_IMAGE` path and msb synthesis
+  are untouched; precedence is explicit and audited by a notice.
+- **Negative / trade-off:** the neutral knob cannot paper over the genuine
+  backend difference in the image contract (UID 1000 on sbx). We document one
+  portable contract rather than hide the difference.
+- **Scope:** applies at sandbox **creation** only, matching where both backends
+  accept an image; it does not retro-fit a running sandbox.
+
+## Validation
+
+- **Offline (`scripts/test-acq`, no Docker/KVM):** asserts `ACQ_IMAGE` and
+  `--image` reach `msb create` as the image positional; that `ACQ_MSB_IMAGE`
+  wins over `ACQ_IMAGE` (with the notice); that a neutral image injects `sbx
+  create --template <ref>`; that a user-supplied `--template` is not
+  double-injected; and that with no image set, sbx omits `--template` and msb
+  uses its default.
+- **Live (`scripts/verify-image-override`, host with a sandbox-capable
+  runtime):** builds a tiny image `FROM docker/sandbox-templates:shell` (via
+  `docker` or `podman` — Docker Desktop is not required), imports it into each
+  installed backend's cache (`sbx template load` for sbx; `msb image load` for
+  msb, then `--image` with `ACQ_MSB_PULL=never`), creates a throwaway sandbox
+  with `--image`, and asserts the sandbox is exec-ready, the kits applied, and
+  the custom image actually took effect (a unique marker baked into the image).
+  A backend whose runtime is absent is `BLOCKED`/skipped, not failed — mirroring
+  the [ADR-0011](0011-msb-backend-and-neutral-kits.md) live-validation cadence.
+
+## Links
+
+- [ADR-0010: acq pluggable backends](0010-acq-pluggable-backends.md) — the neutral
+  adapter contract this extends.
+- [ADR-0011: msb backend and neutral kits](0011-msb-backend-and-neutral-kits.md)
+  — `ACQ_MSB_IMAGE`, the msb base-image contract, and the user/sudo synthesis.
+- Docker Sandboxes base-image requirements:
+  <https://docs.docker.com/ai/sandboxes/customize/kit-reference/#sandbox-block>
+- Docker Sandboxes custom templates:
+  <https://docs.docker.com/ai/sandboxes/customize/templates/>
+- Related code: `acq`, `acq.backends/common.sh`, `acq.backends/sbx.sh`,
+  `acq.backends/msb.sh`, `docs/BACKEND_GUIDE.md`.

--- a/docs/adr/0022-neutral-image-override.md
+++ b/docs/adr/0022-neutral-image-override.md
@@ -157,6 +157,25 @@ the three things `acq` cannot do for the user:
   `sbx template load <tar>` (the tar can come from `docker save` **or** `podman
   save`).
 
+### Registry-auth failure messaging
+
+When a custom `--image` pull is **denied** (missing/incorrect credentials), the
+backend CLI prints its own raw error (e.g. `unauthorized`). On top of that, `acq`
+adds a **targeted, registry-agnostic** remediation hint derived from the *actual*
+image reference — not a hardcoded list of hosts:
+
+- `acq_registry_auth_hint` (in `acq.backends/common.sh`) parses the image's
+  registry host via `_acq_image_registry_host` (a host is a leading component with
+  a `.`, a `:port`, or exactly `localhost`; bare Docker Hub short names carry no
+  host) and prints the correct command for the failing backend:
+  `msb registry login <host> …` or `sbx secret set --registry <host> …`.
+- For a **local** (registry-less) image it instead points at the import path
+  (`msb image load` + `ACQ_MSB_PULL=never`, or `sbx template load`), and does not
+  emit a spurious "login to localhost" line.
+- Both backends' create-failure paths call this, so the sbx path is no longer
+  limited to the backend's bare error and the msb path is no longer limited to a
+  few hardcoded hosts.
+
 ## Consequences
 
 - **Positive:** one neutral image knob; sbx gains custom-template support through

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -1447,6 +1447,62 @@ cleanup_stubs
 
 rm -rf "$_imgproj"
 
+# --- registry-auth hint helpers (ADR-0022 follow-up) --------------------------
+# _acq_image_registry_host must extract a registry host only when the leading
+# component looks like one (has a dot, a :port, or is localhost); Docker Hub
+# short names carry no host. acq_registry_auth_hint must then emit a targeted,
+# registry-agnostic remediation for the RIGHT backend surface.
+make_stubs; load_acq
+# Host parsing.
+assert_eq "reg-host: bare Docker Hub name has no host" "" "$(_acq_image_registry_host ubuntu)"
+assert_eq "reg-host: tagged Docker Hub name has no host" "" "$(_acq_image_registry_host ubuntu:22.04)"
+assert_eq "reg-host: library/ path is still Docker Hub" "" "$(_acq_image_registry_host library/ubuntu)"
+assert_eq "reg-host: ghcr.io detected" "ghcr.io" "$(_acq_image_registry_host ghcr.io/org/img:v1)"
+assert_eq "reg-host: host:port detected" "myreg.example.com:5000" "$(_acq_image_registry_host myreg.example.com:5000/x/y)"
+assert_eq "reg-host: localhost detected" "localhost" "$(_acq_image_registry_host localhost/foo:test)"
+# msb hint: names the SPECIFIC private host + the msb login command, plus local import.
+msb_hint=$(acq_registry_auth_hint msb ghcr.io/org/img:v1 2>&1)
+assert_contains "reg-hint(msb): names msb registry login for the host" "$msb_hint" "msb registry login ghcr.io"
+assert_contains "reg-hint(msb): offers local-import fallback" "$msb_hint" "msb image load"
+# msb hint for a LOCAL image: no bogus 'login localhost', just the import path.
+msb_local_hint=$(acq_registry_auth_hint msb localhost/foo:test 2>&1)
+assert_not_contains "reg-hint(msb): no login hint for localhost" "$msb_local_hint" "registry login"
+assert_contains "reg-hint(msb): local image still gets import path" "$msb_local_hint" "msb image load"
+# sbx hint: names the sbx registry-secret command for the host + template load.
+sbx_hint=$(acq_registry_auth_hint sbx registry.gitlab.com/g/p:1 2>&1)
+assert_contains "reg-hint(sbx): names sbx secret --registry for the host" "$sbx_hint" "sbx secret set --registry registry.gitlab.com"
+assert_contains "reg-hint(sbx): offers template load fallback" "$sbx_hint" "sbx template load"
+# Docker Hub short name: no host-specific login line (host unknown), on either backend.
+hub_hint=$(acq_registry_auth_hint msb ubuntu:22.04 2>&1)
+assert_not_contains "reg-hint(msb): no login line for a Docker Hub short name" "$hub_hint" "registry login"
+cleanup_stubs
+
+# --- sbx: a failed create with a custom --image surfaces the acq auth hint ----
+# End-to-end at the provision layer (like 9q7b): the sbx create fails (modeled as
+# a denied pull); acq must add its registry remediation on top of sbx's raw error
+# instead of leaving the user with only the bare backend denial. Call
+# acq_backend_provision directly so the USAi pre-create gate (a dispatch concern)
+# is out of scope. Registry-agnostic (ghcr.io here).
+make_stubs; load_acq
+cat >"$STUBDIR/sbx" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'sbx'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >>"$CALLS"
+case "${1:-}" in
+  version) printf 'sbx version: v0.38.0 abc123\n' ;;
+  create) printf 'ERROR: failed to pull image: unauthorized\n' >&2; exit 1 ;;
+  exec) printf 'ok\n' ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$STUBDIR/sbx"
+: > "$CALLS"
+_imgfail=$(mktemp -d "${TMPDIR:-/tmp}/acq-imgfail.XXXXXX")
+sbx_fail_err=$(ACQ_IMAGE=ghcr.io/org/priv:v1 acq_backend_provision imgfailbox shell "$_imgfail" 2>&1 >/dev/null) || true
+assert_contains "image(sbx): failed create names the acq auth hint" "$sbx_fail_err" "sbx secret set --registry ghcr.io"
+assert_contains "image(sbx): failed create still shows raw backend error" "$sbx_fail_err" "unauthorized"
+rm -rf "$_imgfail"
+cleanup_stubs
+
 
 # 3z. `acq run` fails CLOSED on an unresolvable target (issue #253). `run` is
 #     create-and-attach for a KNOWN AGENT or a re-attach to an EXISTING sandbox

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -663,6 +663,12 @@ make_stubs; load_acq
   # shellcheck source=acq
   ACQ_SOURCE_ONLY=1 . "$ACQ"
   . "${REPO_ROOT}/acq.backends/msb.sh"
+  # Reset the once-per-process announce guard: on a host where an earlier
+  # parent-scope backend resolve already fired the durable-fix hint (a real
+  # backend reachable only via ~/.local/bin), _ACQ_LOCAL_BIN_ANNOUNCED=1 is
+  # inherited here and would silence the announce this test asserts. Clearing it
+  # makes the test independent of parent process state (the macOS-only flake).
+  _ACQ_LOCAL_BIN_ANNOUNCED=""
   set +e
   _backend_installed msb 2>"$STUBDIR/rep_note"
   rc=$?
@@ -712,6 +718,9 @@ make_stubs; load_acq
   # shellcheck source=acq
   ACQ_SOURCE_ONLY=1 . "$ACQ"
   . "${REPO_ROOT}/acq.backends/msb.sh"
+  # Clear the inherited once-per-process announce guard so the FIRST call below
+  # is guaranteed to announce regardless of parent process state (see 2i).
+  _ACQ_LOCAL_BIN_ANNOUNCED=""
   set +e
   _ensure_local_bin_on_path msb 2>"$STUBDIR/n1"    # first: prepends + announces
   _ensure_local_bin_on_path msb 2>"$STUBDIR/n2"    # second: already on PATH, silent
@@ -778,6 +787,20 @@ log=$(cat "$CALLS")
 assert_contains "dispatch: create -> sbx create --name" "$log" "sbx create --name"
 assert_contains "dispatch: create includes --kit" "$log" "--kit"
 assert_contains "dispatch: create includes usai kit" "$log" "acq-kits/usai-provider"
+# The workspace positional MUST survive --name stripping in the sbx create argv.
+# Regression: the provision arg scan re-appended the dropped --name VALUE, which
+# left a stray positional so sbx read the name as the workspace and the real
+# workspace as an extra mount (the intended workspace then looked "missing" and
+# create prompted, then cancelled). Assert the real workspace path is present and
+# the sandbox name is NOT sitting where sbx expects a workspace.
+# NOTE: sbx.sh forwards the workspace positional to `sbx create` VERBATIM (it does
+# not canonicalize on the create path — unlike the msb --volume mount path). So
+# assert against the RAW $_projdir, not canonicalize_path: on macOS the temp dir
+# is a /var -> /private/var symlink and the canonicalized form would not match the
+# literal path in the argv. Mirrors the sibling "kit-flag: create keeps workspace
+# positional" check.
+sbx_create_line=$(printf '%s\n' "$log" | grep '^sbx create')
+assert_contains "dispatch: create keeps workspace positional" "$sbx_create_line" "$_projdir"
 rm -rf "$_projdir"
 cleanup_stubs
 
@@ -1184,6 +1207,246 @@ assert_not_contains "kit-flag: agent --kit after -- not hijacked (#222)" "$creat
 assert_contains "kit-flag: agent --kit after -- forwarded intact (#222)" "$log" "--kit evil-agent-arg"
 cleanup_stubs
 rm -rf "$_kitproj"
+
+# ===========================================================================
+# 3y. Backend-neutral --image / ACQ_IMAGE (ADR-0022)
+# ===========================================================================
+# A neutral base image knob resolves flag > ACQ_IMAGE env > backend var/default.
+# On msb it becomes the trailing `msb create` image positional; on sbx it becomes
+# `sbx create --template <ref>`. `--image` is acq-owned: it must NOT survive as a
+# raw flag on the backend argv, and must not corrupt the workspace positional.
+# Workspace must be a real dir (pre-flight aborts otherwise); use a temp dir.
+_imgproj=$(mktemp -d "${TMPDIR:-/tmp}/acq-imgproj.XXXXXX")
+
+# --- msb: ACQ_IMAGE env reaches `msb create` as the image positional ----------
+make_stubs
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/img-msb-env-secrets"
+  export ACQ_MSB_KIT_PASSTHROUGH=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'USAI-REAL\n' | acq_secret_store "$(_acq_secret_key usai)"
+  ACQ_IMAGE="localhost/acq-custom:test" ACQ_BACKEND=msb "$ACQ" \
+    create shell "$_imgproj" >/dev/null 2>&1
+)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^msb create')
+assert_contains "image(msb): ACQ_IMAGE env reaches msb create positional" "$create_line" "localhost/acq-custom:test"
+assert_not_contains "image(msb): default image suppressed by ACQ_IMAGE" "$create_line" "docker.io/docker/sandbox-templates:shell-docker"
+assert_not_contains "image(msb): --image not forwarded raw to backend" "$create_line" "--image"
+cleanup_stubs
+
+# --- msb: --image FLAG reaches `msb create` (flag path == env path) -----------
+make_stubs
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/img-msb-flag-secrets"
+  export ACQ_MSB_KIT_PASSTHROUGH=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'USAI-REAL\n' | acq_secret_store "$(_acq_secret_key usai)"
+  ACQ_BACKEND=msb "$ACQ" create shell --image localhost/acq-flag:test "$_imgproj" >/dev/null 2>&1
+)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^msb create')
+assert_contains "image(msb): --image flag reaches msb create positional" "$create_line" "localhost/acq-flag:test"
+assert_not_contains "image(msb): --image flag not left on backend argv" "$create_line" "--image"
+assert_contains "image(msb): workspace positional survives --image" "$create_line" "$(canonicalize_path "$_imgproj")"
+cleanup_stubs
+
+# --- msb: --image=<ref> equals form is also intercepted -----------------------
+make_stubs
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/img-msb-eq-secrets"
+  export ACQ_MSB_KIT_PASSTHROUGH=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'USAI-REAL\n' | acq_secret_store "$(_acq_secret_key usai)"
+  ACQ_BACKEND=msb "$ACQ" create shell --image=localhost/acq-eq:test "$_imgproj" >/dev/null 2>&1
+)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^msb create')
+assert_contains "image(msb): --image=<ref> equals form intercepted" "$create_line" "localhost/acq-eq:test"
+assert_not_contains "image(msb): --image= not left raw" "$create_line" "--image=localhost/acq-eq:test"
+cleanup_stubs
+
+# --- msb: GLOBAL --image (BEFORE the subcommand) is intercepted ----------------
+# `acq --backend msb --image REF create shell …` — the position the live verifier
+# uses. The pre-subcommand global parser must consume --image so it never reaches
+# the backend CLI (regression: msb rejected a forwarded `--image`).
+make_stubs
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/img-msb-global-secrets"
+  export ACQ_MSB_KIT_PASSTHROUGH=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'USAI-REAL\n' | acq_secret_store "$(_acq_secret_key usai)"
+  "$ACQ" --backend msb --image localhost/acq-global:test create shell --name gimg "$_imgproj" >/dev/null 2>&1
+)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^msb create')
+assert_contains "image(msb): global --image reaches msb create positional" "$create_line" "localhost/acq-global:test"
+assert_not_contains "image(msb): global --image not forwarded raw to backend" "$create_line" "--image"
+cleanup_stubs
+
+# --- msb: ACQ_MSB_PULL maps to `msb create --pull <policy>` --------------------
+# A locally-loaded image (no registry behind it) needs --pull never so msb uses
+# its cache instead of trying to pull the un-pullable ref. acq forwards a valid
+# ACQ_MSB_PULL to `msb create --pull`; an invalid value is ignored with a notice.
+make_stubs
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/img-msb-pull-secrets"
+  export ACQ_MSB_KIT_PASSTHROUGH=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'USAI-REAL\n' | acq_secret_store "$(_acq_secret_key usai)"
+  ACQ_MSB_PULL=never ACQ_IMAGE=localhost/acq-cached:test ACQ_BACKEND=msb "$ACQ" \
+    create shell --name pimg "$_imgproj" >/dev/null 2>&1
+)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^msb create')
+assert_contains "image(msb): ACQ_MSB_PULL=never -> msb create --pull never" "$create_line" "--pull never"
+assert_contains "image(msb): cached image still passed with --pull never" "$create_line" "localhost/acq-cached:test"
+cleanup_stubs
+
+# Invalid ACQ_MSB_PULL is ignored (no --pull emitted) with a warning.
+make_stubs
+img_pull_err=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/img-msb-pullbad-secrets"
+  export ACQ_MSB_KIT_PASSTHROUGH=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'USAI-REAL\n' | acq_secret_store "$(_acq_secret_key usai)"
+  ACQ_MSB_PULL=bogus ACQ_BACKEND=msb "$ACQ" create shell --name pbad "$_imgproj" 2>&1 >/dev/null
+)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^msb create')
+assert_not_contains "image(msb): invalid ACQ_MSB_PULL not forwarded" "$create_line" "--pull"
+assert_contains "image(msb): invalid ACQ_MSB_PULL warns" "$img_pull_err" "invalid ACQ_MSB_PULL"
+cleanup_stubs
+
+# --- msb: GLOBAL --image=<ref> equals form (before subcommand) -----------------
+make_stubs
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/img-msb-globaleq-secrets"
+  export ACQ_MSB_KIT_PASSTHROUGH=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'USAI-REAL\n' | acq_secret_store "$(_acq_secret_key usai)"
+  "$ACQ" --backend msb --image=localhost/acq-globaleq:test create shell --name gimgeq "$_imgproj" >/dev/null 2>&1
+)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^msb create')
+assert_contains "image(msb): global --image=<ref> equals form intercepted" "$create_line" "localhost/acq-globaleq:test"
+assert_not_contains "image(msb): global --image= not left raw" "$create_line" "--image="
+cleanup_stubs
+
+# --- msb: PRECEDENCE — explicit ACQ_MSB_IMAGE beats neutral ACQ_IMAGE ----------
+# The most-specific backend var wins (ADR-0022), with a one-time notice.
+make_stubs
+img_prec_err=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/img-msb-prec-secrets"
+  export ACQ_MSB_KIT_PASSTHROUGH=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'USAI-REAL\n' | acq_secret_store "$(_acq_secret_key usai)"
+  ACQ_MSB_IMAGE="localhost/backend-specific:test" ACQ_IMAGE="localhost/neutral:test" \
+    ACQ_BACKEND=msb "$ACQ" create shell "$_imgproj" 2>&1 >/dev/null
+)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^msb create')
+assert_contains "image(msb): ACQ_MSB_IMAGE wins over ACQ_IMAGE" "$create_line" "localhost/backend-specific:test"
+assert_not_contains "image(msb): neutral image loses to backend var" "$create_line" "localhost/neutral:test"
+assert_contains "image(msb): precedence conflict prints a one-time notice" "$img_prec_err" "most-specific wins"
+cleanup_stubs
+
+# --- msb: no image set -> default image is used (regression guard) -------------
+make_stubs
+(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/img-msb-def-secrets"
+  export ACQ_MSB_KIT_PASSTHROUGH=1
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'USAI-REAL\n' | acq_secret_store "$(_acq_secret_key usai)"
+  ACQ_BACKEND=msb "$ACQ" create shell "$_imgproj" >/dev/null 2>&1
+)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^msb create')
+assert_contains "image(msb): no neutral image -> default shell-docker image" "$create_line" "docker.io/docker/sandbox-templates:shell-docker"
+cleanup_stubs
+
+# --- sbx: neutral image injects `sbx create --template <ref>` -----------------
+make_stubs
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
+seed_sbx_usai_proxy_fixture
+ACQ_IMAGE="docker.io/my-org/my-template:v1" ACQ_BACKEND=sbx "$ACQ" \
+  create opencode "$_imgproj" >/dev/null 2>&1
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^sbx create')
+assert_contains "image(sbx): neutral image injects --template" "$create_line" "--template docker.io/my-org/my-template:v1"
+assert_not_contains "image(sbx): --image not forwarded raw" "$create_line" "--image"
+cleanup_stubs
+
+# --- sbx: --image flag path also injects --template ---------------------------
+make_stubs
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
+seed_sbx_usai_proxy_fixture
+ACQ_BACKEND=sbx "$ACQ" create opencode --image docker.io/my-org/flag-tpl:v2 "$_imgproj" >/dev/null 2>&1
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^sbx create')
+assert_contains "image(sbx): --image flag injects --template" "$create_line" "--template docker.io/my-org/flag-tpl:v2"
+cleanup_stubs
+
+# --- sbx: GLOBAL --image (before the subcommand) injects --template -----------
+# Mirrors the live verifier's `acq --backend sbx --image REF create shell …`.
+make_stubs
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
+seed_sbx_usai_proxy_fixture
+"$ACQ" --backend sbx --image docker.io/my-org/global-tpl:v3 create opencode "$_imgproj" >/dev/null 2>&1
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^sbx create')
+assert_contains "image(sbx): global --image injects --template" "$create_line" "--template docker.io/my-org/global-tpl:v3"
+assert_not_contains "image(sbx): global --image not forwarded raw" "$create_line" "--image"
+cleanup_stubs
+
+# --- sbx: an explicit user --template is NOT double-injected -------------------
+# When the user already passed --template, acq honors it and does NOT add its own
+# from --image (the explicit flag wins; a doubled --template is ambiguous).
+make_stubs
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
+seed_sbx_usai_proxy_fixture
+img_dbl_err=$(ACQ_IMAGE="docker.io/my-org/neutral:v1" ACQ_BACKEND=sbx "$ACQ" \
+  create opencode --template docker.io/my-org/explicit:v9 "$_imgproj" 2>&1 >/dev/null)
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^sbx create')
+assert_contains "image(sbx): explicit --template preserved" "$create_line" "--template docker.io/my-org/explicit:v9"
+assert_not_contains "image(sbx): neutral image not injected over explicit --template" "$create_line" "docker.io/my-org/neutral:v1"
+assert_contains "image(sbx): conflict notice names the ignored --image" "$img_dbl_err" "ignoring --image"
+cleanup_stubs
+
+# --- sbx: no image set -> NO --template injected (regression guard) ------------
+make_stubs
+printf 'sk-test\n' | ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
+seed_sbx_usai_proxy_fixture
+ACQ_BACKEND=sbx "$ACQ" create opencode "$_imgproj" >/dev/null 2>&1
+log=$(cat "$CALLS")
+create_line=$(printf '%s\n' "$log" | grep '^sbx create')
+assert_not_contains "image(sbx): no neutral image -> no --template injected" "$create_line" "--template"
+cleanup_stubs
+
+# --- re-attach with --image warns (does not silently ignore) ------------------
+# --image/ACQ_IMAGE only applies at CREATE (ADR-0022). On an AGENT-form re-attach
+# to an EXISTING sandbox, acq must NOT re-provision and must say the flag is
+# ignored rather than pretend it re-imaged the running sandbox.
+make_stubs; load_acq
+printf 'imgreattach\n' > "$STUBDIR/.msb_sandbox_list"
+printf 'imgreattach\n' > "$STUBDIR/.msb_running_list"
+: > "$CALLS"
+img_reattach_err=$(
+  export ACQ_SECRET_STORE_DIR="$STUBDIR/img-reattach-secrets"
+  export ACQ_MSB_KIT_PASSTHROUGH=1
+  export ACQ_UPDATE_CHECK=0
+  . "${REPO_ROOT}/acq.backends/secret-store.sh"
+  printf 'USAI-REAL\n' | acq_secret_store "$(_acq_secret_key usai)"
+  ACQ_IMAGE=localhost/ignored:test ACQ_BACKEND=msb "$ACQ" run shell --name imgreattach "$_imgproj" 2>&1 >/dev/null
+)
+reattach_log=$(cat "$CALLS")
+assert_contains "image(reattach): warns --image ignored on existing sandbox" "$img_reattach_err" "ignored when re-attaching"
+assert_not_contains "image(reattach): no msb create on re-attach" "$reattach_log" "msb create"
+cleanup_stubs
+
+rm -rf "$_imgproj"
+
 
 # 3z. `acq run` fails CLOSED on an unresolvable target (issue #253). `run` is
 #     create-and-attach for a KNOWN AGENT or a re-attach to an EXISTING sandbox

--- a/scripts/verify-image-override
+++ b/scripts/verify-image-override
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# verify-image-override — live end-to-end check for the backend-neutral custom
+# base image knob (ADR-0022): `acq --image <ref>` / `ACQ_IMAGE`. It proves the
+# neutral image ACTUALLY reaches the sandbox on each installed backend:
+#   - msb : the image becomes the `msb create` OCI image positional.
+#   - sbx : the image becomes `sbx create --template <ref>`.
+#
+# This CANNOT run inside a sandbox (no nested sandboxes) and needs a host that
+# can create sandboxes (Docker for sbx; KVM/HVF for msb) AND a container engine
+# to BUILD the tiny test image. It prefers `docker`, falls back to `podman`
+# (Docker Desktop is NOT required — a podman with a `docker` alias also works).
+# A backend whose runtime or engine is absent is reported BLOCKED and SKIPPED,
+# not failed — mirroring the ADR-0011 live-validation cadence.
+#
+# The test image is built `FROM docker/sandbox-templates:shell` (the same family
+# as the msb default) plus a unique marker file, so we can confirm the CUSTOM
+# image — not the default — is what the sandbox booted.
+#
+# Usage:
+#   ./scripts/verify-image-override [--only sbx|msb]
+set -u
+
+ONLY=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --only)
+      # shift-once then read the value, so a trailing bare `--only` (no value)
+      # cannot leave $# unchanged and spin the loop forever under `set -u`.
+      shift
+      [ "$#" -ge 1 ] || { echo "--only needs a value (sbx|msb)" >&2; exit 2; }
+      ONLY="$1"; shift ;;
+    --only=*) ONLY="${1#--only=}"; shift ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Validate --only UP FRONT, before the (slow, network-bound) image build — an
+# invalid value should fail fast, not after wasting a base-image pull.
+case "$ONLY" in
+  sbx|msb|"") : ;;
+  *) echo "--only must be sbx or msb" >&2; exit 2 ;;
+esac
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+ACQ="$SCRIPT_DIR/acq"
+
+PASS=0; FAIL=0; BLOCKED=0
+ok()    { PASS=$((PASS+1));    printf '  \033[32mok  \033[0m %s\n' "$1"; }
+bad()   { FAIL=$((FAIL+1));    printf '  \033[31mBAD \033[0m %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
+block() { BLOCKED=$((BLOCKED+1)); printf '  \033[33mBLOCKED\033[0m %s\n' "$1"; }
+info()  { printf '\n== %s ==\n' "$1"; }
+
+# A unique marker baked into the custom image so we can prove the sandbox booted
+# OUR image and not the backend default.
+MARKER="acq-image-override-$$-$(date +%s)"
+BASE="docker.io/docker/sandbox-templates:shell"
+TAG="localhost/acq-verify-image:test"
+BUILD_DIR=""
+TARBALL=""
+# Throwaway workspace dir mounted into the sandbox. It MUST exist: acq's
+# create/run pre-flight prompts to create a missing workspace, and a piped `N`
+# cancels the whole create (the sbx failure seen on first live run). Created in
+# the run section below and removed in cleanup.
+WORKSPACE=""
+
+# --- Pick a container engine for the BUILD/SAVE step -----------------------
+# CRITICAL: presence of the CLI (`command -v docker`) is NOT enough — Docker
+# Desktop can be installed but its daemon down, in which case every docker call
+# fails at the socket. Probe that the engine is actually USABLE (a cheap `info`
+# that talks to the daemon), and prefer the FIRST engine that responds. This is
+# what makes the podman fallback real: a stopped docker yields to a working
+# podman instead of hard-blocking. `info` is bounded so a wedged daemon cannot
+# hang the probe (use `timeout` when available; docker/podman have no built-in).
+_engine_usable() {
+  local eng="$1"
+  command -v "$eng" >/dev/null 2>&1 || return 1
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 15 "$eng" info >/dev/null 2>&1
+  else
+    "$eng" info >/dev/null 2>&1
+  fi
+}
+ENGINE=""
+for _cand in docker podman; do
+  if _engine_usable "$_cand"; then ENGINE="$_cand"; break; fi
+done
+
+# Bounded, stdin-detached runner for cleanup calls so a wedged daemon / a
+# backend that would prompt cannot hang teardown (the reported Ctrl-C symptom).
+_bounded() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 30 "$@" </dev/null >/dev/null 2>&1 || true
+  else
+    "$@" </dev/null >/dev/null 2>&1 || true
+  fi
+}
+
+# Guard against re-entrancy: an INT/TERM during cleanup (a second Ctrl-C) must
+# not restart cleanup. Disable the trap on first entry.
+_CLEANED=0
+cleanup() {
+  [ "$_CLEANED" -eq 1 ] && return 0
+  _CLEANED=1
+  trap - EXIT INT TERM
+  info "cleanup"
+  [ -n "$BUILD_DIR" ] && rm -rf "$BUILD_DIR" 2>/dev/null || true
+  [ -n "$TARBALL" ] && rm -f "$TARBALL" 2>/dev/null || true
+  [ -n "$WORKSPACE" ] && rm -rf "$WORKSPACE" 2>/dev/null || true
+  # Remove throwaway sandboxes (ignore errors / absent backends). Only touch a
+  # backend whose CLI is present, and bound each call so a stuck backend or a
+  # prompt cannot wedge teardown.
+  command -v msb >/dev/null 2>&1 && _bounded "$ACQ" --backend msb rm imgverify-msb
+  command -v sbx >/dev/null 2>&1 && _bounded "$ACQ" --backend sbx rm imgverify-sbx
+  # Best-effort: drop the locally-built image (leave sbx's loaded template, which
+  # `sbx reset` clears, since there is no per-template rm guarantee across versions).
+  [ -n "$ENGINE" ] && _bounded "$ENGINE" rmi "$TAG"
+}
+trap cleanup EXIT INT TERM
+
+# --- Build the custom test image -------------------------------------------
+build_image() {
+  info "build custom image ($TAG, marker=$MARKER, engine=$ENGINE)"
+  if [ -z "$ENGINE" ]; then
+    block "no container engine (docker/podman) to build the test image — cannot verify --image live"
+    return 1
+  fi
+  BUILD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/acq-imgverify.XXXXXX")
+  # A `RUN` step executes as the image's current USER. The base
+  # (docker/sandbox-templates:shell) sets USER=agent, so a bare
+  # `RUN echo > /etc/...` fails EPERM. The contract does grant `agent`
+  # passwordless sudo, so `RUN sudo …` into /etc WOULD work — but we deliberately
+  # do NOT: the marker is a throwaway read-back artifact, and writing it to the
+  # contract-guaranteed agent-owned /home/agent is the least-privilege choice that
+  # works regardless of whether the custom base ships sudo or leaves USER=root.
+  # read_marker reads the same path.
+  cat > "$BUILD_DIR/Dockerfile" <<EOF
+FROM $BASE
+# Unique marker so the verifier can confirm the sandbox booted THIS image.
+# Written to agent-owned /home/agent (no sudo needed) rather than root-owned /etc.
+RUN echo "$MARKER" > /home/agent/.acq-image-marker
+EOF
+  if "$ENGINE" build -t "$TAG" "$BUILD_DIR" >/tmp/acq-imgbuild.log 2>&1; then
+    ok "built $TAG FROM $BASE via $ENGINE"
+    return 0
+  fi
+  block "image build failed (see /tmp/acq-imgbuild.log) — base pull may need auth or network"
+  tail -5 /tmp/acq-imgbuild.log 2>/dev/null | sed 's/^/        /'
+  return 1
+}
+
+# --- Read the marker back out of a running sandbox -------------------------
+read_marker() {  # $1 = backend, $2 = sandbox
+  "$ACQ" --backend "$1" exec "$2" -- sh -lc 'cat /home/agent/.acq-image-marker 2>/dev/null' 2>/dev/null | tr -d '\r'
+}
+
+# ===========================================================================
+# MSB
+# ===========================================================================
+verify_msb() {
+  info "MSB backend"
+  if ! command -v msb >/dev/null 2>&1; then
+    block "msb not on PATH — skipping msb"; return 0
+  fi
+  case "$(uname -s)" in
+    Linux) [ -e /dev/kvm ] || { block "/dev/kvm absent — msb create will fail on Linux; skipping msb"; return 0; } ;;
+  esac
+  # msb does NOT read the host engine's local image store: a bare tag like
+  # `localhost/acq-verify-image:test` is treated as a REGISTRY reference, so msb
+  # tries to pull `https://localhost/v2/...` and fails. For a locally-built image
+  # we must import it into msb's own cache first with `msb image load` (parallel
+  # to sbx's `sbx template load`). Then create with `--pull never` so msb uses the
+  # cached image instead of trying to re-pull the localhost ref.
+  #
+  # Stream `<engine> save` straight into `msb image load` (both use stdout/stdin
+  # by default) so no multi-hundred-MB tarball is ever written to disk — this
+  # host is disk-constrained, and a temp tar would double the footprint.
+  #
+  # `set -o pipefail` INSIDE the inner shell makes the pipeline's exit status
+  # reflect a failure in EITHER stage — critical here so a `save` failure is not
+  # masked by an `msb image load` that "succeeds" on truncated input. (An outer
+  # PIPESTATUS check would be wrong: from bash's view the pipeline is hidden
+  # inside a single `sh -c`, so PIPESTATUS[0] would be timeout/sh, not `save`.)
+  # A timeout bounds the whole thing.
+  info "msb: import the local image (engine save | msb image load, no temp tar)"
+  local _import_rc=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 180 sh -c 'set -o pipefail; "$1" save "$2" | msb image load -t "$2"' _ "$ENGINE" "$TAG" \
+      >/tmp/acq-msb-imgload.log 2>&1 || _import_rc=$?
+  else
+    sh -c 'set -o pipefail; "$1" save "$2" | msb image load -t "$2"' _ "$ENGINE" "$TAG" \
+      >/tmp/acq-msb-imgload.log 2>&1 || _import_rc=$?
+  fi
+  if [ "$_import_rc" -eq 0 ]; then
+    ok "streamed $TAG into msb image cache ($ENGINE save | msb image load)"
+  else
+    block "could not import the image into msb (see /tmp/acq-msb-imgload.log); skipping msb"
+    tail -5 /tmp/acq-msb-imgload.log 2>/dev/null | sed 's/^/        /'
+    return 0
+  fi
+  _bounded "$ACQ" --backend msb rm imgverify-msb
+  # ACQ_MSB_PULL=never so msb uses the just-loaded cache entry rather than trying
+  # to pull the localhost ref from a registry (see acq.backends/msb.sh).
+  info "msb: acq --image $TAG create shell (cached, --pull never)"
+  if printf 'N\n' | ACQ_MSB_PULL=never "$ACQ" --backend msb --image "$TAG" create shell --name imgverify-msb "$WORKSPACE" \
+       >/tmp/acq-imgverify-msb.log 2>&1; then
+    ok "msb create with --image returned 0"
+  else
+    bad "msb create with --image failed" "$(tail -5 /tmp/acq-imgverify-msb.log)"
+    return 0
+  fi
+  local got
+  got=$(read_marker msb imgverify-msb)
+  if [ "$got" = "$MARKER" ]; then
+    ok "msb booted the CUSTOM image (marker matched)"
+  else
+    bad "msb did not boot the custom image" "expected marker '$MARKER', got '$got'"
+  fi
+  _bounded "$ACQ" --backend msb rm imgverify-msb
+}
+
+# ===========================================================================
+# SBX
+# ===========================================================================
+verify_sbx() {
+  info "SBX backend"
+  if ! command -v sbx >/dev/null 2>&1; then
+    block "sbx not on PATH — skipping sbx"; return 0
+  fi
+  # sbx pulls templates from a registry, not the host engine's local store. For a
+  # locally-built image we must import it with `sbx template load <FILE>` first.
+  # Unlike `msb image load` (which reads stdin, so we stream into it), `sbx
+  # template load` takes a FILE path and does NOT accept `-` for stdin — so the
+  # sbx path must write a temp tar. It is removed in cleanup ($TARBALL).
+  info "sbx: import the local image via 'sbx template load'"
+  TARBALL=$(mktemp "${TMPDIR:-/tmp}/acq-imgverify.XXXXXX.tar")
+  if "$ENGINE" save "$TAG" -o "$TARBALL" >/tmp/acq-imgsave.log 2>&1; then
+    ok "saved $TAG to a tarball via $ENGINE save"
+  else
+    block "could not '$ENGINE save' the image; skipping sbx"; return 0
+  fi
+  if sbx template load "$TARBALL" >/tmp/acq-tplload.log 2>&1; then
+    ok "sbx template load imported the image"
+  else
+    block "sbx template load failed (see /tmp/acq-tplload.log); skipping sbx"
+    tail -5 /tmp/acq-tplload.log 2>/dev/null | sed 's/^/        /'
+    return 0
+  fi
+  _bounded "$ACQ" --backend sbx rm imgverify-sbx
+  # The base is the `shell` variant, so run the `shell` agent to match the variant.
+  # ACQ_DEBUG=1 so acq logs the exact `sbx create …` line for the trace assertion.
+  # A real workspace path is REQUIRED: without one acq prompts "workspace does not
+  # exist" and a piped `N` cancels the create. Use the throwaway WORKSPACE dir.
+  info "sbx: acq --image $TAG create shell $WORKSPACE"
+  if printf 'N\n' | ACQ_DEBUG=1 "$ACQ" --backend sbx --image "$TAG" create shell --name imgverify-sbx "$WORKSPACE" \
+       >/tmp/acq-imgverify-sbx.log 2>&1; then
+    ok "sbx create with --image returned 0"
+  else
+    bad "sbx create with --image failed" "$(tail -5 /tmp/acq-imgverify-sbx.log)"
+    return 0
+  fi
+  # Confirm acq actually issued `sbx create --template <tag>` (belt-and-suspenders
+  # over the marker read). The create log carries acq's own notice line.
+  if grep -q "sbx create --template $TAG" /tmp/acq-imgverify-sbx.log 2>/dev/null; then
+    ok "acq issued 'sbx create --template $TAG'"
+  fi
+  local got
+  got=$(read_marker sbx imgverify-sbx)
+  if [ "$got" = "$MARKER" ]; then
+    ok "sbx booted the CUSTOM template (marker matched)"
+  else
+    bad "sbx did not boot the custom template" "expected marker '$MARKER', got '$got'"
+  fi
+  _bounded "$ACQ" --backend sbx rm imgverify-sbx
+}
+
+# ===========================================================================
+# Run
+# ===========================================================================
+info "preconditions"
+if [ -n "$ENGINE" ]; then
+  ok "container engine for build: $ENGINE (daemon reachable)"
+else
+  # Distinguish "no CLI at all" from "CLI present but daemon down" so the user
+  # knows whether to install an engine or just start one (e.g. Docker Desktop
+  # not running, and podman also unreachable).
+  _present=""
+  command -v docker >/dev/null 2>&1 && _present="$_present docker"
+  command -v podman >/dev/null 2>&1 && _present="$_present podman"
+  if [ -n "$_present" ]; then
+    block "engine CLI present ($(echo "$_present" | sed 's/^ //')) but no daemon responded to '\''info'\'' — start Docker Desktop or the podman machine, then re-run"
+  else
+    block "no docker/podman CLI — install one (podman is fine; Docker Desktop is not required)"
+  fi
+fi
+command -v curl >/dev/null 2>&1 && ok "curl on PATH" || true
+
+if ! build_image; then
+  # Without a built image there is nothing to verify live; surface BLOCKED, not FAIL.
+  printf '\n  passed: %d   failed: %d   blocked: %d\n' "$PASS" "$FAIL" "$BLOCKED"
+  [ "$FAIL" -eq 0 ] && exit 0 || exit 1
+fi
+
+# Throwaway workspace to mount into the sandbox. It MUST exist: acq's create/run
+# pre-flight prompts to create a missing workspace, and the piped `N` we feed to
+# decline the github-scope prompt would cancel the whole create (the sbx failure
+# seen on the first live run). Removed in cleanup.
+WORKSPACE=$(mktemp -d "${TMPDIR:-/tmp}/acq-imgverify-ws.XXXXXX")
+
+case "$ONLY" in
+  sbx) verify_sbx ;;
+  msb) verify_msb ;;
+  "")  verify_msb; verify_sbx ;;
+esac
+
+printf '\n  passed: %d   failed: %d   blocked: %d\n' "$PASS" "$FAIL" "$BLOCKED"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Context
`acq`'s neutral adapter contract (ADR-0010) never carried a base image, so choosing a custom image was per-backend and asymmetric: msb had `ACQ_MSB_IMAGE`, sbx had no acq-level knob. This adds one neutral way to select a custom base image across both backends. Implements [ADR-0022](docs/adr/0022-neutral-image-override.md).

AI-assisted (OpenCode, claude-opus). Human-owned and reviewed.

## What changed
- **Neutral knob `--image <ref>` / `ACQ_IMAGE`**, accepted both as a pre-subcommand global (`acq --backend msb --image REF create …`) and after run/create. acq-owned; never forwarded raw to the backend CLI.
  - **msb** -> the `msb create` OCI image positional (the `ACQ_MSB_IMAGE` slot).
  - **sbx** -> `sbx create --template <ref>` (injected only if the user didn't pass their own `--template`/`-t`).
- **Precedence:** `--image` > `ACQ_IMAGE` > backend var/default; a set `ACQ_MSB_IMAGE` wins over the neutral value with a one-time notice.
- **`ACQ_MSB_PULL`** (`always|if-missing|never`) -> `msb create --pull`, so a locally-`msb image load`ed image can be used with `--pull never`.
- Re-attach with `--image` warns (create-only, ADR-0022) rather than silently ignoring.
- **Registry-agnostic auth hint on a failed custom-image pull.** When a pull is denied, acq adds a targeted remediation on top of the backend's raw error, derived from the actual image's registry host (not a hardcoded host list): `msb registry login <host>` or `sbx secret set --registry <host>`, or the local-import path for a registry-less image (and never a spurious "login to localhost"). The msb path replaces a former hardcoded `ghcr.io|azurecr|private` case; the sbx path previously surfaced only the backend's bare error.
- Docs: `docs/BACKEND_GUIDE.md` "Custom base image" section documents the portable image contract, registry auth for each backend, and a devcontainer wrapper recipe.

## Verification
- **Offline suite:** `./scripts/test-acq` -> **1032 passed, 0 failed** (adds flag/env/precedence/`--template`/`--pull`/re-attach assertions, registry-host parsing + auth-hint tests for both backends incl. a failed-create end-to-end, and hardens two pre-existing `self-repair` tests that depended on parent-process state).
- **Live, both backends, both container engines** via `./scripts/verify-image-override`:

<details><summary>Docker</summary>

```
== MSB backend ==
  ok   streamed localhost/acq-verify-image:test into msb image cache (docker save | msb image load)
  ok   msb create with --image returned 0
  ok   msb booted the CUSTOM image (marker matched)
== SBX backend ==
  ok   sbx template load imported the image
  ok   acq issued 'sbx create --template localhost/acq-verify-image:test'
  ok   sbx booted the CUSTOM template (marker matched)
  passed: 11   failed: 0   blocked: 0
```
</details>

<details><summary>Podman (Docker Desktop down)</summary>

```
  ok   container engine for build: podman (daemon reachable)
== MSB backend ==
  ok   streamed localhost/acq-verify-image:test into msb image cache (podman save | msb image load)
  ok   msb booted the CUSTOM image (marker matched)
== SBX backend ==
  ok   sbx booted the CUSTOM template (marker matched)
  passed: 11   failed: 0   blocked: 0
```
</details>

- **shellcheck** (`--severity=warning`, one file per invocation per AGENTS.md): clean on `acq`, `acq.backends/*.sh`, `scripts/verify-image-override`.
  > [!WARNING]
  > `scripts/test-acq` could not be shellcheck'd on the dev host — shellcheck OOMs on the ~7.7k-line harness with the memory available there. It is syntactically valid (`bash -n`) and the pre-commit hook / CI must lint it on a normally-resourced machine.
- **markdownlint:** 0 errors.

## Rollback
Revert the two commits on this branch; no state migration. The knob is opt-in (unset = the prior default image on each backend).

## Security impact
No new attack surface: `--image` selects a base image at sandbox creation only; registry auth is delegated to the backends' existing credential stores; the sandbox remains the security boundary.