### PR TITLE
feat(acq): add per-verb --help for all acq-owned subcommands

### DIFF
--- a/acq
+++ b/acq
@@ -211,6 +211,187 @@ Usage:
 BACKENDUSAGE
 }
 
+# _acq_simple_verb_usage VERB — acq's OWN one-verb usage for the remaining
+# acq-owned top-level verbs that are NOT the multi-word topics (secret/kit/
+# backend) handled above. Kept as a single source (one case) so `acq VERB --help`
+# and the topic router below never drift, and so acq documents ITS OWN semantics
+# for a verb rather than only surfacing the backend's help for it. Returns 0 if
+# VERB is known (usage printed to stderr), 1 otherwise (caller falls back to the
+# top-level banner). See docs/BACKEND_GUIDE.md for the backend-specific details.
+_acq_simple_verb_usage() {
+  case "$1" in
+    run)
+      cat >&2 <<'U'
+acq run — create+attach a sandbox, or re-attach an existing one
+
+Usage:
+  acq run AGENT PATH [--kit REF]... [--image REF] [--no-update-check] [-- AGENT_ARGS...]
+  acq run NAME [-- AGENT_ARGS...]     # re-attach an existing sandbox by name
+
+Creates a sandbox for AGENT (e.g. opencode) mounted at PATH if one does not
+already exist, applies the pinned kits, then attaches. Re-attaching an existing
+sandbox heals its kits and (on msb) resumes it if stopped. This is the verb that
+both resumes AND attaches — so an interactive session started via `acq run` gets
+the forwarded host ssh-agent (SSH_AUTH_SOCK) injected, unlike `acq start`.
+U
+      ;;
+    create)
+      cat >&2 <<'U'
+acq create — create a sandbox (detached; does not attach)
+
+Usage:
+  acq create AGENT PATH [--kit REF]... [--image REF]
+
+Provisions a sandbox for AGENT mounted at PATH and applies the pinned kits, then
+returns without attaching. Attach later with `acq run NAME`.
+U
+      ;;
+    ls)
+      cat >&2 <<'U'
+acq ls — list sandboxes
+
+Usage:
+  acq ls
+U
+      ;;
+    stop)
+      cat >&2 <<'U'
+acq stop — stop a sandbox without removing it
+
+Usage:
+  acq stop NAME
+
+State is preserved; resume with `acq run NAME` (or `acq start NAME` on msb).
+U
+      ;;
+    start)
+      cat >&2 <<'U'
+acq start — resume a stopped sandbox and re-run its kit startup (msb only)
+
+Usage:
+  acq start NAME
+
+Resumes NAME (`msb start`), restarts the in-guest ssh-agent bridge, then re-runs
+the pinned kits' startup phase via the exec heal — the deterministic mechanism
+that brings supervised services back up (a bare `msb start` does not replay them;
+see ADR-0017). `acq start` does NOT attach, so the resulting shell you enter by
+another route will not have SSH_AUTH_SOCK injected — use `acq run NAME` for an
+interactive session, or `acq exec NAME -- CMD` for a one-off command (both inject
+it). On sbx there is no `start` verb; a stopped sandbox resumes automatically on
+`acq run`.
+U
+      ;;
+    restart)
+      cat >&2 <<'U'
+acq restart — stop then start a sandbox, re-running kit startup (msb only)
+
+Usage:
+  acq restart NAME
+
+A best-effort bounce: `acq stop` then the same resume+heal as `acq start` (see
+`acq start --help`). Like `acq start`, it does NOT attach, so it does not inject
+SSH_AUTH_SOCK into a session you enter afterward by another route — use `acq run
+NAME` to attach. On sbx there is no `restart` verb; use `acq stop` then `acq run`.
+U
+      ;;
+    rm)
+      cat >&2 <<'U'
+acq rm — remove a sandbox
+
+Usage:
+  acq rm NAME
+
+Destroys the sandbox and all of its state (including uncommitted work in it).
+U
+      ;;
+    exec)
+      cat >&2 <<'U'
+acq exec — run a command inside a sandbox
+
+Usage:
+  acq exec NAME -- CMD...
+
+Runs CMD as the unprivileged agent user in the workspace. On msb, when the host
+ssh-agent is forwarded, SSH_AUTH_SOCK is injected so git/ssh reach the agent.
+U
+      ;;
+    cp)
+      cat >&2 <<'U'
+acq cp — copy files in or out of a sandbox
+
+Usage:
+  acq cp SRC DST                # use NAME:path for the in-sandbox side
+U
+      ;;
+    ports)
+      cat >&2 <<'U'
+acq ports — list or publish a sandbox's ports
+
+Usage:
+  acq ports NAME [--publish HOST:GUEST ...]
+U
+      ;;
+    github-scope)
+      cat >&2 <<'U'
+acq github-scope — scope a GitHub token to a workspace's repos (least-privilege)
+
+Usage:
+  acq github-scope SANDBOX [WORKSPACE_PATH]
+
+Guides minting a fine-grained PAT scoped to the workspace's repos and stores it
+sandbox-scoped (ADR-0013). WORKSPACE_PATH defaults to the current directory.
+U
+      ;;
+    usai-rotate-api-key)
+      cat >&2 <<'U'
+acq usai-rotate-api-key — rotate the stored USAi API key
+
+Usage:
+  acq usai-rotate-api-key
+U
+      ;;
+    version)
+      cat >&2 <<'U'
+acq version — show acq version + backend info
+
+Usage:
+  acq version
+U
+      ;;
+    doctor)
+      cat >&2 <<'U'
+acq doctor — backend health check + write config
+
+Usage:
+  acq doctor
+U
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+# _acq_verb_backend_help_kind VERB — classify an acq-owned VERB for the help
+# router's decision about whether to ALSO append the backend's own help:
+#   "shared"  -> the backend has a genuinely-corresponding subcommand whose help
+#                adds context (run/ls/stop/rm/exec/cp/ports; also the topic verbs
+#                secret/kit which map to backend refs).
+#   "acqonly" -> acq owns the verb outright; the backend either has no such verb
+#                or its help would be misleading/wrong (start/restart/create/
+#                version/doctor/github-scope/usai-rotate-api-key/backend). For
+#                these, suppress the backend block.
+#   ""        -> not an acq-owned verb (unknown / passthrough); caller decides.
+# The FIRST word of VERB is classified (so "secret set" -> secret).
+_acq_verb_backend_help_kind() {
+  case "${1%% *}" in
+    run|ls|stop|rm|exec|cp|ports|secret|kit) printf 'shared' ;;
+    start|restart|create|version|doctor|github-scope|usai-rotate-api-key|backend) printf 'acqonly' ;;
+    *) printf '' ;;
+  esac
+}
+
 # _acq_print_topic_help TOPIC — print acq's OWN help for a known top-level verb
 # TOPIC (so `acq <verb> --help` documents the acq verb, not just the backend).
 # Returns 0 if TOPIC was a known acq verb (help printed), 1 otherwise (caller
