### PR TITLE
fix(kits): mode validator dropped all kit files on mawk (interval regex)

### DIFF
--- a/acq.backends/kit-translate.sh
+++ b/acq.backends/kit-translate.sh
@@ -524,7 +524,17 @@ kit_spec_files() {
         # smuggle a command via mode, a metacharacter-bearing path, or a bad
         # source path. Drop the whole record on any violation and warn.
         # mode: octal only. path/source: no shell metacharacters or whitespace.
-        if (cur_mode != "" && cur_mode !~ /^[0-7]{3,4}$/) {
+        #
+        # The octal test is written longhand — /^[0-7][0-7][0-7][0-7]?$/ — NOT as
+        # the interval form /^[0-7]{3,4}$/ ON PURPOSE. mawk (the DEFAULT awk on
+        # Debian and Ubuntu, so most hosts that run acq) does not support POSIX
+        # interval expressions in regex; gawk does. Under mawk, /^[0-7]{3,4}$/
+        # matches NOTHING, so every files[] entry carrying a mode (i.e. every
+        # entry in every shipped kit) is dropped here as "invalid mode" and the
+        # kit stages no files at all — a silent, host-dependent failure, because
+        # the warning goes to stderr and the create path treats kit failures as
+        # best-effort. Do NOT "simplify" this back to an interval expression.
+        if (cur_mode != "" && cur_mode !~ /^[0-7][0-7][0-7][0-7]?$/) {
           print "kit-translate: skipping file with invalid mode: " cur_mode > "/dev/stderr"
         } else if (cur_path !~ /^[A-Za-z0-9._\/-]+$/) {
           print "kit-translate: skipping file with unsafe path: " cur_path > "/dev/stderr"
@@ -1172,7 +1182,13 @@ EOF
     /^[[:space:]]+mode:/ {
       v=$0; sub(/^[^:]*:[[:space:]]*/,"",v); sub(/[[:space:]]*#.*/,"",v)
       gsub(/^["'\'' ]+|["'\'' ]+$/,"",v)
-      if (v !~ /^[0-7]{3,4}$/) print v
+      # Longhand /^[0-7][0-7][0-7][0-7]?$/, NOT the interval /^[0-7]{3,4}$/:
+      # mawk (Debian/Ubuntu default awk) has no interval expressions, so the
+      # interval form matches NOTHING under mawk. Here the test is INVERTED
+      # (collect modes that FAIL the pattern, to reject the spec), so under mawk
+      # EVERY mode looks invalid and the whole spec is wrongly rejected. See the
+      # detailed note in the files[] parser above. Do not "simplify" to {3,4}.
+      if (v !~ /^[0-7][0-7][0-7][0-7]?$/) print v
     }' "$spec")
   if [ -n "$bad_mode" ]; then
     while IFS= read -r m; do

--- a/test/bats/100-kit-translate.bats
+++ b/test/bats/100-kit-translate.bats
@@ -191,3 +191,22 @@ SPEC
   assert_regex "$spec" 'OPENCODE_CONFIG: /home/agent/usai-config/opencode\.jsonc'
   refute_regex "$spec" '1BAD'
 }
+
+# Regression guard: the files[].mode validator must NOT use a brace-interval
+# quantifier (/^[0-7]{3,4}$/). mawk — the default awk on Debian/Ubuntu — has no
+# interval-expression support, so that form matches NOTHING under mawk and every
+# kit's files are silently dropped. Both validator sites must stay longhand
+# (/^[0-7][0-7][0-7][0-7]?$/). This source-level check catches a regression
+# regardless of which awk the test runner ships (gawk/BSD-awk would not
+# reproduce the failure at runtime).
+@test "kit-translate: mode validator uses no {n,m} interval regex (mawk-safe)" {
+  run grep -nE 'cur_mode !~ /\^\[0-7\]\{|v !~ /\^\[0-7\]\{' "$REPO_ROOT/acq.backends/kit-translate.sh"
+  assert_failure   # no match -> exit 1 -> the interval form is absent
+}
+
+# The longhand octal pattern accepts 3- and 4-digit octal modes and rejects
+# non-octal / over-long values, portably across awk implementations.
+@test "kit-translate: longhand octal mode pattern accepts valid, rejects junk" {
+  run bash -c 'printf "0755\n755\nabc\n07555\n" | awk "\$0 ~ /^[0-7][0-7][0-7][0-7]?\$/ {print}"'
+  assert_output $'0755\n755'
+}


### PR DESCRIPTION
Closes GSA-TTS/agentic-coding-quickstart#374. Part of epic GSA-TTS/agentic-coding-quickstart#373 — **the standalone blocker that must land first**, ahead of the prime-agent kit + msb recipe work.

## Defect
`kit-translate.sh` validated `files[].mode` with `/^[0-7]{3,4}$/`. **mawk** — the DEFAULT awk on Debian and Ubuntu (most hosts that run acq) — does not support POSIX interval expressions in regex; gawk does. Under mawk `/^[0-7]{3,4}$/` matches **nothing**, so every `files[]` entry carrying a mode (i.e. every entry in every shipped kit) was dropped as "invalid mode" and **the kit staged no files at all**. The warning goes to stderr and the create path treats kit failures as best-effort, so the symptom is a sandbox that comes up fine and silently lacks its kit payload — host-dependent, and it blocks all kit work.

## Fix
Longhand octal test — `/^[0-7][0-7][0-7][0-7]?$/` — at both validator sites (the `files[]` record parser and the raw-spec mode scan), each with a comment explaining the mawk constraint and "do not simplify to an interval". Same shell-portability class as the bash-3.2 vsock guard (#332).

## Verification
- Reproduced on **real mawk 1.3.4 (no-interval mode)**: the old `/^[0-7]{3,4}$/` fails to match `0755`; the longhand form matches `0755` and `755` and still rejects junk / overlong / injection modes (`abc`, `07555`, `"0644; touch /tmp/x"`).
- Added a **source-level regression** (asserts neither validator uses a `{n,m}` interval on the mode regex — portable across every awk, can't be hidden by a gawk/BSD-awk dev box) + longhand accept/reject assertions.
- Full offline suite: **1096 passed / 0 failed**. shellcheck + gitleaks + secrets pre-commit hooks pass.

Refs #374 #373

AI-assisted (OpenCode).