### PR TITLE
docs: reconcile backend-primacy framing + refresh CONTEXT-GUIDE.md

### DIFF
--- a/CONTEXT-GUIDE.md
+++ b/CONTEXT-GUIDE.md
@@ -35,9 +35,14 @@ These define the behavioral contract. Load for **every task**.
 
 | Document | Load When Task Involves |
 |----------|------------------------|
-| `docs/howto/sbx.md` | Setting up SBX, running agents, USAi configuration, first-time setup |
-| `docs/KNOWN_FAILURE_MODES.md` | Debugging SBX/USAi issues, troubleshooting, error diagnosis |
-| `docs/adr/0001-sbx-usai-agent-execution-architecture.md` | Understanding SBX architecture decisions, isolation rationale |
+| `docs/howto/acq.md` | Setting up a sandbox with `acq`, running agents, USAi configuration, first-time setup (backend-neutral; default backend is msb) |
+| `docs/CONCEPTS.md` | Cross-cutting, backend-neutral concepts (e.g. mounting multiple workspaces) |
+| `docs/BACKEND_GUIDE.md` | Choosing between backends (msb, sbx); per-backend strengths, tradeoffs, and configuration |
+| `docs/howto/sbx.md` | sbx-specific setup and mechanics (proxy secrets, `set-custom`, policy, `--clone`) — the sbx alternative to the default |
+| `docs/KNOWN_FAILURE_MODES.md` | Debugging sandbox/USAi issues, troubleshooting, error diagnosis (both backends) |
+| `docs/adr/0010-acq-pluggable-backends.md` | Understanding the acq pluggable-backend architecture |
+| `docs/adr/0011-msb-backend-and-neutral-kits.md` | Understanding the msb backend and neutral kits |
+| `docs/adr/0001-sbx-usai-agent-execution-architecture.md` | Understanding sbx architecture decisions, isolation rationale |
 
 ## Tier 3 — Reference Only
 
@@ -53,6 +58,7 @@ Load only when the specific activity is being performed.
 | Task Type | Load |
 |-----------|------|
 | Code generation/review | Tier 1 only |
-| SBX + USAi setup | Tier 1 + docs/howto/sbx.md |
+| Sandbox + USAi setup (default/neutral) | Tier 1 + docs/howto/acq.md (+ docs/BACKEND_GUIDE.md to choose a backend) |
+| sbx-specific setup | Tier 1 + docs/howto/sbx.md |
 | Debugging agent issues | Tier 1 + KNOWN_FAILURE_MODES.md |
 | Pre-deployment review | Tier 1 + checklist |

--- a/docs/howto/sbx.md
+++ b/docs/howto/sbx.md
@@ -6,7 +6,10 @@
 > **Note:** `msb` (microsandbox) is `acq`'s **default** backend. Use this `sbx`
 > guide when you specifically want the Docker Sandboxes backend (for example, you
 > already run Docker Sandboxes, or want its proxy-based credential store). See the
-> [Backend Guide](../BACKEND_GUIDE.md) to choose between backends.
+> [Backend Guide](../BACKEND_GUIDE.md) to choose between backends. This guide is
+> the sbx **alternative**, not the recommended default (see
+> [ADR-0024](../adr/0024-neutral-user-facing-docs-vs-backend-specific.md) for the
+> neutral-first documentation convention).
 
 This guide walks you through setting up Docker Sandboxes using the `sbx` command-line interface to run AI coding agents with USAi.
 
@@ -29,7 +32,10 @@ This guide walks you through setting up Docker Sandboxes using the `sbx` command
 | Audit trail | ✅ | Limited |
 | Scriptable setup | ✅ | ❌ |
 
-For federal compliance and automation, sbx CLI is the recommended approach.
+If you have chosen the sbx backend, use the sbx CLI (not the Docker Desktop
+UI) for federal compliance and automation. To choose between backends in the
+first place, see the [Backend Guide](../BACKEND_GUIDE.md) — `msb` is `acq`'s
+default.
 
 ---
 


### PR DESCRIPTION
Part of the epic GSA-TTS/agentic-coding-quickstart#348. Closes GSA-TTS/agentic-coding-quickstart#353.

> **Stacked PR.** Base is `docs/350-howto-rename` (GSA-TTS/agentic-coding-quickstart#361) — parallel to #362/#363. Order: #358 → #359 → #360 → #361 (#350) → **this**.

## Context
Two framing inconsistencies steered readers toward the non-default backend: the sbx guide opened by implying sbx is the recommended federal path (contradicting the README's msb-default stance), and `CONTEXT-GUIDE.md` routed only to the sbx guide with no mention of `acq`, `msb`, or the neutral concept/backend docs.

## What changed
- `docs/howto/sbx.md`: reframe the "recommended" language as an sbx-vs-Docker-Desktop-UI comparison for readers who have already chosen sbx, and state it is the **alternative**, not the default; cite [ADR-0024](docs/adr/0024-neutral-user-facing-docs-vs-backend-specific.md).
- `CONTEXT-GUIDE.md`: route Tier 2 + task profiles through the neutral acq docs (`docs/howto/acq.md`, `docs/CONCEPTS.md`, `docs/BACKEND_GUIDE.md`) and both backends.

## Relationship to GSA-TTS/agentic-coding-quickstart#338
Overlap with the broader backend-primacy reconciliation (#338) is **cross-linked, not re-litigated** (see ADR-0024 Links). This PR's unique contribution is the `CONTEXT-GUIDE.md` refresh and the sbx how-to opening framing.

## Verification
- `npm run lint:md` → 0 errors; markdown links resolve
- Reviewed by a separate agent; the #338 cross-link and ADR-0024 link were added per feedback.

## Rollback
Revert this commit; docs-only.

## Security impact
None (documentation only).

AI-assisted (OpenCode, claude_4_8_opus). Human-owned and reviewed.