@@ -223,7 +404,7 @@ _acq_print_topic_help() {
     secret)  _acq_secret_usage; return 0 ;;
     kit)     _acq_kit_usage; return 0 ;;
     backend) _acq_backend_subcmd_usage; return 0 ;;
-    *)       return 1 ;;
+    *)       _acq_simple_verb_usage "$head"; return $? ;;
   esac
 }
 
@@ -355,15 +536,25 @@ case "$subcommand" in
     ;;
 esac
 if [ -n "$_acq_wants_help" ]; then
-  # Prefer acq's OWN per-verb usage for verbs acq owns (secret/kit/backend), so
-  # `acq secret --help` documents the acq verb rather than only the top banner.
-  # For anything else, print the top-level banner. Then append the backend's own
-  # help (best-effort) for additional context.
+  # Prefer acq's OWN per-verb usage for verbs acq owns, so `acq VERB --help`
+  # documents the acq verb rather than only the top banner. For anything acq
+  # does not own, print the top-level banner. Then append the backend's own help
+  # (best-effort) ONLY when it adds genuine context — i.e. for verbs the backend
+  # actually shares. For acq-only verbs (start/restart/create/version/doctor/…)
+  # the backend has no such subcommand, or its help would be MISLEADING (e.g.
+  # `msb restart --help` for the acq `restart` verb, which does not fall through
+  # to `msb restart`), so we suppress the backend block there. See
+  # _acq_verb_backend_help_kind. A bare help request (no topic) still shows the
+  # backend's top-level help for discoverability.
   if ! _acq_print_topic_help "$_acq_help_topic"; then
     print_help
   fi
   acq_resolve_backend "${explicit_backend}" 2>/dev/null || true
