### PR TITLE
docs: fix multi-directory mount guidance + add neutral CONCEPTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ and the [Full sbx CLI Guide](docs/QUICKSTART_SBX.md).
 
 **Working across multiple repos?** Mounting extra directories works on either
 backend via `acq`; the command syntax and examples are documented in
-[Multiple Workspaces](docs/QUICKSTART_SBX.md#multiple-workspaces).
+[Multiple Workspaces](docs/CONCEPTS.md#multiple-workspaces).
 
 ---
 

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -6,7 +6,7 @@ tier: 2
 last_updated: "2026-08-18"
 audience: "developers"
 keywords: ["acq", "backend", "sbx", "msb", "microsandbox", "tradeoffs"]
-related_files: ["docs/QUICKSTART.md", "docs/QUICKSTART_SBX.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md", "docs/adr/0014-neutral-port-publish-and-background-vocab.md", "docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md"]
+related_files: ["docs/QUICKSTART.md", "docs/QUICKSTART_SBX.md", "docs/CONCEPTS.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md", "docs/adr/0014-neutral-port-publish-and-background-vocab.md", "docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md"]
 load_priority: "on-demand"
 review_cycle: "quarterly"
 ---
@@ -304,10 +304,10 @@ msb does **not** create the host mount path, so each host workspace path must
 already exist — `acq` errors clearly if one does not.
 
 The msb backend mounts every workspace at the **same absolute path inside the
-guest** (matching sbx's multi-workspace semantics — see
-`docs/QUICKSTART_SBX.md`): `acq run opencode /my/repo` makes the repo appear at
-`/my/repo` in the sandbox. Extra workspaces and a trailing `:ro` marker work the
-same as sbx:
+guest** (matching sbx's multi-workspace semantics — see the canonical
+[Multiple Workspaces](CONCEPTS.md#multiple-workspaces) concept): `acq run
+opencode /my/repo` makes the repo appear at `/my/repo` in the sandbox. Extra
+workspaces and a trailing `:ro` marker work the same as sbx:
 
 ```bash
 acq --backend msb run opencode ~/projects/app ~/projects/lib:ro
@@ -315,8 +315,9 @@ acq --backend msb run opencode ~/projects/app ~/projects/lib:ro
 ```
 
 **Starting directory:** the agent starts in the **primary** (first) workspace,
-matching sbx (`docs/QUICKSTART_SBX.md`: "Primary workspace — the first path;
-agent starts here"). Override the start dir with `ACQ_MSB_WORKSPACE`.
+matching sbx (see [Multiple Workspaces](CONCEPTS.md#multiple-workspaces):
+"Primary workspace — the first path; the agent starts here"). Override the start
+dir with `ACQ_MSB_WORKSPACE`.
 
 **Symlinked host paths are canonicalized.** msb cannot mount a symlinked host
 path — it fails to start with `mount ...: Not a directory (os error 20)`, even

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -1,0 +1,95 @@
+---
+title: "acq Concepts"
+description: "Backend-neutral concepts for working with acq sandboxes (workspaces, mounts)"
+status: canonical
+tier: 2
+last_updated: "2026-08-21"
+audience: "developers"
+keywords: ["acq", "concepts", "workspace", "mount", "backend-neutral", "sbx", "msb"]
+related_files: ["docs/QUICKSTART.md", "docs/BACKEND_GUIDE.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
+load_priority: "on-demand"
+review_cycle: "quarterly"
+---
+
+# acq Concepts
+
+Cross-cutting concepts for working with `acq` sandboxes. These apply to **both**
+backends (sbx and msb) because `acq` presents one neutral interface over both.
+For per-backend strengths, tradeoffs, and caveats, see the
+[Backend Guide](BACKEND_GUIDE.md).
+
+---
+
+## Multiple Workspaces
+
+You can mount additional directories alongside the primary workspace when
+creating a sandbox. This is useful when you need to reference multiple repos or
+folders from one sandbox session — for example, editing an app while reading a
+reference library or the playbook.
+
+`acq` supports the multi-workspace positional list on **both** backends with
+identical syntax, so this is the canonical, backend-neutral way to mount extra
+directories.
+
+### Syntax
+
+```bash
+acq run <agent> <primary-workspace> [extra-workspace][:ro] ...
+# e.g.
+acq run opencode ~/projects/app ~/projects/lib:ro
+```
+
+- **Primary workspace** — the first path. The agent starts here, and it is
+  mounted read/write.
+- **Extra workspaces** — additional paths the agent can access. Each mounts at
+  its **absolute host path** inside the sandbox (e.g. `~/projects/lib` appears at
+  `/Users/you/projects/lib`), matching across backends.
+- **`:ro` suffix** — mounts that extra workspace read-only. Recommended for
+  reference repos so the agent cannot modify them.
+- **Mounts are fixed at creation** — you cannot add or remove workspaces from an
+  existing sandbox. To change mounts, remove the sandbox (`acq rm <name>`) and
+  recreate it with the new paths.
+
+The same positional list works with `acq create` when you want to name a sandbox
+without attaching immediately:
+
+```bash
+acq create <agent> <primary-workspace> [extra-workspace][:ro] ...
+```
+
+### Example: app repo + read-only reference
+
+```bash
+# Primary: your app (read/write)
+# Secondary: the playbook, read-only reference
+acq run opencode ~/projects/my-app ~/projects/agentic-coding-playbook:ro
+```
+
+The agent can edit `~/projects/my-app` and read from
+`~/projects/agentic-coding-playbook` without risk of modifying the reference
+content.
+
+### Security recommendation
+
+Prefer read-only (`:ro`) mounts for secondary workspaces unless the agent
+genuinely needs write access. This limits accidental modification and reduces
+the blast radius of agent errors.
+
+> [!WARNING]
+> Mounted directories expose **all content** to the agent, including `.env`
+> files, `.git/config` (which may contain tokens), and any secrets in the
+> mounted path. Mount only what the agent needs. Prefer selective, targeted
+> mounts over mounting parent or home directories.
+
+### Backend caveats
+
+The syntax and semantics above are identical across backends, but each backend
+has a few mechanics worth knowing. Rather than duplicate them here, see the
+[Backend Guide](BACKEND_GUIDE.md) for:
+
+- **msb** — each host workspace path must already exist (msb does not create the
+  host mount path), and symlinked host paths (notably macOS `$TMPDIR`) are
+  canonicalized to their real path before mounting.
+- **sbx** — the `--clone` remote-clone lifecycle interacts with multi-workspace
+  mounts; see the [sbx how-to guide](QUICKSTART_SBX.md) for the sbx-specific
+  clone story.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,7 +6,7 @@ tier: 2
 last_updated: "2026-08-17"
 audience: "developers"
 keywords: ["acq", "backend", "sbx", "msb", "quickstart", "sandbox"]
-related_files: ["docs/BACKEND_GUIDE.md", "docs/QUICKSTART_SBX.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
+related_files: ["docs/BACKEND_GUIDE.md", "docs/CONCEPTS.md", "docs/QUICKSTART_SBX.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
 load_priority: "on-demand"
 review_cycle: "quarterly"
 ---
@@ -228,8 +228,9 @@ sbx policy set <your-network-policy>
 ./acq --backend sbx run opencode /path/to/your/project
 ```
 
-For sbx-specific detail (proxy secrets, multiple workspaces, network policy),
-see the [full sbx guide](QUICKSTART_SBX.md).
+For sbx-specific detail (proxy secrets, network policy), see the
+[full sbx guide](QUICKSTART_SBX.md). For the backend-neutral way to mount
+multiple directories, see [Multiple Workspaces](CONCEPTS.md#multiple-workspaces).
 
 ### msb host setup
 

--- a/docs/QUICKSTART_SBX.md
+++ b/docs/QUICKSTART_SBX.md
@@ -427,68 +427,15 @@ echo "$DOCKER_PAT" | sbx login --password-stdin --username "$DOCKER_USER"
 
 ## Multiple Workspaces
 
-You can mount additional directories alongside the primary workspace when creating a sandbox. This
-is useful when you need to reference multiple repos or folders from one sandbox session.
+Mounting extra directories alongside the primary workspace is a **backend-neutral**
+feature: the `acq run <agent> <primary> [extra][:ro] ...` syntax works
+identically on sbx and msb. The canonical description — syntax, semantics,
+constraints, and security guidance — lives in
+[Multiple Workspaces](CONCEPTS.md#multiple-workspaces).
 
-### Syntax
-
-```bash
-sbx run <agent> <primary-workspace> [extra-workspace]:ro [extra-workspace]:ro ...
-```
-
-- **Primary workspace** — The first path; agent starts here. Read/write by default.
-- **Extra workspaces** — Additional paths the agent can access.
-- **`:ro` suffix** — Mounts extra workspaces as read-only (recommended for reference repos).
-
-All workspaces appear inside the sandbox at their absolute host paths.
-
-### Example: App Repo + Playbook Reference
-
-```bash
-# Primary: your app (read/write)
-# Secondary: agentic-coding-playbook (read-only reference)
-sbx run opencode ~/projects/my-app ~/projects/agentic-coding-playbook:ro
-```
-
-The agent can edit `~/projects/my-app` and read from `~/projects/agentic-coding-playbook` without
-risk of modifying the playbook content.
-
-### Example: Frontend + Backend Repos
-
-```bash
-# Primary: backend (read/write)
-# Secondary: frontend (read-only for now)
-sbx run opencode ~/projects/backend ~/projects/frontend:ro
-```
-
-### Important Constraints
-
-| Constraint | Detail |
-|------------|--------|
-| Mounts are fixed at creation | You cannot add or remove workspaces from an existing sandbox |
-| Changing mounts requires recreation | `sbx rm <name>` then recreate with new paths |
-| `:ro` applies to extra workspaces only | Primary workspace is always read/write in direct mode |
-| Mounted content is visible to agent | Only mount what the agent needs to see |
-
-### When to Use Multi-Workspace
-
-| Use Case | Recommended Setup |
-|----------|-------------------|
-| Reference standards/skills from playbook | Primary: your app, Secondary: playbook `:ro` |
-| Cross-repo code review | Primary: repo under review, Secondary: related repos `:ro` |
-| Docs + implementation side by side | Primary: implementation, Secondary: docs `:ro` |
-| Monorepo-style multi-package work | Primary: one package, Secondary: shared libs `:ro` |
-
-### Security Recommendation
-
-Prefer read-only mounts for secondary workspaces unless the agent genuinely needs write access. This
-limits accidental modifications and reduces the blast radius of agent errors.
-
-> [!WARNING]
-> Mounted directories expose **all content** to the agent, including `.env` files, `.git/config`
-> (which may contain tokens), and any secrets in the mounted path. Avoid mounting directories that
-> contain sensitive files you do not want the agent to see. Use selective, targeted mounts rather
-> than mounting parent or home directories.
+The only sbx-specific angle is how multi-workspace mounts interact with the
+`--clone` remote-clone lifecycle, covered below under
+[Clone Mode + Multiple Workspaces](#clone-mode--multiple-workspaces).
 
 ---
 


### PR DESCRIPTION
Part of the epic GSA-TTS/agentic-coding-quickstart#348. Closes GSA-TTS/agentic-coding-quickstart#349.

> **Stacked PR.** Base is `feat/neutral-image-override` (GSA-TTS/agentic-coding-quickstart#358). Review/merge order: #358 → **this** → #354 → #350 → #351 → #352 → #353. GitHub auto-retargets the base as lower PRs merge.

## Context
The README says mounting extra directories "works on either backend via `acq`", but the linked **Multiple Workspaces** section lived in the sbx guide and was written entirely in raw `sbx run` syntax — contradicting the neutral claim. `acq` supports the multi-workspace positional list identically on both backends.

## What changed
- Add `docs/CONCEPTS.md` owning cross-cutting, backend-neutral concepts, seeded with a **Multiple Workspaces** section in `acq` terms (`acq run <agent> <primary> [extra][:ro] ...`).
- Repoint README, `docs/QUICKSTART.md`, and `docs/BACKEND_GUIDE.md` at the neutral concept doc.
- Trim the sbx guide's Multiple Workspaces section to its genuinely sbx-specific angle (the `--clone` lifecycle) and link back to `CONCEPTS.md`.
- Update `related_files` frontmatter for the new doc.

## Verification
- `npm run lint:md` → 0 errors
- `./scripts/test-acq` → 1032 passed, 0 failed
- Markdown link/anchor check: `#multiple-workspaces` resolves from all repointed links
- **Live mount smoke-check (§8.3):** human-run on a sandbox-capable host — `acq run opencode ./ppp ./rjsf-agent:ro` mounted both host paths and reached a functional TUI. ✅

## Rollback
Revert this commit; docs-only, no state.

## Security impact
None (documentation only).

AI-assisted (OpenCode, claude_4_8_opus). Human-owned and reviewed.
