### PR TITLE
docs: add symmetric docs/howto/msb.md peer (closes #355)

### DIFF
--- a/CONTEXT-GUIDE.md
+++ b/CONTEXT-GUIDE.md
@@ -38,6 +38,7 @@ These define the behavioral contract. Load for **every task**.
 | `docs/howto/acq.md` | Setting up a sandbox with `acq`, running agents, USAi configuration, first-time setup (backend-neutral; default backend is msb) |
 | `docs/CONCEPTS.md` | Cross-cutting, backend-neutral concepts (e.g. mounting multiple workspaces) |
 | `docs/BACKEND_GUIDE.md` | Choosing between backends (msb, sbx); per-backend strengths, tradeoffs, and configuration |
+| `docs/howto/msb.md` | msb-specific setup and mechanics (host readiness, egress tiers, images, ssh-agent forwarding) — the default backend |
 | `docs/howto/sbx.md` | sbx-specific setup and mechanics (proxy secrets, `set-custom`, policy, `--clone`) — the sbx alternative to the default |
 | `docs/KNOWN_FAILURE_MODES.md` | Debugging sandbox/USAi issues, troubleshooting, error diagnosis (both backends) |
 | `docs/adr/0010-acq-pluggable-backends.md` | Understanding the acq pluggable-backend architecture |
@@ -59,6 +60,7 @@ Load only when the specific activity is being performed.
 |-----------|------|
 | Code generation/review | Tier 1 only |
 | Sandbox + USAi setup (default/neutral) | Tier 1 + docs/howto/acq.md (+ docs/BACKEND_GUIDE.md to choose a backend) |
+| msb-specific setup | Tier 1 + docs/howto/msb.md |
 | sbx-specific setup | Tier 1 + docs/howto/sbx.md |
 | Debugging agent issues | Tier 1 + KNOWN_FAILURE_MODES.md |
 | Pre-deployment review | Tier 1 + checklist |

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ see [Secrets](docs/howto/acq.md#secrets) in the acq how-to.
 
 **Need more details, or want to use the sbx backend instead?** See the
 [acq How-To](docs/howto/acq.md), the [Backend Guide](docs/BACKEND_GUIDE.md),
-and the [Full sbx CLI Guide](docs/howto/sbx.md).
+the [msb How-To](docs/howto/msb.md) (default backend), and the
+[sbx How-To](docs/howto/sbx.md).
 
 **Working across multiple repos?** Mounting extra directories works on either
 backend via `acq`; the command syntax and examples are documented in
@@ -457,7 +458,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 | `AGENTS.md`                         | Rules for working **on this quickstart repo**              |
 | `docs/howto/acq.md`                 | acq how-to guide and backend selection                     |
 | `docs/BACKEND_GUIDE.md`             | Per-backend strengths, tradeoffs, and configuration       |
-| `docs/howto/sbx.md`                 | Full sbx CLI setup guide                                   |
+| `docs/howto/msb.md`                 | msb (microsandbox) setup guide — the default backend       |
+| `docs/howto/sbx.md`                 | sbx CLI setup guide — the alternative backend              |
 | `docs/KNOWN_FAILURE_MODES.md`       | Troubleshooting guide                                      |
 
 ---

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -6,7 +6,7 @@ tier: 2
 last_updated: "2026-08-18"
 audience: "developers"
 keywords: ["acq", "backend", "sbx", "msb", "microsandbox", "tradeoffs"]
-related_files: ["docs/howto/acq.md", "docs/howto/sbx.md", "docs/CONCEPTS.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md", "docs/adr/0014-neutral-port-publish-and-background-vocab.md", "docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md"]
+related_files: ["docs/howto/acq.md", "docs/howto/msb.md", "docs/howto/sbx.md", "docs/CONCEPTS.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md", "docs/adr/0014-neutral-port-publish-and-background-vocab.md", "docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md"]
 load_priority: "on-demand"
 review_cycle: "quarterly"
 ---

--- a/docs/howto/acq.md
+++ b/docs/howto/acq.md
@@ -6,7 +6,7 @@ tier: 2
 last_updated: "2026-08-21"
 audience: "developers"
 keywords: ["acq", "backend", "sbx", "msb", "howto", "sandbox"]
-related_files: ["docs/BACKEND_GUIDE.md", "docs/CONCEPTS.md", "docs/howto/sbx.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
+related_files: ["docs/BACKEND_GUIDE.md", "docs/CONCEPTS.md", "docs/howto/msb.md", "docs/howto/sbx.md", "docs/adr/0010-acq-pluggable-backends.md", "docs/adr/0011-msb-backend-and-neutral-kits.md"]
 load_priority: "on-demand"
 review_cycle: "quarterly"
 ---
@@ -367,6 +367,7 @@ export ACQ_EXEC_READY_TIMEOUT=120
 ## See also
 
 - [docs/BACKEND_GUIDE.md](../BACKEND_GUIDE.md) — per-backend strengths and tradeoffs
+- [docs/howto/msb.md](msb.md) — detailed msb (microsandbox) reference (the default backend)
 - [docs/howto/sbx.md](sbx.md) — detailed sbx CLI reference
 - [docs/adr/0010-acq-pluggable-backends.md](../adr/0010-acq-pluggable-backends.md) — architecture decision
 - [docs/KNOWN_FAILURE_MODES.md](../KNOWN_FAILURE_MODES.md) — troubleshooting

--- a/docs/howto/msb.md
+++ b/docs/howto/msb.md
@@ -1,0 +1,237 @@
+---
+title: "msb How-To Guide"
+description: "Detailed how-to for the msb (microsandbox) backend behind acq"
+status: canonical
+tier: 2
+last_updated: "2026-08-24"
+audience: "developers"
+keywords: ["msb", "microsandbox", "backend", "acq", "howto", "sandbox"]
+related_files: ["docs/BACKEND_GUIDE.md", "docs/CONCEPTS.md", "docs/howto/acq.md", "docs/howto/sbx.md", "docs/adr/0011-msb-backend-and-neutral-kits.md", "docs/adr/0024-neutral-user-facing-docs-vs-backend-specific.md"]
+load_priority: "on-demand"
+review_cycle: "quarterly"
+---
+
+# msb How-To Guide
+
+> The [README](../../README.md) is the quickstart. This is the detailed msb
+> how-to.
+>
+> **Note:** `msb` (microsandbox) is `acq`'s **default** backend, so most readers
+> reach it simply by running `acq run opencode .` (see the
+> [acq How-To](acq.md)). This guide collects the msb-specific mechanics the
+> neutral docs deliberately do not abstract. For the sbx alternative, see the
+> [sbx How-To](sbx.md); to choose between backends, see the
+> [Backend Guide](../BACKEND_GUIDE.md). This is the symmetric msb peer to the sbx
+> guide per the neutral-first documentation convention
+> ([ADR-0024](../adr/0024-neutral-user-facing-docs-vs-backend-specific.md)).
+
+This guide walks you through the [microsandbox](https://github.com/superradcompany/microsandbox)
+(`msb`) backend, driven through `acq`, to run AI coding agents with USAi.
+
+## What is microsandbox?
+
+[microsandbox](https://github.com/superradcompany/microsandbox) is an
+open-source (Apache-2.0) microVM runtime (libkrun). Each sandbox is a real
+microVM with its own kernel, filesystem, and per-sandbox network policy. It runs
+standard OCI images, needs no Docker account/seat, and supports snapshot/restore
+and detached long-running sandboxes.
+
+## Why msb?
+
+| Property | msb (microsandbox) |
+|----------|--------------------|
+| Runtime | microVM (libkrun) |
+| Account required | None — FOSS binary |
+| Base images | Any OCI registry (Docker Hub, GHCR, …) |
+| Secret handling | Host-env binding `--secret ENV@HOST` (values never enter the guest) |
+| Host CA trust | Native `--trust-host-cas` (Zscaler shortcut) |
+
+`msb` is `acq`'s default. Prefer it unless you specifically need Docker
+Sandboxes — see the [Backend Guide](../BACKEND_GUIDE.md) for the full
+strengths/tradeoffs comparison.
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+|-------------|---------|-------|
+| `msb` CLI | >= 0.6.8 | `--net-rule`, `--trust-host-cas`, `--secret`, `--net-default-egress`. Host ssh-agent forwarding (git signing) additionally needs msb >= 0.6.9 (`--vsock`; [ADR-0021](../adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md)) — it warns and skips on older msb. |
+| Host virtualization | — | Linux: KVM (`/dev/kvm`); macOS: HVF (Apple Silicon); Windows: WHP |
+
+Run `msb doctor` to check host readiness (`msb doctor --fix` attempts setup).
+`acq` runs this check automatically before create; set `ACQ_SKIP_MSB_DOCTOR=1`
+to skip it.
+
+## Step 1: Install msb
+
+```bash
+curl -fsSL https://install.microsandbox.dev | sh        # macOS / Linux
+brew install superradcompany/tap/microsandbox           # Homebrew
+
+# Verify
+msb --version
+```
+
+<a id="msb-host-setup"></a>
+
+### Host setup
+
+If `msb doctor` reports the host is not ready, follow its guidance (`msb doctor
+--fix` attempts the setup). Common items: enabling KVM on Linux
+(`/dev/kvm` present and accessible) or Apple Virtualization on macOS. `acq`
+surfaces the doctor output before it provisions a sandbox.
+
+## Step 2: Select the backend
+
+`msb` is the default, so no selection is needed for a fresh setup. To be
+explicit or to switch back from sbx:
+
+```bash
+# Persist msb as the default backend
+./acq backend set msb
+
+# Or per-invocation
+./acq --backend msb run opencode /proj
+
+# Or via environment
+export ACQ_BACKEND=msb
+```
+
+## Step 3: Store your secrets
+
+On msb, secrets are **bound from host environment variables at create time**
+(`--secret ENV@HOST`); the real values never enter the guest. Drive this through
+`acq secret`:
+
+```bash
+# USAi API key (bound as USAI_API_KEY@api.gsa.usai.gov)
+acq secret set usai
+
+# GitHub token (bound per-sandbox, scoped to the GitHub hosts)
+acq secret set github
+
+# Any custom endpoint (generic host/env binding)
+acq secret set gitlab --host workshop.cloud.gov --env GITLAB_TOKEN
+```
+
+`acq secret set <svc>` reads the value from your host environment (or prompts)
+and records the `ENV@HOST` binding msb applies at create. See
+[Credential Injection Methods](../../AGENTS.md#credential-injection-methods) and
+the [Backend Guide](../BACKEND_GUIDE.md) for the full per-backend secret model.
+
+> [!NOTE]
+> Because msb swaps the real value in on the wire, inspecting the guest
+> environment is not automatically a leak — but never deliberately dump secret
+> values (`echo $SECRET`, piping `env` to a log). See `AGENTS.md`.
+
+## Step 4: Create your first sandbox
+
+```bash
+# Navigate to your project
+cd /path/to/your/project
+
+# Create and run a sandbox with OpenCode (msb is the default backend)
+acq run opencode .
+```
+
+The sandbox boots and you land in the agent environment.
+
+### Other supported agents
+
+```bash
+acq run claude .      # Claude Code
+acq run copilot .     # GitHub Copilot
+acq run cursor .      # Cursor
+acq run codex .       # OpenAI Codex
+acq run gemini .      # Google Gemini
+acq run shell .       # Just a shell (no agent)
+```
+
+### Create with a custom name
+
+```bash
+acq create --name my-feature opencode .
+acq run my-feature          # re-attach by name
+```
+
+### Multiple workspaces
+
+Mounting extra directories works identically on both backends via `acq`; see the
+canonical [Multiple Workspaces](../CONCEPTS.md#multiple-workspaces) concept. The
+only msb-specific caveats: each host workspace path must already exist (msb does
+not create the mount path), and symlinked host paths (notably macOS `$TMPDIR`)
+are canonicalized to their real path before mounting.
+
+## Step 5: Managing sandboxes
+
+```bash
+acq ls                      # list sandboxes
+acq stop my-sandbox         # stop (preserves state)
+acq run my-sandbox          # resume / re-attach by name
+acq rm my-sandbox           # remove permanently
+acq run my-sandbox          # interactive attach (acq exec runs a command, not a TTY)
+acq exec my-sandbox -- <cmd>   # run a one-off command in the sandbox
+```
+
+Unlike sbx, msb **can** stop and resume detached long-running sandboxes and
+supports snapshot/restore natively (`msb snapshot …`); `acq` does not yet
+surface a neutral `acq snapshot` verb (see the Backend Guide's
+known-limitations note).
+
+## Common commands reference
+
+| Task | acq command | Raw msb equivalent |
+|------|-------------|--------------------|
+| List sandboxes | `acq ls` | `msb list` |
+| Create sandbox | `acq run <agent> .` | `msb run …` |
+| Stop sandbox | `acq stop <name>` | `msb stop <name>` |
+| Resume sandbox | `acq run <name>` | `msb run <name>` |
+| Remove sandbox | `acq rm <name>` | `msb remove <name>` |
+| Run a command | `acq exec <name> -- <cmd>` | `msb exec <name> -- <cmd>` |
+| Interactive shell | `acq run <name>` (attach) | `msb exec -it <name> -- bash` |
+
+The following are genuinely msb-specific mechanics the wrapper does not
+abstract — use the raw `msb` command:
+
+| Task | Command |
+|------|---------|
+| Check host readiness | `msb doctor` (`msb doctor --fix`) |
+| Check version | `msb --version` |
+| Self-update | `msb self update` |
+| Import a local image | `msb image load -i <tar> -t <ref>` |
+| Snapshots | `msb snapshot …` |
+
+## msb-specific configuration
+
+msb exposes a large set of `ACQ_MSB_*` (and neutral `ACQ_*`) tunables — base
+image and pull policy, network egress tier, memory/CPU, DNS, host ssh-agent
+forwarding, post-hoc port publishing, and OCI-engine provisioning. Rather than
+duplicate them here, the authoritative reference is the
+[Backend Guide → msb Backend](../BACKEND_GUIDE.md#msb-backend-microsandbox-default),
+including:
+
+- [Network egress tiers (`ACQ_NETWORK_TIER`)](../BACKEND_GUIDE.md#network-egress-tiers-acq_network_tier)
+- [Custom base image (`--image` / `ACQ_IMAGE`)](../BACKEND_GUIDE.md#custom-base-image---image--acq_image)
+- [Running OCI images inside the sandbox (podman)](../BACKEND_GUIDE.md#running-oci-images-inside-the-sandbox-podman)
+- [Host ssh-agent forwarding (git signing)](../BACKEND_GUIDE.md#host-ssh-agent-forwarding-git-signing)
+
+## Troubleshooting
+
+For symptom-driven fixes (DNS, egress, image pulls, port publishing, git
+signing, kit services after a resume, host virtualization), see
+[`KNOWN_FAILURE_MODES.md`](../KNOWN_FAILURE_MODES.md) — the msb-tagged entries
+cover the backend-specific failures.
+
+A few quick msb pointers:
+
+```bash
+# Host not ready / boot fails
+msb doctor            # then msb doctor --fix
+
+# Guest can't resolve allow-listed hosts (corporate/VPN resolver unreachable)
+# acq defaults --dns-nameserver 1.1.1.1; override if 1.1.1.1 is blocked:
+export ACQ_MSB_DNS_NAMESERVER=<reachable-resolver>
+
+# A locally-built image won't pull (registry-less reference)
+msb image load -i image.tar -t localhost/my-image:tag
+ACQ_MSB_PULL=never acq run --image localhost/my-image:tag opencode .
+```

--- a/docs/howto/sbx.md
+++ b/docs/howto/sbx.md
@@ -6,7 +6,8 @@
 > **Note:** `msb` (microsandbox) is `acq`'s **default** backend. Use this `sbx`
 > guide when you specifically want the Docker Sandboxes backend (for example, you
 > already run Docker Sandboxes, or want its proxy-based credential store). See the
-> [Backend Guide](../BACKEND_GUIDE.md) to choose between backends. This guide is
+> [Backend Guide](../BACKEND_GUIDE.md) to choose between backends, or the
+> [msb How-To](msb.md) for the default backend. This guide is
 > the sbx **alternative**, not the recommended default (see
 > [ADR-0024](../adr/0024-neutral-user-facing-docs-vs-backend-specific.md) for the
 > neutral-first documentation convention).


### PR DESCRIPTION
Closes GSA-TTS/agentic-coding-quickstart#355. Part of the epic GSA-TTS/agentic-coding-quickstart#348.

## Context
#355 flagged a structural asymmetry: sbx had a dedicated ~560-line how-to (`docs/howto/sbx.md`) while **msb — the default backend — had none**, its content folded into `docs/howto/acq.md` and `docs/BACKEND_GUIDE.md`. That subtly signals "sbx is primary" even though `msb` is the default.

The blocking dependency is now cleared: ADR-0024 (neutral user-facing docs vs. backend-specific) is merged, and we (as maintainers of both repos) confirmed the hosting decision. Because the backend **adapters** live in *this* repo (`acq.backends/{sbx,msb}.sh`), the deep-dives are authored here "alongside the implementation" — a symmetric `docs/howto/msb.md` peer — rather than relocated to `agentic-coding-patterns` (which hosts the kits, not the adapters).

## What changed
- **New `docs/howto/msb.md`**, mirroring the sbx guide's shape: install, host setup (`#msb-host-setup`), backend selection, secrets (host-env `--secret ENV@HOST` binding), create/manage sandboxes, an **acq-first command table with raw `msb` equivalents**, and pointers into `BACKEND_GUIDE.md` for the msb-specific tunables (egress tiers, custom image, podman, ssh-agent forwarding) rather than duplicating them.
- Cross-linked the new peer from `README.md`, `CONTEXT-GUIDE.md`, `docs/howto/acq.md`, `docs/howto/sbx.md`, and `BACKEND_GUIDE.md` frontmatter.

## Acceptance criteria (#355)
- [x] ADR-backed decision on backend-doc ownership recorded (ADR-0024).
- [x] A symmetric `docs/howto/msb.md` exists (chosen over cross-repo relocation, since the adapters live here).
- [x] No user-facing framing implies sbx primacy (already reconciled in #364; this PR completes the symmetry).

## Verification
- `npm run lint:md` → 0 errors
- All `docs/howto/msb.md` relative links resolve; BACKEND_GUIDE anchors verified.
- Commit SSH-signed / Verified.

## Rollback
Revert this commit; docs-only.

## Security impact
None (documentation only).

AI-assisted (OpenCode, claude_4_8_opus). Human-owned and reviewed.