-  _acq_backend_help "$_acq_help_topic"
+  if [ -z "$_acq_help_topic" ]; then
+    _acq_backend_help ""
+  elif [ "$(_acq_verb_backend_help_kind "$_acq_help_topic")" = "shared" ]; then
+    _acq_backend_help "$_acq_help_topic"
+  fi
   # A bare `acq` (no subcommand) is a usage error (exit 2); an explicit help
   # request is success (exit 0).
   [ -z "$subcommand" ] && exit 2 || exit 0

--- a/scripts/test-acq
+++ b/scripts/test-acq
@@ -2057,8 +2057,7 @@ cleanup_stubs
 
 # 7b2. Per-subcommand `--help` prints acq's OWN per-verb usage for verbs acq owns
 #      (secret/kit/backend), not merely the top-level banner. `acq secret set
-#      --help` (a sub-subcommand) routes to the `secret` usage too. Non-owned
-#      topics (run) still show the top-level banner. All exit 0.
+#      --help` (a sub-subcommand) routes to the `secret` usage too. All exit 0.
 make_stubs
 # secret family
 sec_help=$(ACQ_BACKEND=sbx "$ACQ" secret --help 2>&1); sec_rc=$?
@@ -2082,9 +2081,52 @@ assert_eq "help: 'backend --help' exits 0" "0" "$be_rc"
 assert_contains "help: 'backend --help' shows acq backend usage" "$be_help" "acq backend — select the sandbox backend"
 beset_help=$(ACQ_BACKEND=sbx "$ACQ" backend set --help 2>&1)
 assert_contains "help: 'backend set --help' routes to backend usage" "$beset_help" "acq backend — select the sandbox backend"
