### PR TITLE
fix(acq): bind GitHub token at create by prompting before provision

### DIFF
--- a/acq
+++ b/acq
@@ -873,6 +873,16 @@ case "$subcommand" in
     if ! ensure_key_present "$local_name"; then
       exit 1
     fi
+
+    # Nudge toward a per-sandbox scoped GitHub token BEFORE provisioning, for the
+    # same reason as the USAi gate above: msb binds secrets only at create time
+    # (--secret ENV@HOST), so a GitHub token stored AFTER create would never bind
+    # to this sandbox. Prompting first lets a supplied token be picked up at
+    # create. Warn-not-block (ADR-0013): declining never aborts the create, it
+    # just proceeds without a scoped token (the token is optional).
+    [ -n "$ws" ] || ws="$PWD"
+    advise_github_scope "$local_name" "$ws"
+
     acq_backend_provision "$local_name" "$@"
 
     # Non-blocking USAi key advisory. `create` is detached and never attaches,
@@ -880,12 +890,6 @@ case "$subcommand" in
     # just warn if it's already invalid so a create-only user knows before they
     # later `acq run`.
     advise_valid_key "$local_name"
-
-    # Nudge toward a per-sandbox scoped GitHub token, same as `run`. `create`
-    # is detached (no attached agent), but the advisory is informational plus
-    # an optional interactive prompt, so it applies equally here.
-    [ -n "$ws" ] || ws="$PWD"
-    advise_github_scope "$local_name" "$ws"
     ;;
 
   run)
@@ -952,6 +956,14 @@ case "$subcommand" in
         # just-provisioned sandbox (else branch) is current by construction, so
         # the offer is intentionally only on this path.
         maybe_offer_bundle_refresh "${ACQ_RESOLVED_BACKEND}" "$local_name" "$_pre_heal_status"
+
+        # Re-attach GitHub-token advisory. A sandbox that already exists cannot
+        # re-bind a token at create, but it CAN be re-fed live (msb modify /
+        # sbx proxy), so still nudge toward a scoped token when one is missing.
+        # Fresh creates run the advisory BEFORE provision (below) so msb binds it
+        # at create; this re-attach case is the live-refeed path.
+        [ -n "$ws" ] || ws="$PWD"
+        advise_github_scope "$local_name" "$ws"
       else
         # Fresh create: the USAi API key MUST be stored before we provision,
         # because a backend (msb) binds secrets only at create time. Creating the
@@ -962,6 +974,16 @@ case "$subcommand" in
         if ! ensure_key_present "$local_name"; then
           exit 1
         fi
+
+        # Nudge toward a per-sandbox scoped GitHub token BEFORE provisioning, for
+        # the SAME reason as the USAi gate: msb binds secrets only at create time
+        # (--secret ENV@HOST), so a token stored AFTER create would never bind to
+        # this sandbox. Prompting first lets a supplied token be picked up at
+        # create. Warn-not-block (ADR-0013): declining never aborts, it just
+        # proceeds without a scoped token (the token is optional).
+        [ -n "$ws" ] || ws="$PWD"
+        advise_github_scope "$local_name" "$ws"
+
         acq_backend_provision "$local_name" "${create_args[@]}"
       fi
 
@@ -978,7 +1000,6 @@ case "$subcommand" in
 
       [ -n "$ws" ] || ws="$PWD"
       warn_if_no_git_identity "$ws"
-      advise_github_scope "$local_name" "$ws"
 
       # opencode (since v1.15.1) fetches its binary in a postinstall step that
       # some sandbox images skip, so a fresh launch fails with "postinstall

--- a/docs/adr/0013-per-sandbox-github-token-downscoping.md
+++ b/docs/adr/0013-per-sandbox-github-token-downscoping.md
@@ -77,6 +77,16 @@ Concretely:
   **warn-not-block** convention
   (matching `warn_if_no_ssh_signing_key` / `warn_if_no_git_identity`) — it never
   blocks a run and is a no-op in CI / non-TTY.
+  On a **fresh create**, this advisory runs **before** `acq_backend_provision`,
+  not after. A backend that binds secrets only at create time (msb, via
+  `--secret ENV@HOST`) can only pick up a token that is already stored when the
+  sandbox is created; a token scoped after create would never bind to that
+  sandbox. Ordering the advisory before provision — the same reason the USAi key
+  gate precedes provision — lets a supplied token bind at create. It stays
+  warn-not-block: declining proceeds with the create (unlike the USAi gate, the
+  GitHub token is optional). On a **re-attach to an existing** sandbox the
+  advisory still runs (after the heal), but there it drives the live re-feed path
+  (`msb modify` / sbx proxy) rather than a create-time binding.
 - The global `sbx secret set -g github` path is **deprecated in the docs** (kept
   working for back-compat), and the per-sandbox scoped flow becomes the
   documented default.

