### PR TITLE
docs: renumber ADR-0022 volumes vocabulary to ADR-0023

### DIFF
--- a/acq.backends/kit-translate.sh
+++ b/acq.backends/kit-translate.sh
@@ -398,7 +398,7 @@ _kit_pp_validate() {
 # content at the path, so a kit needing seeded content ships its own first-boot
 # copy step. Multiple kits union by path, last wins — sbx resolves that itself.
 # The neutral schema carries no `mode` (msb has no equivalent; kits chmod in a
-# startup step instead — see ADR-0022).
+# startup step instead — see ADR-0023).
 #
 # VALIDATION (SI-10): these values reach a generated sbx-v2 spec and an msb
 # create argv, so they are untrusted. path must be absolute, charset-restricted
@@ -1285,7 +1285,7 @@ EOF
   # them). A valid-but-small block size additionally gets a WARNING (not an
   # error): msb refuses ext4 disk images under 128M, so a sub-floor size
   # passes validate for sbx-only use but will fail an msb create.
-  # (ADR-0022, SI-10)
+  # (ADR-0023, SI-10)
   local vline vp vt vs vbytes
   while IFS= read -r vline; do
     [ -n "$vline" ] || continue

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -27,7 +27,7 @@
 #   - `msb list|ls [-q] [--running]`, `msb stop`, `msb remove|rm [-f]`,
 #     `msb copy|cp SRC DST`, `msb ssh [SANDBOX] [-- CMD…]`, `msb ssh authorize`,
 #     `msb run … -p HOST:GUEST` (published ports), `msb doctor`.
-#   - Volume surface (ADR-0022): `msb create … --mount-named
+#   - Volume surface (ADR-0023): `msb create … --mount-named
 #     NAME:PATH:kind=disk,size=SIZE` (create-or-reuse disk-backed named volume),
 #     `--tmpfs PATH:SIZE`, and `msb volume ls -q` / `msb volume rm NAME` for the
 #     terminate-time cleanup of derived volumes. LIVE-VERIFIED end-to-end on
@@ -1273,7 +1273,7 @@ EOF
 # on STDIN into the named array. Usage:
 #   _acq_msb_volume_flags_from_records ARRVAR SANDBOX <<EOF ... records ... EOF
 #
-# ADR-0022: records come from kit_spec_volumes (path absolute + charset-safe,
+# ADR-0023: records come from kit_spec_volumes (path absolute + charset-safe,
 # type ""|tmpfs, size byte-size grammar), UNIONED across kits by
 # _acq_msb_volume_records_dedupe before reaching here. Mapping, mirroring the
 # sbx kit-spec v2 §5.7 semantics:
@@ -1363,7 +1363,7 @@ _acq_msb_volume_records_dedupe() {
 # would drain the loop's stdin (the recorded loop-stdin-consumption pitfall).
 # NOTE: prefix-matched, so a sandbox name that is itself a prefix of another
 # sandbox's name + '-' (e.g. `web` vs `web-2`) could match the longer sandbox's
-# volumes; accepted for now — see ADR-0022.
+# volumes; accepted for now — see ADR-0023.
 _acq_msb_remove_derived_volumes() {
   local _name="$1" _vol _vols=()
   while IFS= read -r _vol; do
@@ -2323,7 +2323,7 @@ acq_backend_provision() {
     _acq_msb_port_flags_into pp "$spec"
     [ "${#pp[@]}" -gt 0 ] && create_flags+=("${pp[@]}")
 
-    # Volumes (ADR-0022): ACCUMULATE this kit's validated records; they are
+    # Volumes (ADR-0023): ACCUMULATE this kit's validated records; they are
     # unioned across all kits (last wins by path, matching sbx's own
     # composition rule) and emitted as create flags AFTER the loop — emitting
     # per kit here would produce conflicting --mount-named flags when two kits
@@ -2341,7 +2341,7 @@ $(kit_spec_volumes "$spec")"
     _acq_msb_stage_startup_script "$spec" create_flags
   done
 
-  # Volumes (ADR-0022) → create-time storage flags, from the union of every
+  # Volumes (ADR-0023) → create-time storage flags, from the union of every
   # kit's records (last wins by path): a block entry becomes a derived named
   # disk volume (--mount-named acq-<name>-<pathslug>-<crc>:<path>:kind=disk,
   # size=<size>, removed again in acq_backend_terminate), a tmpfs entry becomes
@@ -3625,7 +3625,7 @@ acq_backend_terminate() {
   # before removing the sandbox (ADR-0015). Killing a dead PID / missing state
   # file is a no-op.
   _acq_msb_ports_teardown "$1"
-  # Clean up derived volumes (ADR-0022) whenever the sandbox is GONE after the
+  # Clean up derived volumes (ADR-0023) whenever the sandbox is GONE after the
   # remove attempt — not merely when remove succeeded. A failed remove of a
   # still-existing sandbox must not touch volumes that may be in use, but a
   # failed remove of an already-gone sandbox (removed via `msb rm` directly, or
@@ -4062,7 +4062,7 @@ acq_backend_apply_kit() {
     echo "acq(msb): error: could not fetch kit: $kitref" >&2
     return 1
   }
-  # Volumes are creation-time only (ADR-0022): a mid-life apply cannot attach
+  # Volumes are creation-time only (ADR-0023): a mid-life apply cannot attach
   # them, so say so instead of leaving the kit's storage requirement silently
   # unmet. (Provision-time applies do not pass here — their volumes were
   # mounted at create.)

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -733,7 +733,7 @@ rationale, the fixed vsock port (3552), and the trust-boundary discussion.
 | Secret binding breadth | 7 built-in services + any custom `--host/--env` endpoint | usai + github + **any** custom `--host/--env` endpoint bound generically via `--secret ENV@HOST` (shipped) |
 | Snapshots | not supported (`SUPPORTS_SNAPSHOTS=0`) | `msb snapshot` verb exists but **not surfaced by `acq`** (beyond-parity; `SUPPORTS_SNAPSHOTS=0`) |
 | Port forwarding | `acq ports` (post-hoc) | create/run (`-p`) via neutral `publishedPorts` now (shipped); **plus** post-hoc `acq ports --publish` via `msb ssh serve` + `ssh -L` now implemented (ADR-0015) — live end-to-end verification pending a KVM host |
-| Kit volumes | neutral `volumes:` passed through 1:1 to kit-spec v2 §5.7 (sized block device / tmpfs, mounted at create; dies with the sandbox) | neutral `volumes:` unioned across kits (last wins by path) and mapped to a derived named disk volume (`--mount-named acq-<sandbox>-<pathslug>-<crc>:<path>:kind=disk,size=<size>`) or `--tmpfs <path>:<size>`; derived volumes removed on `acq rm` (ADR-0022) |
+| Kit volumes | neutral `volumes:` passed through 1:1 to kit-spec v2 §5.7 (sized block device / tmpfs, mounted at create; dies with the sandbox) | neutral `volumes:` unioned across kits (last wins by path) and mapped to a derived named disk volume (`--mount-named acq-<sandbox>-<pathslug>-<crc>:<path>:kind=disk,size=<size>`) or `--tmpfs <path>:<size>`; derived volumes removed on `acq rm` (ADR-0023) |
 | Agent binary | supplied by the sbx agent template | installed at provision on a plain base (`npm install -g opencode-ai`), then launched on attach |
 | OpenCode web UI | `openchamber` acq kit (publishes port 4096) | same kit once it declares `backends: [sbx, msb]` against the released patterns schema (neutral port/background vocab consumed by both backends; the patterns repo's openchamber kit) |
 | In-place kit heal | `sbx kit add` (state-preserving, 0.35.0+; **no startup-bearing kits on 0.38+ — recreate to extend/refresh**) | re-apply kits idempotently (no state-preserving add) |
@@ -929,7 +929,7 @@ the kit spec never carries a secret value.
 > release commit (`f5fb887`); the pin is only advanced to a tagged release,
 > per the fail-closed cross-repo gating.
 
-**`volumes` (sized guest storage, [ADR-0022](adr/0022-neutral-volumes-kit-vocabulary.md)).**
+**`volumes` (sized guest storage, [ADR-0023](adr/0023-neutral-volumes-kit-vocabulary.md)).**
 A top-level list of `{path, type?, size}` entries — `path` required, absolute,
 and normalized (no `.`/`..` segments, no `//`, no trailing `/` — a volume
 mounts a whole filesystem, so `/.` would shadow the guest root), `type` empty
@@ -1016,7 +1016,7 @@ See [ADR-0016](adr/0016-kit-bundle-provenance-and-stale-refresh.md).
 - Neutral top-level `volumes` vocab consumed by **both** backends (sbx: 1:1
   into kit-spec v2 §5.7; msb: derived named disk volume / `--tmpfs`, with
   derived-volume cleanup on `acq rm`)
-  ([ADR-0022](adr/0022-neutral-volumes-kit-vocabulary.md)). **Live-verified on
+  ([ADR-0023](adr/0023-neutral-volumes-kit-vocabulary.md)). **Live-verified on
   both backends** (`verify-backends`: msb 0.6.12 macOS HVF 17/17 — dedicated
   virtio-blk mount at boot + derived-volume removal on rm; sbx 0.39.0 9/9 —
   dedicated block-device mount of the declared size); the patterns schema

--- a/docs/adr/0023-neutral-volumes-kit-vocabulary.md
+++ b/docs/adr/0023-neutral-volumes-kit-vocabulary.md
@@ -11,7 +11,7 @@ risk_treatment: accept
 supersedes: []
 ---
 
-# ADR-0022: Neutral Volumes Kit Vocabulary
+# ADR-0023: Neutral Volumes Kit Vocabulary
 
 ## Context and Problem Statement
 

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -373,12 +373,12 @@ case "$_msb_sub" in
     : ;;
   remove|rm)
     # STUB_MSB_RM_FAIL=1 models a failed `msb remove` (e.g. sandbox not found)
-    # for the ADR-0022 terminate volume-cleanup matrix.
+    # for the ADR-0023 terminate volume-cleanup matrix.
     [ "${STUB_MSB_RM_FAIL:-0}" = "1" ] && exit 1 || : ;;
   copy|cp) : ;;
   modify) : ;;
   volume)
-    # ADR-0022 derived-volume cleanup: `msb volume ls -q` lists names from the
+    # ADR-0023 derived-volume cleanup: `msb volume ls -q` lists names from the
     # fixture a test plants; `msb volume rm NAME` is logged (above) and no-ops.
     if [ "${2:-}" = "ls" ]; then
       [ -f "$STUBDIR/.msb_volume_list" ] && cat "$STUBDIR/.msb_volume_list"
@@ -6336,7 +6336,7 @@ assert_not_contains "pp: sbx-v2 does not leak host column into protocol" "$hospe
 cleanup_stubs
 
 # ===========================================================================
-# 10a5. ADR-0022: neutral volumes vocabulary
+# 10a5. ADR-0023: neutral volumes vocabulary
 # ===========================================================================
 # Adds a neutral top-level `volumes:` list ({path, type?(""|tmpfs), size}),
 # consumed by BOTH backends: sbx-v2 passes entries through 1:1 (kit-spec v2

--- a/scripts/verify-backends
+++ b/scripts/verify-backends
@@ -199,7 +199,7 @@ export ACQ_PROVENANCE_DIR="$VERIFY_STATE/provenance"
 export ACQ_SECRET_NO_LIVE_REFEED=1
 mkdir -p "$XDG_CONFIG_HOME" "$ACQ_SECRET_STORE_DIR" "$ACQ_STATE_DIR" "$ACQ_PROVENANCE_DIR"
 
-# Fixture kit for the neutral `volumes:` vocabulary (ADR-0022): a tiny local kit
+# Fixture kit for the neutral `volumes:` vocabulary (ADR-0023): a tiny local kit
 # declaring a 256m block volume. Appended to ACQ_EXTRA_KITS so every create below
 # carries it; the volumes check inside verify_backend asserts the mount landed.
 # 256m, not smaller: msb refuses tiny ext4 disk images ("image size is too small
@@ -700,7 +700,7 @@ verify_backend() {
   # 5) OCI engine (podman) usable — msb only (ADR-0020).
   _verify_oci_checks "$backend" "$name"
 
-  # 6) Neutral kit volumes (ADR-0022): the verifier's fixture kit (appended to
+  # 6) Neutral kit volumes (ADR-0023): the verifier's fixture kit (appended to
   #    ACQ_EXTRA_KITS at setup) declares a 256m block volume at /acq-verify-vol.
   #    Assert the path is a MOUNTPOINT on a dedicated /dev block device of
   #    roughly the declared size — df is used (not findmnt) because it is
@@ -733,7 +733,7 @@ verify_backend() {
     printf '        (keeping sandbox %s; --keep set)\n' "$name"
   else
     run_acq "rm" --backend "$backend" rm "$name" >/dev/null 2>&1 || true
-    # ADR-0022: on msb the derived kit volumes (acq-<name>-*) must not outlive
+    # ADR-0023: on msb the derived kit volumes (acq-<name>-*) must not outlive
     # the sandbox — acq_backend_terminate removes them by prefix after a
     # successful `msb remove`.
     if [ "$backend" = "msb" ]; then


### PR DESCRIPTION
Two ADRs merged to main both numbered 0022: 0022-neutral-image-override (GSA-TTS/agentic-coding-quickstart#358) and 0022-neutral-volumes-kit-vocabulary (GSA-TTS/agentic-coding-quickstart#357). Keep image-override at 0022 (merged first); renumber the volumes vocabulary to 0023 and update its inbound refs (BACKEND_GUIDE, msb.sh, kit-translate.sh, test-acq, verify-backends). Image refs untouched.

Verification: ./scripts/test-acq 1093 passed; npm run lint:md 0 errors.

Refs: GSA-TTS/agentic-coding-quickstart#357, GSA-TTS/agentic-coding-quickstart#358

AI-assisted (OpenCode, claude_4_8_opus). Human-owned and reviewed.