-# non-owned verb: still the top-level banner
-run_help=$(ACQ_BACKEND=sbx "$ACQ" run --help 2>&1)
-assert_contains "help: 'run --help' shows the top-level banner" "$run_help" "agentic coding quickstart wrapper"
+cleanup_stubs
+
+# 7b3. Every acq-OWNED verb now has its OWN per-verb usage on `--help` (exit 0),
+#      NOT the generic top-level banner. This is the fix for the reported gap
+#      where `acq start --help` / `acq restart --help` printed only the banner and
+#      then the backend's (misleading) help. Assert each verb's own usage header.
+make_stubs
+_assert_verb_help() { # NAME EXPECT_SUBSTRING
+  local _n="$1" _sub="$2" _out _rc
+  _out=$(ACQ_BACKEND=msb "$ACQ" "$_n" --help 2>&1); _rc=$?
+  assert_eq "help: '$_n --help' exits 0" "0" "$_rc"
+  assert_contains "help: '$_n --help' shows acq's own $_n usage" "$_out" "$_sub"
+  assert_not_contains "help: '$_n --help' is NOT the generic banner" "$_out" "Global flags (before the subcommand):"
+}
+_assert_verb_help run          "acq run — create+attach a sandbox"
+_assert_verb_help create       "acq create — create a sandbox (detached"
+_assert_verb_help ls           "acq ls — list sandboxes"
+_assert_verb_help stop         "acq stop — stop a sandbox"
+_assert_verb_help start        "acq start — resume a stopped sandbox"
+_assert_verb_help restart      "acq restart — stop then start a sandbox"
+_assert_verb_help rm           "acq rm — remove a sandbox"
+_assert_verb_help exec         "acq exec — run a command inside a sandbox"
+_assert_verb_help cp           "acq cp — copy files in or out"
+_assert_verb_help ports        "acq ports — list or publish"
+_assert_verb_help github-scope "acq github-scope — scope a GitHub token"
+_assert_verb_help usai-rotate-api-key "acq usai-rotate-api-key — rotate"
+_assert_verb_help version      "acq version — show acq version"
+_assert_verb_help doctor       "acq doctor — backend health check"
+cleanup_stubs
+
+# 7b4. Backend-help suppression policy: for acq-ONLY verbs (start/restart/create/
+#      version/doctor/github-scope/usai-rotate-api-key) the backend's own help is
+#      NOT appended (it is absent or misleading — the reported `msb restart`
+#      fallthrough). For SHARED verbs (run/exec/…) the backend help IS appended.
+make_stubs
+# acq-only: no backend separator line, no backend help body.
+start_help=$(ACQ_BACKEND=msb "$ACQ" start --help 2>&1)
+assert_not_contains "help: 'start --help' suppresses the backend help block" "$start_help" "msb start --help"
+assert_not_contains "help: 'start --help' shows no backend top-level help" "$start_help" "MSB-TOPLEVEL-HELP"
+restart_help=$(ACQ_BACKEND=msb "$ACQ" restart --help 2>&1)
+assert_not_contains "help: 'restart --help' suppresses the backend help block" "$restart_help" "msb restart --help"
+# start/restart usage cross-references acq run (the attach path that injects SSH_AUTH_SOCK).
+assert_contains "help: 'start --help' points at acq run for an attached session" "$start_help" "acq run"
+# shared verb: the backend's per-verb help IS appended (sbx run stub emits SBX-RUN-HELP).
+runh=$(ACQ_BACKEND=sbx "$ACQ" run --help 2>&1)
+assert_contains "help: 'run --help' still appends the backend's run help" "$runh" "SBX-RUN-HELP"
 cleanup_stubs
 
 # 7c. `acq secret ls` is a silent acq-store view (delegates to the backend on


### PR DESCRIPTION
## Context

`acq start --help` and `acq restart --help` previously printed only the generic
top-level banner followed by the backend's own help — and for `start`/`restart`
that backend block was actively misleading (it showed `msb start`/`msb restart`
help even though those acq verbs do **not** fall through to the backend). Only
the multi-word topics (`secret`/`kit`/`backend`) had dedicated usage.

## Change

Every acq-owned subcommand now prints its **own** `--help`:

- Add `_acq_simple_verb_usage` with per-verb usage for `run`, `create`, `ls`,
  `stop`, `start`, `restart`, `rm`, `exec`, `cp`, `ports`, `github-scope`,
  `usai-rotate-api-key`, `version`, `doctor`, routed via `_acq_print_topic_help`
  (single source, so `acq VERB --help` and the topic router can't drift).
- The `start`/`restart` usage documents that they do **not** attach and points
  at `acq run` for a session that gets `SSH_AUTH_SOCK` injected.
- Append the backend's own help **only** for genuinely-shared verbs
  (`run`/`ls`/`stop`/`rm`/`exec`/`cp`/`ports`/`secret`/`kit`) via
  `_acq_verb_backend_help_kind`; suppress it for acq-only verbs where it is
  absent or misleading.

## Verification

- `./scripts/test-acq`: **1139 passed, 0 failed** (added ~30 assertions covering
  per-verb usage, banner suppression, and backend-help appending).
- `shellcheck --severity=warning acq`: clean.

## Rollback

Revert this commit; `acq` behavior returns to the prior banner + passthrough
help. No data or config migration involved.

## Security Impact

None. Help-text and CLI-usage only; no change to auth, secrets, data handling,
or attack surface.

---

AI-assisted: authored with OpenCode (claude_4_8_opus); human-reviewed before merge.