--- a/docs/howto/msb.md
+++ b/docs/howto/msb.md
@@ -119,6 +119,14 @@ and records the `ENV@HOST` binding msb applies at create. See
 the [Backend Guide](../BACKEND_GUIDE.md) for the full per-backend secret model.
 
 > [!NOTE]
+> Because msb binds secrets **at create time**, both the USAi key and any GitHub
+> token must be in place *before* the sandbox is created. `acq run` / `acq create`
+> handle this for you: on a fresh create they gate on the USAi key and offer to
+> scope a GitHub token **before** provisioning, so a token you supply binds to the
+> new sandbox. A token added after create would not bind to it (you can still add
+> it live with `acq secret set` / `acq github-scope`, which re-feeds a running
+> sandbox via `msb modify`).
+>
 > Because msb swaps the real value in on the wire, inspecting the guest
 > environment is not automatically a leak — but never deliberately dump secret
 > values (`echo $SECRET`, piping `env` to a log). See `AGENTS.md`.

--- a/test/bats/30-dispatch-routing.bats
+++ b/test/bats/30-dispatch-routing.bats
@@ -118,6 +118,23 @@ _seed_usai() {
   assert [ -f "$STUBDIR/.msb_created" ]
 }
 
+# The github-scope advisory MUST run BEFORE the sandbox is created. On msb the
+# GitHub token binds only at create time (--secret ENV@HOST), so a token stored
+# by the advisory after create would never bind to the sandbox — the same
+# ordering the USAi key gate uses (both precede provision). Assert the advisory's
+# line appears AND the create still proceeds (warn-not-block: a declined,
+# non-TTY advisory does not abort the create). Uses msb, where create-time
+# binding is the operative constraint.
+@test "create(msb): github advisory runs before provision; declined advisory still provisions" {
+  local ghproj="$STUBDIR/gh-mcreate"; mkdir -p "$ghproj"
+  ( cd "$ghproj" && git init -q && git remote add origin https://github.com/GSA-TTS/quickstart.git )
+  rm -f "$STUBDIR/.msb_created"
+  run bash -c 'printf "" | USAI_API_KEY="sk-ci-host" ACQ_BACKEND=msb ACQ_SECRET_FORCE_FILE=1 ACQ_SECRET_FILE_DIR="$3/.secrets" "$1" create opencode "$2"' _ "$ACQ" "$ghproj" "$ghproj"
+  assert_output --partial 'no repo-scoped GitHub token'
+  assert_regex "$(cat "$CALLS")" 'msb create'
+  assert [ -f "$STUBDIR/.msb_created" ]
+}
+
 @test "run: present key + bad status -> post-create gate offers rotate; decline aborts" {
   local proj="$STUBDIR/keyrun2"; mkdir -p "$proj"
   _seed_usai


### PR DESCRIPTION
## Context

On the MSB backend, secrets are bound **at create time** (`--secret ENV@HOST`) — the same constraint the USAi API key already respects (`ensure_key_present` runs before `acq_backend_provision`). But the GitHub-token prompt (`advise_github_scope`) ran **after** `acq_backend_provision`, so a token stored during that prompt would never bind to the just-created sandbox.

This makes the GitHub token behave like the USAi key: the prompt to set/scope it now happens **before** the sandbox is created.

## Changes

**`acq`** (dispatch):
- `create` verb: moved `advise_github_scope` to run **before** `acq_backend_provision`, right after the `ensure_key_present` USAi gate.
- `run` verb, fresh-create branch: added `advise_github_scope` before `acq_backend_provision` (it previously only ran post-provision).
- `run` verb, re-attach branch: kept an advisory call — a re-attach can't rebind at create, so there it drives the live re-feed path (`msb modify` / sbx proxy).

The prompt now runs pre-create for **all** backends and stays **warn-and-continue** (declining never aborts the create — the GitHub token is optional, consistent with ADR-0013, unlike the USAi gate which fails closed).

**Docs:**
- `docs/adr/0013-per-sandbox-github-token-downscoping.md` — documents the pre-create ordering and rationale.
- `docs/howto/msb.md` — notes that both the USAi key and a GitHub token must be in place before create, and that `acq run`/`acq create` handle this ordering.

## Verification

- `bash -n acq` and `bash -n scripts/test-acq`: clean
- `./scripts/test-acq`: **1142 passed, 0 failed** (+3 new msb assertions covering "advisory runs before `msb create`" and "declined advisory still provisions")
- `shellcheck --severity=warning` on `acq`, `acq.backends/common.sh`, `scripts/test-acq`: clean (one file per invocation, per the repo's shellcheck guidance)

## Security impact

No change to attack surface. The GitHub token is still read from the TTY (never argv), stored sandbox-scoped, and the real value never enters the guest. Reordering only affects *when* the prompt fires relative to sandbox creation.

## Rollback

Revert the single commit on this branch; the prior post-provision ordering is restored.
