### PR TITLE
docs: neutralize generic entries in KNOWN_FAILURE_MODES.md

### DIFF
--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -61,10 +61,9 @@ Ensure header format is correct:
 Authorization: Bearer <API_KEY>
 ```
 
-Confirm SBX injected env var is present inside container:
+Confirm the injected env var is present inside the sandbox:
 ```bash
-sbx exec -it <sandbox> sh
-echo $USAI_API_KEY
+acq exec <sandbox> -- sh -c 'echo $USAI_API_KEY'
 ```
 
 ---
@@ -243,7 +242,7 @@ Set explicit timeouts in config:
 
 Check network connectivity from inside container:
 ```bash
-sbx exec <sandbox> curl -I https://api.gsa.usai.gov/api/v1/models
+acq exec <sandbox> -- curl -I https://api.gsa.usai.gov/api/v1/models
 ```
 
 ---
@@ -334,18 +333,19 @@ Config file exists on host but not mounted into container.
 
 ### Fix
 
-Ensure config is in the mounted working directory. When using `sbx run` or `sbx create`, the current directory is automatically mounted:
+Ensure config is in the mounted working directory. When using `acq run` (or
+`acq create`), the current directory is automatically mounted:
 
 ```bash
 # Run from the directory containing your config
 cd /path/to/project-with-config
-sbx run opencode .
+acq run opencode .
 ```
 
 Or copy config into an existing container:
 
 ```bash
-sbx cp ./opencode.jsonc my-sandbox:/workspace/
+acq cp ./opencode.jsonc my-sandbox:/workspace/
 ```
 
 ---
@@ -722,7 +722,7 @@ sbx secret ls -g | grep USAI_API_KEY
 If problems persist, see [Section 2](#2-api-key-works-in-ui-but-fails-in-agent) and [Section 3](#3-agent-cannot-see-api-key--usai-authentication-fails). As a last resort, recreate the sandbox (this destroys all sandbox state, including uncommitted work):
 
 ```bash
-sbx rm <sandbox-name>
+acq rm <sandbox-name>
 ```
 
 ---


### PR DESCRIPTION
Part of the epic GSA-TTS/agentic-coding-quickstart#348. Closes GSA-TTS/agentic-coding-quickstart#352.

> **Stacked PR.** Base is `docs/351-neutralize-sbx-howto` (GSA-TTS/agentic-coding-quickstart#362). Order: #358 → #359 → #360 → #361 → #362 (#351) → **this**.

## Context
`docs/KNOWN_FAILURE_MODES.md` mixes genuinely backend-diagnostic entries with generic entries phrased in raw `sbx` that `acq` covers. The file already models the "acq-first, raw-as-equivalent" pattern in places; this propagates it to the generic entries.

## What changed
- Generic operations the wrapper covers now lead with `acq`:
  - §2 env-var presence check → `acq exec <sandbox> -- sh -c '...'`
  - §9 connectivity probe → `acq exec <sandbox> -- curl ...`
  - §13 config-not-mounted → `acq run` / `acq create` / `acq cp`
  - §20 last-resort recreate → `acq rm <name>`
- Backend-diagnostic entries left **as-is** and tagged by backend: §1 unknown-agent, §6 CLI behavior, §14 proxy/`set-custom`, §16 `sbx exec -e`, §18 docker-sandbox migration table, §19 kit healing, §21, §26, §27, §29, §35, and per-backend `exec` diagnostics.

## Verification
- `npm run lint:md` → 0 errors
- `./scripts/test-acq` → 1032 passed
- Reviewed by a separate agent; converted entries confirmed to still diagnose the described failure, no diagnostic detail lost.

## Rollback
Revert this commit; docs-only.

## Security impact
None (documentation only).

AI-assisted (OpenCode, claude_4_8_opus). Human-owned and reviewed.
