### PR TITLE
docs!: rename QUICKSTART*.md to docs/howto/{acq,sbx}.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -27,7 +27,7 @@ body:
     id: location
     attributes:
       label: Which document?
-      description: File path or section (e.g., "README.md Quick Start" or "docs/QUICKSTART_SBX.md")
+      description: File path or section (e.g., "README.md Quick Start" or "docs/howto/sbx.md")
       placeholder: "README.md"
     validations:
       required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ tier: 1
 last_updated: "2026-08-18"
 audience: "developers"
 keywords: ["AGENTS.md", "acq", "sbx", "msb", "usai", "sandbox", "agent-rules", "workspace"]
-related_files: ["docs/QUICKSTART.md", "docs/BACKEND_GUIDE.md", "docs/KNOWN_FAILURE_MODES.md", "docs/adr/0001-sbx-usai-agent-execution-architecture.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
+related_files: ["docs/howto/acq.md", "docs/BACKEND_GUIDE.md", "docs/KNOWN_FAILURE_MODES.md", "docs/adr/0001-sbx-usai-agent-execution-architecture.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
 load_priority: "always"
 review_cycle: "quarterly"
 ---
@@ -435,7 +435,7 @@ real value in on the wire. Both keep the real secret out of the agent's hands.
 
 See [`docs/BACKEND_GUIDE.md`](docs/BACKEND_GUIDE.md) for the full per-backend
 credential-injection and secret-binding model (and
-[`docs/QUICKSTART_SBX.md`](docs/QUICKSTART_SBX.md) for SBX-specific proxy
+[`docs/howto/sbx.md`](docs/howto/sbx.md) for SBX-specific proxy
 patterns).
 
 ---

--- a/CONTEXT-GUIDE.md
+++ b/CONTEXT-GUIDE.md
@@ -35,7 +35,7 @@ These define the behavioral contract. Load for **every task**.
 
 | Document | Load When Task Involves |
 |----------|------------------------|
-| `docs/QUICKSTART_SBX.md` | Setting up SBX, running agents, USAi configuration, first-time setup |
+| `docs/howto/sbx.md` | Setting up SBX, running agents, USAi configuration, first-time setup |
 | `docs/KNOWN_FAILURE_MODES.md` | Debugging SBX/USAi issues, troubleshooting, error diagnosis |
 | `docs/adr/0001-sbx-usai-agent-execution-architecture.md` | Understanding SBX architecture decisions, isolation rationale |
 
@@ -53,6 +53,6 @@ Load only when the specific activity is being performed.
 | Task Type | Load |
 |-----------|------|
 | Code generation/review | Tier 1 only |
-| SBX + USAi setup | Tier 1 + QUICKSTART_SBX.md |
+| SBX + USAi setup | Tier 1 + docs/howto/sbx.md |
 | Debugging agent issues | Tier 1 + KNOWN_FAILURE_MODES.md |
 | Pre-deployment review | Tier 1 + checklist |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ This project operates under professional standards of conduct. All contributors:
 2. Read the core documentation:
    - `AGENTS.md` — Behavioral rules for AI agents
    - [`CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md) (GSA agentic-coding-playbook) — Secure coding standards
-   - `docs/QUICKSTART_SBX.md` — sbx CLI setup guide
+   - `docs/howto/sbx.md` — sbx CLI setup guide
 
 3. Follow the quickstart to set up your environment
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ configures the environment for federal usage. To provide that isolation, it uses
 (microsandbox), a lightweight, open-source microVM runtime.
 
 > acq is designed to support multiple isolation backends. A Docker Sandboxes (**`sbx`**) backend
-> is also supported. See [docs/QUICKSTART_SBX.md](docs/QUICKSTART_SBX.md) for sbx setup and
+> is also supported. See [docs/howto/sbx.md](docs/howto/sbx.md) for sbx setup and
 > [docs/BACKEND_GUIDE.md](docs/BACKEND_GUIDE.md) for how the two backends compare.
 
 ## Agentic Coding Ecosystem
@@ -48,9 +48,9 @@ and GitHub access interactively on first run (see [Step 3](#step-3-create-and-ru
 
 | Requirement     | Notes                                                      |
 | --------------- | ---------------------------------------------------------- |
-| A supported host for microVMs | msb uses hardware virtualization. You need one of:<ul><li>**macOS** — Apple Silicon (Intel Macs are not supported)</li><li>**Windows 11** — with the Windows Hypervisor Platform enabled (preview)</li><li>**Linux** — glibc-based, with KVM enabled (`/dev/kvm` present)</li></ul>If you need more detail than this, see [msb host setup](docs/QUICKSTART.md#msb-host-setup) for per-platform particulars. |
+| A supported host for microVMs | msb uses hardware virtualization. You need one of:<ul><li>**macOS** — Apple Silicon (Intel Macs are not supported)</li><li>**Windows 11** — with the Windows Hypervisor Platform enabled (preview)</li><li>**Linux** — glibc-based, with KVM enabled (`/dev/kvm` present)</li></ul>If you need more detail than this, see [msb host setup](docs/howto/acq.md#msb-host-setup) for per-platform particulars. |
 | `git`           | Already installed on macOS and on the supported Linux hosts — **nothing to do**. (On macOS, the first time you run a `git` command the system may offer to install the Command Line Tools; accept it.) Check with `git --version`. |
-| USAi API key    | **Required, but `acq` guides you** — on first run `acq` prompts you to paste a key and validates it, so you need not configure anything beforehand. You will need to [create a key](https://console.gsa.usai.gov/key-management) (do it now or when prompted); USAi keys expire every 7 days. <p>Running **non-interactively** (CI/piped) has no prompt, so the key must be set in advance — see [Secrets](docs/QUICKSTART.md#secrets).</p> |
+| USAi API key    | **Required, but `acq` guides you** — on first run `acq` prompts you to paste a key and validates it, so you need not configure anything beforehand. You will need to [create a key](https://console.gsa.usai.gov/key-management) (do it now or when prompted); USAi keys expire every 7 days. <p>Running **non-interactively** (CI/piped) has no prompt, so the key must be set in advance — see [Secrets](docs/howto/acq.md#secrets).</p> |
 | GitHub token | **Nothing to get in advance** — `acq` offers to walk you through creating a repo-scoped token on first run, when your project contains GitHub repos. You can decline and add one later. <p>(A token lets the agent authenticate to GitHub, work with private repositories, and act on your behalf — open PRs, push to branches, etc.)</p> |
 
 ### Step 1: Install microsandbox (msb)
@@ -141,7 +141,7 @@ On first run, `acq` sets you up interactively — nothing to configure beforehan
 
 `acq` injects secrets into the sandbox at runtime — the real values **never
 enter the guest**. To set secrets ahead of time (for CI or scripted setups),
-see [Secrets](docs/QUICKSTART.md#secrets) in the acq Quickstart.
+see [Secrets](docs/howto/acq.md#secrets) in the acq how-to.
 
 > [!NOTE]
 > Sandboxes sign your git commits with your host SSH key on **both** backends —
@@ -157,8 +157,8 @@ see [Secrets](docs/QUICKSTART.md#secrets) in the acq Quickstart.
 **Want to know more about what `acq` is doing under the hood?** See [How It Works](#how-it-works).
 
 **Need more details, or want to use the sbx backend instead?** See the
-[acq Quickstart](docs/QUICKSTART.md), the [Backend Guide](docs/BACKEND_GUIDE.md),
-and the [Full sbx CLI Guide](docs/QUICKSTART_SBX.md).
+[acq How-To](docs/howto/acq.md), the [Backend Guide](docs/BACKEND_GUIDE.md),
+and the [Full sbx CLI Guide](docs/howto/sbx.md).
 
 **Working across multiple repos?** Mounting extra directories works on either
 backend via `acq`; the command syntax and examples are documented in
@@ -455,9 +455,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 | `scripts/verify-backends`           | Live end-to-end backend verification (needs Docker or KVM) |
 | `.pre-commit-config.yaml`           | Optional pre-commit hooks (secret detection, file hygiene) |
 | `AGENTS.md`                         | Rules for working **on this quickstart repo**              |
-| `docs/QUICKSTART.md`                | acq quickstart and backend selection guide                |
+| `docs/howto/acq.md`                 | acq how-to guide and backend selection                     |
 | `docs/BACKEND_GUIDE.md`             | Per-backend strengths, tradeoffs, and configuration       |
-| `docs/QUICKSTART_SBX.md`            | Full sbx CLI setup guide                                   |
+| `docs/howto/sbx.md`                 | Full sbx CLI setup guide                                   |
 | `docs/KNOWN_FAILURE_MODES.md`       | Troubleshooting guide                                      |
 
 ---

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@ guidance for running AI coding agents in isolated environments.
 ## Documentation
 
 - [README](README.md) — overview and 5-minute quick start
-- [docs/QUICKSTART.md](docs/QUICKSTART.md) — start here
+- [docs/howto/acq.md](docs/howto/acq.md) — start here
 - [docs/](docs/) — full documentation (backend guide, troubleshooting, ADRs)
 
 ## Questions or help

--- a/acq
+++ b/acq
@@ -3,7 +3,7 @@
 # acq — pluggable-backend wrapper for agentic-coding-quickstart
 #
 # acq wraps a sandbox backend (msb or sbx) and applies the shared neutral kits.
-# See `acq help` for usage, or docs/QUICKSTART.md and docs/BACKEND_GUIDE.md.
+# See `acq help` for usage, or docs/howto/acq.md and docs/BACKEND_GUIDE.md.
 
 set -euo pipefail
 
@@ -140,7 +140,7 @@ run/create flags:
   --image REF          Same as the global --image above; accepted here too so
                        `acq create AGENT --image REF PATH` works.
 
-See docs/QUICKSTART.md and docs/BACKEND_GUIDE.md for more.
+See docs/howto/acq.md and docs/BACKEND_GUIDE.md for more.
 HELP
 }
 

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -694,7 +694,7 @@ acq_backend_prepare() {
   echo "      msb needs host virtualization (KVM on Linux, Apple Silicon's" >&2
   echo "      hypervisor on macOS, or the Windows Hypervisor Platform on Windows)." >&2
   echo "      acq tried 'msb doctor --fix' automatically but the host is still not" >&2
-  echo "      ready. For details run 'msb doctor', see docs/QUICKSTART.md#msb-host-setup," >&2
+  echo "      ready. For details run 'msb doctor', see docs/howto/acq.md#msb-host-setup," >&2
   echo "      or ask us for help at agentic-coding@gsa.gov." >&2
 }
 
@@ -2528,17 +2528,17 @@ EOF
 
   # Translate the caller's workspace path(s) into --volume mounts.
   #
-  # CONTRACT (matches sbx semantics — see docs/QUICKSTART_SBX.md "Multiple
+  # CONTRACT (matches sbx semantics — see docs/CONCEPTS.md "Multiple
   # Workspaces"): every workspace positional after the agent is mounted at its
-  # SAME absolute path inside the guest ("All workspaces appear inside the
-  # sandbox at their absolute host paths."). A trailing `:ro` marks that mount
+  # SAME absolute path inside the guest (all workspaces appear inside the
+  # sandbox at their absolute host paths). A trailing `:ro` marks that mount
   # read-only. `acq run opencode ~/app ~/lib:ro` therefore mounts ~/app rw and
   # ~/lib ro, each at its own host path.
   #
   # STARTING DIRECTORY (ACQ_MSB_GUEST_WORKSPACE, consumed by attach): the FIRST
   # workspace positional is the "primary" — the agent starts there — regardless
-  # of how many mounts are given (docs/QUICKSTART_SBX.md: "Primary workspace —
-  # The first path; agent starts here."). ACQ_MSB_WORKSPACE overrides it.
+  # of how many mounts are given (docs/CONCEPTS.md: the primary workspace is the
+  # first path and the agent starts there). ACQ_MSB_WORKSPACE overrides it.
   #
   # Why mount at the host path (not remapped under /home/agent): `msb create`
   # performs the mount at create time, BEFORE acq can create the `agent` user and

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -6,7 +6,7 @@ tier: 2
 last_updated: "2026-08-18"
 audience: "developers"
 keywords: ["acq", "backend", "sbx", "msb", "microsandbox", "tradeoffs"]
-related_files: ["docs/QUICKSTART.md", "docs/QUICKSTART_SBX.md", "docs/CONCEPTS.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md", "docs/adr/0014-neutral-port-publish-and-background-vocab.md", "docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md"]
+related_files: ["docs/howto/acq.md", "docs/howto/sbx.md", "docs/CONCEPTS.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md", "docs/adr/0014-neutral-port-publish-and-background-vocab.md", "docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md"]
 load_priority: "on-demand"
 review_cycle: "quarterly"
 ---

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -6,7 +6,7 @@ tier: 2
 last_updated: "2026-08-21"
 audience: "developers"
 keywords: ["acq", "concepts", "workspace", "mount", "backend-neutral", "sbx", "msb"]
-related_files: ["docs/QUICKSTART.md", "docs/BACKEND_GUIDE.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
+related_files: ["docs/howto/acq.md", "docs/BACKEND_GUIDE.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
 load_priority: "on-demand"
 review_cycle: "quarterly"
 ---
@@ -91,5 +91,5 @@ has a few mechanics worth knowing. Rather than duplicate them here, see the
   host mount path), and symlinked host paths (notably macOS `$TMPDIR`) are
   canonicalized to their real path before mounting.
 - **sbx** — the `--clone` remote-clone lifecycle interacts with multi-workspace
-  mounts; see the [sbx how-to guide](QUICKSTART_SBX.md) for the sbx-specific
+  mounts; see the [sbx how-to guide](howto/sbx.md) for the sbx-specific
   clone story.

--- a/docs/PRE_COMMIT_SETUP.md
+++ b/docs/PRE_COMMIT_SETUP.md
@@ -133,5 +133,5 @@ echo "path/to/file:line-number" >> .gitleaksignore
 
 ## Next Steps
 
-- [sbx CLI Quickstart](QUICKSTART_SBX.md) — Main setup guide
+- [sbx CLI How-To](howto/sbx.md) — Main setup guide
 - [Known Failure Modes](KNOWN_FAILURE_MODES.md) — Common issues and solutions

--- a/docs/howto/acq.md
+++ b/docs/howto/acq.md
@@ -1,22 +1,24 @@
 ---
-title: "acq Backend Quickstart"
-description: "Get running with acq, the pluggable-backend wrapper for agentic-coding-quickstart"
+title: "acq How-To Guide"
+description: "Detailed how-to for acq, the pluggable-backend wrapper for agentic-coding-quickstart"
 status: canonical
 tier: 2
-last_updated: "2026-08-17"
+last_updated: "2026-08-21"
 audience: "developers"
-keywords: ["acq", "backend", "sbx", "msb", "quickstart", "sandbox"]
-related_files: ["docs/BACKEND_GUIDE.md", "docs/CONCEPTS.md", "docs/QUICKSTART_SBX.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
+keywords: ["acq", "backend", "sbx", "msb", "howto", "sandbox"]
+related_files: ["docs/BACKEND_GUIDE.md", "docs/CONCEPTS.md", "docs/howto/sbx.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
 load_priority: "on-demand"
 review_cycle: "quarterly"
 ---
 
-# acq Backend Quickstart
+# acq How-To Guide
 
-> **`acq` is the entry point.** It provides a pluggable-backend architecture
-> supporting two backends — **msb** (microsandbox, the default) and **sbx**
-> (Docker Sandboxes) — sharing one neutral kit vocabulary. Install a backend and
-> `acq` runs the same commands on either one.
+> The [README](../../README.md) is the quickstart — the fast path to a running
+> sandbox. This guide is the deeper how-to for `acq`, the entry point. It
+> provides a pluggable-backend architecture supporting two backends — **msb**
+> (microsandbox, the default) and **sbx** (Docker Sandboxes) — sharing one
+> neutral kit vocabulary. Install a backend and `acq` runs the same commands on
+> either one.
 
 ---
 
@@ -30,7 +32,7 @@ once (install one, and it auto-detects). Pick the one that fits your environment
 | **msb** | `curl -fsSL https://install.microsandbox.dev \| sh` | You want a FOSS microVM runtime, no Docker seat, snapshots |
 | **sbx** | `brew install docker/tap/sbx && sbx login` | You have Docker and want the commercial product |
 
-See [docs/BACKEND_GUIDE.md](BACKEND_GUIDE.md) for a full comparison. `acq`
+See [docs/BACKEND_GUIDE.md](../BACKEND_GUIDE.md) for a full comparison. `acq`
 auto-detects an installed backend (msb preferred when both are present); persist
 a choice with `acq backend set <sbx|msb>` or `acq doctor`.
 
@@ -46,7 +48,7 @@ a choice with `acq backend set <sbx|msb>` or `acq doctor`.
 
 ### Step 1: Prerequisites (msb)
 
-Complete the standard setup in [README.md](../README.md#5-minute-quickstart):
+Complete the standard setup in [README.md](../../README.md#5-minute-quickstart):
 
 - Install the `msb` CLI: `curl -fsSL https://install.microsandbox.dev | sh`
 - Run `msb doctor` (add `--fix` to set up KVM/HVF/WHP virtualization)
@@ -56,7 +58,7 @@ Re-run `msb doctor` once more after setup — a clean `doctor` pass is the quick
 way to confirm the host is ready before your first `acq run` (and, if an
 established setup later starts failing every outbound call at once, a wipe +
 reinstall then `msb doctor` is the first thing to try; see
-[Troubleshooting](BACKEND_GUIDE.md#troubleshooting)).
+[Troubleshooting](../BACKEND_GUIDE.md#troubleshooting)).
 
 You do **not** need to gather a USAi key or GitHub token in advance — `acq`
 prompts you for the USAi key on first run and offers to scope a GitHub token
@@ -146,7 +148,7 @@ the guest.
 > This is also what `acq run` offers interactively. Fine-grained tokens can't
 > contribute to public repos you're not a member of or call the Checks API — fall
 > back to a global token for those cases. See
-> [ADR-0013](adr/0013-per-sandbox-github-token-downscoping.md).
+> [ADR-0013](../adr/0013-per-sandbox-github-token-downscoping.md).
 
 ### Rotate your USAi key
 
@@ -166,7 +168,7 @@ the guest.
 4. Auto-detect: first installed backend found (msb preferred, then sbx)
 
 **Today (1.2.x), two backends ship: `msb` (default) and `sbx`.** See
-[docs/BACKEND_GUIDE.md](BACKEND_GUIDE.md) for per-backend details. A third
+[docs/BACKEND_GUIDE.md](../BACKEND_GUIDE.md) for per-backend details. A third
 backend (`ppp` — Podman-Plus-Proxy) is deferred.
 
 ### Persist the default backend
@@ -229,8 +231,8 @@ sbx policy set <your-network-policy>
 ```
 
 For sbx-specific detail (proxy secrets, network policy), see the
-[full sbx guide](QUICKSTART_SBX.md). For the backend-neutral way to mount
-multiple directories, see [Multiple Workspaces](CONCEPTS.md#multiple-workspaces).
+[full sbx guide](sbx.md). For the backend-neutral way to mount
+multiple directories, see [Multiple Workspaces](../CONCEPTS.md#multiple-workspaces).
 
 ### msb host setup
 
@@ -305,7 +307,7 @@ never blocks a launch. Refreshes are in place (sessions, secrets, and project
 files are kept). Skip the automatic check with `ACQ_UPDATE_CHECK=0` or
 `./acq run --no-update-check`.
 
-See [ADR-0016](adr/0016-kit-bundle-provenance-and-stale-refresh.md) for the full
+See [ADR-0016](../adr/0016-kit-bundle-provenance-and-stale-refresh.md) for the full
 design and trust model.
 
 ---
@@ -364,7 +366,7 @@ export ACQ_EXEC_READY_TIMEOUT=120
 
 ## See also
 
-- [docs/BACKEND_GUIDE.md](BACKEND_GUIDE.md) — per-backend strengths and tradeoffs
-- [docs/QUICKSTART_SBX.md](QUICKSTART_SBX.md) — detailed sbx CLI reference
-- [docs/adr/0010-acq-pluggable-backends.md](adr/0010-acq-pluggable-backends.md) — architecture decision
-- [docs/KNOWN_FAILURE_MODES.md](KNOWN_FAILURE_MODES.md) — troubleshooting
+- [docs/BACKEND_GUIDE.md](../BACKEND_GUIDE.md) — per-backend strengths and tradeoffs
+- [docs/howto/sbx.md](sbx.md) — detailed sbx CLI reference
+- [docs/adr/0010-acq-pluggable-backends.md](../adr/0010-acq-pluggable-backends.md) — architecture decision
+- [docs/KNOWN_FAILURE_MODES.md](../KNOWN_FAILURE_MODES.md) — troubleshooting

--- a/docs/howto/sbx.md
+++ b/docs/howto/sbx.md
@@ -1,9 +1,12 @@
-# sbx CLI Quickstart Guide
+# sbx CLI How-To Guide
 
+> The [README](../../README.md) is the quickstart. This is the detailed sbx
+> how-to.
+>
 > **Note:** `msb` (microsandbox) is `acq`'s **default** backend. Use this `sbx`
 > guide when you specifically want the Docker Sandboxes backend (for example, you
 > already run Docker Sandboxes, or want its proxy-based credential store). See the
-> [Backend Guide](BACKEND_GUIDE.md) to choose between backends.
+> [Backend Guide](../BACKEND_GUIDE.md) to choose between backends.
 
 This guide walks you through setting up Docker Sandboxes using the `sbx` command-line interface to run AI coding agents with USAi.
 
@@ -105,7 +108,7 @@ sbx policy ls
 > `brew uninstall erofs-utils` (so sbx uses its bundled binary), or approve the
 > Homebrew binary via **System Settings → Privacy & Security → "Allow Anyway"**
 > and re-run. `xattr -d com.apple.quarantine` does **not** work. Details:
-> [KNOWN_FAILURE_MODES.md](KNOWN_FAILURE_MODES.md#26-macos-gatekeeper-blocks-mkfserofs-at-sbx-policy-init-path-shadowing).
+> [KNOWN_FAILURE_MODES.md](../KNOWN_FAILURE_MODES.md#26-macos-gatekeeper-blocks-mkfserofs-at-sbx-policy-init-path-shadowing).
 
 ### Understanding Network Policies
 
@@ -156,7 +159,7 @@ sbx secret set -g anthropic
 > acq github-scope <sandbox-name> /path/to/your/project
 > ```
 >
-> See [ADR-0013](adr/0013-per-sandbox-github-token-downscoping.md) for the
+> See [ADR-0013](../adr/0013-per-sandbox-github-token-downscoping.md) for the
 > rationale and the alternatives considered. Fine-grained tokens can't
 > contribute to public repos you're not a member of or call the Checks API —
 > use the global token below for those cases.
@@ -390,7 +393,7 @@ sbx reset --preserve-secrets
 1. Verify USAi endpoint is allowed: `sbx policy ls`
 2. Check your API key is set: `sbx secret ls`
 3. Check policy logs: `sbx policy log`
-4. See [Known Failure Modes](KNOWN_FAILURE_MODES.md) for more
+4. See [Known Failure Modes](../KNOWN_FAILURE_MODES.md) for more
 
 ---
 
@@ -431,7 +434,7 @@ Mounting extra directories alongside the primary workspace is a **backend-neutra
 feature: the `acq run <agent> <primary> [extra][:ro] ...` syntax works
 identically on sbx and msb. The canonical description — syntax, semantics,
 constraints, and security guidance — lives in
-[Multiple Workspaces](CONCEPTS.md#multiple-workspaces).
+[Multiple Workspaces](../CONCEPTS.md#multiple-workspaces).
 
 The only sbx-specific angle is how multi-workspace mounts interact with the
 `--clone` remote-clone lifecycle, covered below under
@@ -521,13 +524,13 @@ sbx create --clone --name feature-work opencode ~/my-app ~/shared-libs:ro
 
 The Docker Desktop-integrated `docker sandbox` command is deprecated. For the
 `sbx` equivalents, see
-[Known Failure Modes — Migrating from `docker sandbox`](KNOWN_FAILURE_MODES.md#18-migrating-from-docker-sandbox).
+[Known Failure Modes — Migrating from `docker sandbox`](../KNOWN_FAILURE_MODES.md#18-migrating-from-docker-sandbox).
 
 ---
 
 ## Next Steps
 
-- [Known Failure Modes](KNOWN_FAILURE_MODES.md) — Common issues and solutions
+- [Known Failure Modes](../KNOWN_FAILURE_MODES.md) — Common issues and solutions
 - [Coding Practices](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md) — Secure coding standards (GSA agentic-coding-playbook)
 
 ---

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -3078,8 +3078,8 @@ cleanup_stubs
 
 #       its own absolute host path (sbx-parity), a trailing :ro is preserved, and
 #       the recorded start dir is the FIRST (primary) workspace regardless of how
-#       many mounts are given (docs/QUICKSTART_SBX.md: "Primary workspace — the
-#       first path; agent starts here").
+#       many mounts are given (docs/CONCEPTS.md: the primary workspace is the
+#       first path and the agent starts there).
 make_stubs; load_acq
 # Two real host dirs to mount (a nonexistent path would hard-fail provision).
 mkdir -p "$STUBDIR/ws-app" "$STUBDIR/ws-lib"


### PR DESCRIPTION
Part of the epic GSA-TTS/agentic-coding-quickstart#348. Closes GSA-TTS/agentic-coding-quickstart#350.

> **Stacked PR.** Base is `docs/354-adr-neutral-docs` (GSA-TTS/agentic-coding-quickstart#360). Order: #358 → #359 → #360 (#354) → **this** → #351 → #352 → #353.

## Context
The README is the quickstart (the fast path). The files named `docs/QUICKSTART.md` / `docs/QUICKSTART_SBX.md` are slower-paced how-to guides; the naming was misleading and didn't express the neutral-vs-backend split.

## What changed (Option B — `docs/howto/` subdir)
- `git mv docs/QUICKSTART.md → docs/howto/acq.md` and `docs/QUICKSTART_SBX.md → docs/howto/sbx.md` (history preserved; 87% / 95% similarity).
- Reframe titles so the README is the quickstart and these are the deeper how-tos.
- Repoint **all** durable references (docs, code comments, frontmatter, issue template) to the new paths.
- Fix intra-file relative links in the moved files (now one level deeper in `docs/howto/`).
- `docs/howto/msb.md` intentionally **not** created (reserved future symmetric slot — see GSA-TTS/agentic-coding-quickstart#355).

## Decisions (settled)
- **No redirect stubs** — this lands ahead of 3.0.0; hard-break of old links accepted.
- ADR bodies citing the old path are left as-is (durable historical records).

## Verification
- `rg -n 'QUICKSTART' -g '!docs/adr/**' -g '!docs/explorations/**'` → only the `QUICKSTART_CLONE` env-var name remains (not a path)
- `npm run lint:md` → 0 errors; markdown link/anchor validation clean
- `./scripts/test-acq` → 1032 passed (one comment in it edited, no logic change); `bash -n` OK
- shellcheck (one file per invocation per AGENTS.md) clean on `acq`, `acq.backends/*.sh`

> [!NOTE]
> `scripts/test-acq` (~7.7k lines) OOMs shellcheck on the dev host; it is syntactically valid (`bash -n`) and CI lints it on a normally-resourced machine — same limitation noted in GSA-TTS/agentic-coding-quickstart#358.

## Rollback
Revert this commit; docs + comment paths only, no state.

## Security impact
None (documentation + comment path updates only).

AI-assisted (OpenCode, claude_4_8_opus). Human-owned and reviewed.
