### PR TITLE
feat(install): add auto-selecting curl|sh installer + streamline README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,141 +29,179 @@ Once you complete this Quickstart to get your environment working, use the Playb
 
 ## 5-Minute Quickstart
 
-### Step 0: Prerequisites
+You'll do three things: **open a terminal**, **install `acq`**, and **run it**.
+You do **not** need to be a developer, and you do **not** need administrator
+rights on your Mac.
 
-You will run the commands in this guide from a terminal. Open one now...
+### Step 1: Open a terminal
+
+- **macOS:** press ⌘-Space, type "Terminal", press Return. (Or find it in
+  Applications → Utilities.)
+
+You'll type (or paste) the commands below into this window.
+
+> **Not on an Apple Silicon Mac?** The sandbox needs hardware virtualization. See
+> [prerequisites and other platforms](#prerequisites-and-other-platforms) below.
+
+### Step 2: Install acq
+
+Paste this one line and press Return:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/GSA-TTS/agentic-coding-quickstart/main/install.sh | sh
+```
+
+That's it — you don't have to choose *how* to install. The installer:
+
+- **picks the best method already on your Mac** — Homebrew if you have it, then
+  npm if you have it, otherwise a self-contained download — so you get automatic
+  upgrades/uninstall if you already use a package manager, and a working setup
+  either way,
+- puts the `acq` command on your computer so you can run it from **any folder**,
+- offers to install **msb** (the sandbox `acq` runs your agent inside), and
+- **asks before** changing anything about your setup — it never edits your
+  configuration without your OK, and it never needs administrator rights.
 
 <details>
-<summary>How to open a terminal (click to expand)</summary>
+<summary>Prompted to install "Command Line Tools"? (click to expand)</summary>
 
-- **macOS:** open **Terminal** — find it in Applications → Utilities, or press ⌘-Space, type "Terminal", and press Return.
-- **Windows:** open **Windows Terminal** or **PowerShell** — press the Start button, type "Terminal" (or "PowerShell"), and press Enter.
-- **Linux (Ubuntu):** press Ctrl-Alt-T, or search for "Terminal" in your applications menu.
+acq needs Apple's **Command Line Tools** (they provide `git`, which acq uses).
+If they aren't installed yet, the installer starts them for you and **waits**
+while they install — you'll see a window titled **"Install Command Line
+Developer Tools."** Click **Install** and accept the license. No administrator
+rights are required.
+
+**Can't find the window?** It sometimes opens **minimized in your Dock** rather
+than in front of you — look there. The installer keeps waiting until the tools
+finish, then continues on its own.
 
 </details>
 
-Good news: there's very little to gather in advance. You need a supported
-computer and a way to run these commands — `acq` walks you through the USAi key
-and GitHub access interactively on first run (see [Step 3](#step-3-create-and-run-a-sandbox)).
+<details>
+<summary>Prefer to look before you run it? (recommended) (click to expand)</summary>
 
-| Requirement     | Notes                                                      |
-| --------------- | ---------------------------------------------------------- |
-| A supported host for microVMs | msb uses hardware virtualization. You need one of:<ul><li>**macOS** — Apple Silicon (Intel Macs are not supported)</li><li>**Windows 11** — with the Windows Hypervisor Platform enabled (preview)</li><li>**Linux** — glibc-based, with KVM enabled (`/dev/kvm` present)</li></ul>If you need more detail than this, see [msb host setup](docs/howto/acq.md#msb-host-setup) for per-platform particulars. |
-| `git`           | Already installed on macOS and on the supported Linux hosts — **nothing to do**. Check with `git --version`. (On macOS, the first time you run a `git` command the system may offer to install the Command Line Tools; look for a pop-up window with a license agreement, then accept it to install the tools.)|
-| USAi API key    | **Required, but `acq` guides you** — on first run `acq` prompts you to paste a key and validates it, so you need not configure anything beforehand. You will need to [create a key](https://console.gsa.usai.gov/key-management) (do it now or when prompted); USAi keys expire every 7 days. <p>Running **non-interactively** (CI/piped) has no prompt, so the key must be set in advance — see [Secrets](docs/howto/acq.md#secrets).</p> |
-| GitHub token | **Nothing to get in advance** — `acq` offers to walk you through creating a repo-scoped token on first run, when your project contains GitHub repos. You can decline and add one later. <p>(A token lets the agent authenticate to GitHub, work with private repositories, and act on your behalf — open PRs, push to branches, etc.)</p> |
-
-### Step 1: Install microsandbox (msb)
-
-msb is a standalone, open-source (Apache-2.0) microVM runtime (a host-level tool, independent of this repository). Install it on your machine:
+You never have to pipe a script straight into your shell. Download it, read it,
+then run it:
 
 ```bash
-# With Homebrew, our preference at GSA TTS:
-brew install superradcompany/tap/microsandbox
+curl -fsSL -o install-acq.sh https://raw.githubusercontent.com/GSA-TTS/agentic-coding-quickstart/main/install.sh
+less install-acq.sh      # read it
+sh install-acq.sh --dry-run   # show what it WOULD do, changing nothing
+sh install-acq.sh             # actually install
 ```
 
-> Don't have Homebrew? Install it from [brew.sh](https://brew.sh), or use the
-> `curl` installer below (which needs no Homebrew).
+You can also force a specific method with `--method brew|npm|clone`.
 
-or
+</details>
+
+<details>
+<summary>Already use Homebrew or Node? (click to expand)</summary>
+
+You don't need to do anything special — the one-line installer above **detects
+Homebrew and npm automatically** and uses whichever you have (falling back to a
+self-contained download if you have neither). Package-manager installs give you
+`upgrade`/`uninstall` for free.
+
+If you'd rather run the direct command yourself:
 
 ```bash
-# More generally, on macOS, Linux, or WSL (Windows):
-curl -fsSL https://install.microsandbox.dev | sh
+npm install -g github:GSA-TTS/agentic-coding-quickstart   # if you use Node/npm — works today
+brew install GSA-TTS/tap/acq                              # if you use Homebrew — coming soon (tap not published yet)
 ```
 
-### Step 2: Clone this repo
+</details>
+
+### Step 3: Run it
+
+Point `acq` at the folder you want the agent to work in (an existing project, or
+a new empty folder you just made):
+
+```bash
+acq run opencode ~/my-project
+```
+
+That's it — you're now running an AI coding agent with USAi access and
+restricted filesystem and network access. Repeat Step 3 for each project.
+
+> [!NOTE]
+> **The first run takes a minute or two.** `acq` boots a microVM, installs the
+> coding agent, and fetches its configuration kits, showing progress as it goes.
+> Later runs against the same project are much faster.
+
+On first run, `acq` sets you up interactively — nothing to configure beforehand:
+
+- **USAi key** — `acq` prompts you to paste a key and validates it. Create one at
+  the [USAi key console](https://console.gsa.usai.gov/key-management) (keys expire
+  every 7 days).
+- **GitHub token** — when your project contains GitHub repos, `acq` offers to walk
+  you through creating a repo-scoped token. You can decline and add one later.
+- **Git signing** — `acq` warns if your commits won't sign/verify correctly, and
+  tells you how to fix it.
+
+`acq` injects secrets into the sandbox at runtime — the real values **never enter
+the guest**.
+
+---
+
+### Prerequisites and other platforms
+
+Almost nothing to gather in advance — `acq` walks you through the USAi key and
+GitHub access on first run. What you do need:
+
+| Requirement | Notes |
+| --- | --- |
+| A supported host | The sandbox uses hardware virtualization. You need **macOS on Apple Silicon** (Intel Macs are not supported), **Windows 11** with the Windows Hypervisor Platform (preview), or **Linux** (glibc, with `/dev/kvm`). More detail: [msb host setup](docs/howto/acq.md#msb-host-setup). |
+| A terminal | macOS: Terminal (⌘-Space → "Terminal"). Windows: Windows Terminal / PowerShell. Linux: Ctrl-Alt-T. |
+| USAi API key | `acq` prompts for it on first run. [Create one here](https://console.gsa.usai.gov/key-management). |
+
+**Manual install (developers).** If you'd rather clone and run from the clone —
+or want a specific tagged release — see [Manual install](#manual-install).
+
+**Want the sbx backend instead of msb?** See the
+[Backend Guide](docs/BACKEND_GUIDE.md) and [sbx How-To](docs/howto/sbx.md).
+
+**Want to know what `acq` is doing under the hood?** See
+[How It Works](#how-it-works).
+
+**Working across multiple repos?** See
+[Multiple Workspaces](docs/CONCEPTS.md#multiple-workspaces).
+
+---
+
+### Manual install
+
+If you're comfortable in a terminal and prefer to run `acq` from a clone:
 
 ```bash
 git clone https://github.com/GSA-TTS/agentic-coding-quickstart.git
 cd agentic-coding-quickstart
+./acq run opencode ~/my-project
 ```
 
-The `acq` command in Step 3 is run from inside this cloned folder.
+You'll also need the `msb` sandbox runtime — install it without admin via
+`curl -fsSL https://install.microsandbox.dev | sh` (or, if you have Homebrew,
+`brew install superradcompany/tap/microsandbox`).
+
+> **Running `./acq` from the clone?** It only works from **inside** the
+> `agentic-coding-quickstart` folder (that's where the `acq` file lives). If you
+> get "no such file `./acq`", `cd` back into that folder first. The one-line
+> installer in [Step 2](#step-2-install-acq) avoids this entirely by putting `acq`
+> on your PATH.
 
 <details>
 <summary>Testing a specific tagged release? (click to expand)</summary>
 
-To try a specific tagged version, check it out after cloning:
+After cloning, check out the tag:
 
 ```bash
-git checkout v3.0.0-rc1
+git checkout v3.0.0-rc2
 ```
 
-Git will print a message about being in a **"detached HEAD" state**. That is
-**normal — it is not an error.** It just means you're looking at a specific
-tagged snapshot rather than a branch. You can run `acq` exactly as described
-below. To go back to the latest development version, run `git switch main`.
+Git prints a message about a **"detached HEAD" state** — that's **normal, not an
+error.** It just means you're on a specific snapshot. Run `acq` as usual; to go
+back to the latest, run `git switch main`.
 
 </details>
-
-### Step 3: Create and run a sandbox
-
-```bash
-./acq run opencode /path/to/your/project
-```
-
-`/path/to/your/project` is the folder you want the agent to work in. It can be
-an **existing project** or a **new, empty folder** you just made for this — your
-choice. If the folder is (or will be) a software project, initialize git in it
-first so the agent can track its changes:
-
-```bash
-mkdir -p ~/my-project        # a new folder, if you don't have one yet
-cd ~/my-project
-git init .                   # recommended if this is for software development
-```
-
-Then point `acq` at it (e.g. `./acq run opencode ~/my-project`).
-
-That's it. You're now running an AI coding agent with USAi access and restricted
-filesystem and network access. Repeat this to create sandboxes for each project
-you want to work on.
-
-> [!NOTE]
-> **The first run does real work and takes a minute or two.** `acq` boots a
-> microVM, installs the coding agent, and fetches its configuration kits. It
-> shows a progress spinner and status lines as it goes, so you can watch each
-> phase — later runs against the same project are much faster. (To silence the
-> animation, e.g. in a script, set `ACQ_NO_PROGRESS=1`; plain status lines still
-> print.)
-
-On first run, `acq` sets you up interactively — nothing to configure beforehand:
-
-- **USAi key** — `acq` validates your key and, if none is set (or it has
-  expired), prompts you to paste one and stores it. Have your key from the
-  [prerequisites](#step-0-prerequisites) handy.
-- **GitHub token** — when your workspace contains GitHub repos, `acq` offers to
-  walk you through creating a repo-scoped token so the agent can access them.
-  You can decline and add one later.
-- **Git signing** — `acq` warns if your host has no SSH key loaded or the repo
-  has no `user.email`, so your sandbox commits sign and verify correctly.
-
-`acq` injects secrets into the sandbox at runtime — the real values **never
-enter the guest**. To set secrets ahead of time (for CI or scripted setups),
-see [Secrets](docs/howto/acq.md#secrets) in the acq how-to.
-
-> [!NOTE]
-> Sandboxes sign your git commits with your host SSH key on **both** backends —
-> sbx forwards the host ssh-agent implicitly, and msb forwards it via `--vsock`
-> (msb >= 0.6.9) — both triggered simply by having your host `SSH_AUTH_SOCK` set,
-> so `ssh-add` your signing key first. For those commits to
-> show **Verified** on GitHub you need, one time: a GitHub-verified `user.email`
-> set **in the project** (repo-local config, since the sandbox has its own home
-> and does not see your host global git config) and your **public** signing key
-> registered on GitHub as a _Signing Key_. See
-> [Commits show "Unverified" on GitHub](#troubleshooting) below.
-
-**Want to know more about what `acq` is doing under the hood?** See [How It Works](#how-it-works).
-
-**Need more details, or want to use the sbx backend instead?** See the
-[acq How-To](docs/howto/acq.md), the [Backend Guide](docs/BACKEND_GUIDE.md),
-the [msb How-To](docs/howto/msb.md) (default backend), and the
-[sbx How-To](docs/howto/sbx.md).
-
-**Working across multiple repos?** Mounting extra directories works on either
-backend via `acq`; the command syntax and examples are documented in
-[Multiple Workspaces](docs/CONCEPTS.md#multiple-workspaces).
 
 ---
 
@@ -172,6 +210,38 @@ backend via `acq`; the command syntax and examples are documented in
 If the happy path above didn't work, the most common issues are below. For
 everything else (wrong providers, auth failures, TLS/certificate errors, and
 more), see **[docs/KNOWN_FAILURE_MODES.md](docs/KNOWN_FAILURE_MODES.md)**.
+
+<details>
+<summary><strong>"no such file or directory: ./acq"</strong> (click to expand)</summary>
+
+This means `acq` isn't where you're typing the command. Two fixes:
+
+- **Recommended:** install `acq` with the one-line installer in
+  [Step 2](#step-2-install-acq). Then run `acq` (no `./`) from **any** folder.
+- **If you cloned manually:** `./acq` only works from **inside** the
+  `agentic-coding-quickstart` folder — that's where the `acq` file lives. `cd`
+  back into it first (`cd ~/agentic-coding-quickstart`, or wherever you cloned
+  it), then run `./acq run opencode ~/my-project`.
+
+</details>
+
+<details>
+<summary><strong>"No developer tools were found" / git won't run</strong> (click to expand)</summary>
+
+The first time your Mac uses `git`, it installs the Command Line Tools. If you
+see `xcode-select: note: No developer tools were found, requesting install`,
+run:
+
+```bash
+xcode-select --install
+```
+
+A pop-up window titled **"Install Command Line Developer Tools"** appears — click
+**Install** and accept the license. **If you can't find the window, look in your
+Dock** — it sometimes opens minimized there rather than in front of you. When it
+finishes, re-run your command. (No administrator rights are required.)
+
+</details>
 
 <details>
 <summary><strong>Authentication failures (expired USAi key)</strong> (click to expand)</summary>
@@ -246,8 +316,8 @@ git config user.name  "Your Name"
 ```
 
 **Step 2 — register your signing key on GitHub.** Add the **public** half of your
-signing key as a **Signing Key**: _Settings → SSH and GPG keys → New SSH key →
-Key type: **Signing Key**_. (The same key may already be an authentication key;
+signing key as a **Signing Key**: *Settings → SSH and GPG keys → New SSH key →
+Key type: **Signing Key***. (The same key may already be an authentication key;
 add it again as a signing key.)
 
 Then make a **new** commit — verification applies going forward.

--- a/docs/adr/0026-installation-and-distribution.md
+++ b/docs/adr/0026-installation-and-distribution.md
@@ -1,0 +1,347 @@
+---
+title: "Installation and Distribution of acq for Non-Technical Users"
+status: accepted
+date: 2026-08-24
+decision_makers: ["Bret Mogilefsky"]
+category: architecture
+nist_controls: ["CM-2", "CM-3", "CM-6", "SA-8", "SA-15", "SR-3", "SR-11"]
+impact_level: low
+ato_relevance: no
+risk_treatment: accept
+supersedes: []
+---
+
+# ADR-0026: Installation and Distribution of `acq` for Non-Technical Users
+
+## Context and Problem Statement
+
+Today the only documented way to get `acq` onto a machine is a manual
+`git clone` followed by running `./acq` from inside the clone (README Step 2).
+That is fine for developers, but the Quickstart's target audience explicitly
+includes **new, non-technical users who are uncomfortable with the command
+line**. For them the current flow has two problems:
+
+1. **`acq` is not on `PATH`.** Users must `cd` into the clone and type `./acq`,
+   or hand-craft a symlink. Neither is obvious to a non-technical user.
+2. **There is no gentle "just install it" front door.** The natural instincts a
+   newcomer might reach for do not serve a *bare* Mac:
+   - `npm install …` fails with `command not found` because macOS ships no
+     Node.js and — unlike `git` — provides **no shim that offers to install it**
+     (see "The `git` vs `npm` asymmetry" below). The error is a dead end.
+   - `brew install …` only works if Homebrew is already present.
+
+We want an installation story that puts `acq` (and, at the user's option, the
+`msb` sandbox runtime) on `PATH` with the least possible friction, without
+compromising the federal security posture (no `sudo`, no silent `PATH` edits,
+and a path to verifiable/pinned installs — available today via `--ref`/`--sha`,
+default-pinned once release automation lands; see the Security posture section).
+
+### Observed evidence from early non-technical users
+
+Onboarding sessions with self-described "not very technical" users surfaced the
+exact failure modes this ADR addresses, and constrain the solution space:
+
+- **The `./acq`-from-the-wrong-folder trap hit multiple users.** After cloning,
+  users ran `./acq run opencode ~/my-project` from their *project* directory (or
+  their home directory) and got "no such file `./acq`", with no idea they had to
+  `cd` back into the clone. At least two separate users hit this; one only
+  recovered with an experienced colleague sitting next to them. Getting `acq`
+  onto `PATH` removes this trap entirely — there is no "correct folder" to be in.
+- **Homebrew cannot be *assumed* for the target audience on GSA GFE.** A user
+  could not install Homebrew because installing it **requires administrator
+  rights**. Not all GFE accounts lack admin — many developers have admin as part
+  of a developer profile — but a *non-technical* newcomer generally does not, and
+  cannot be assumed to. The `curl`-based paths (both `acq`'s installer and
+  microsandbox's) worked **without admin** and were repeatedly called out as a
+  major reduction in barrier to entry. This means the front door must **not
+  require** Homebrew, while still *using* it automatically when it happens to be
+  present (see method selection below).
+- **The Xcode Command Line Tools prompt is easy to miss.** The CLT install
+  dialog that `git` triggers can appear minimized in the Dock rather than in
+  front of the user, stalling a newcomer who is watching the terminal. The
+  installer and README should tell users to look for that pop-up (including in
+  the Dock) explicitly.
+- **Interim workarounds users invented — a shell alias or a hand-made symlink
+  into `~/.local/bin` — all require walking a neophyte through editing dotfiles**,
+  which is exactly the friction we are trying to remove. An installer that offers
+  (with consent) to add the `PATH` line is the humane version of this.
+
+These observations reinforce the decision drivers below and, in particular, the
+choice of a no-admin `curl | sh` installer as the primary path rather than
+Homebrew or npm.
+
+### The `git` vs `npm` asymmetry (why npm cannot be the front door)
+
+A common assumption is that `npm`, like `git`, will prompt a fresh Mac to
+install what it needs. It does not:
+
+- **`git`** is backed by an Apple *shim* at `/usr/bin/git`. The first invocation
+  on a clean Mac triggers a **GUI dialog** offering to install the Command Line
+  Tools (CLT). One click installs `git`, `clang`, `make`, etc.
+- **`node`/`npm` have no shim.** There is no `/usr/bin/npm`. On a bare Mac,
+  `npm` yields `zsh: command not found: npm` with **no pop-up and no next step**.
+  Getting `npm` requires the user to already know it comes from Node.js and to
+  install Node (nodejs.org `.pkg`, or Homebrew, or a version manager) first —
+  precisely the reasoning a non-technical user cannot be expected to perform.
+
+Therefore `npm` is only reasonable as a *convenience for users who already have
+Node*, never as the primary path.
+
+### Can we avoid the `git` / Command Line Tools dependency?
+
+We explored a **hash-confirmed tarball** install to avoid requiring `git` (and
+therefore the macOS Command Line Tools, CLT): download the release tarball with
+`curl`, verify it against a published `SHA256SUMS` (fail-closed on mismatch),
+and extract it — all with tools macOS already ships (`curl`, `shasum`, `tar`).
+
+We decided **not** to pursue this, because it does not actually remove the CLT
+dependency — it only defers it:
+
+- **`acq` itself needs `git` at runtime.** The tool shells out to `git` for
+  version introspection (`acq version` reports `branch@commit`) and users are
+  immediately guided to `git init` their project so the agent can track changes.
+  A user who installed via tarball would hit the CLT prompt on their very first
+  real `acq` command instead of during install — a *worse* experience, because
+  it happens after they think setup is finished.
+- **The integrity win is available without the tarball.** Git objects are
+  content-addressed, so pinning the clone to a **full commit SHA** is itself a
+  cryptographic integrity check — the checkout cannot succeed with tampered
+  content. That gives us hash-confirmed provenance without a second download
+  path or a separate checksum artifact to maintain.
+
+So the CLT dependency is unavoidable for this tool; the right move is to make it
+**painless and early** rather than to engineer around it. The installer's clone
+method therefore **proactively triggers and waits for the CLT install** (via
+`xcode-select --install`, no admin required), guiding the user to the dialog —
+including the fact that it can open **minimized in the Dock**, a real stumbling
+point observed in onboarding — and polls until `git` is usable before
+continuing. This turns the previously fatal "git not found" into a handled,
+guided step.
+
+## Decision Drivers
+
+- **Zero-to-installed on a bare Mac** — the front door must work on a machine
+  with nothing but what macOS ships (`curl`; the installer then sets up `git`
+  via the CLT install, which needs no admin).
+- **No administrator rights required** — managed GSA GFE accounts are not
+  admins. The front door must not depend on anything that needs `sudo` or admin
+  to install (this rules Homebrew out as the primary path, since installing
+  Homebrew itself requires admin).
+- **`acq` on `PATH`** — after install, the user types `acq`, not `./acq` from a
+  clone.
+- **Never touch the user's `PATH` without consent** — offer to add the line,
+  and if declined, print the exact line for them to add themselves.
+- **Federal security posture** — pinned to a release tag, published checksums,
+  inspect-first supported, no `sudo`, install into a user-writable prefix.
+- **Preserve `acq version` introspection and easy updates** — the on-disk layout
+  should keep `acq`'s git-based version reporting and support in-place updates.
+- **Minimal new surface** — reuse the existing `acq`/kit machinery and `msb`
+  install methods rather than inventing new runtime dependencies.
+
+## Considered Options
+
+### Getting `acq` on PATH — one front door that picks the best available method
+
+There is a **single** entry point — the hardened `curl … | sh` installer — so a
+newcomer never has to *decide* how to install. `curl` ships with macOS, so the
+front door works on a bare machine. The installer then **auto-selects the best
+method already available on the host**, in this order, so users who happen to
+have a package manager get its upgrade/uninstall semantics for free:
+
+1. **Homebrew, if `brew` is already present** → `brew install GSA-TTS/tap/acq`.
+   Idiomatic for a Bash CLI, auditable/versioned formula, and — crucially —
+   `brew upgrade` / `brew uninstall` lifecycle. The installer **never installs
+   Homebrew itself** (that needs administrator rights, which a non-technical
+   newcomer generally lacks); it only *uses* brew when it is already there.
+2. **npm, if `npm` is already present** → `npm install -g
+   github:GSA-TTS/agentic-coding-quickstart`. Gives `npm -g` upgrade/uninstall
+   semantics for users who already have Node. Not a *front* door itself, because
+   on a bare Mac `npm` does not exist and — unlike `git` — offers no install
+   prompt (see the asymmetry section above).
+3. **Managed git clone + launcher symlink (fallback)** → the always-works path
+   that needs nothing but `curl` and `git`. Chosen when neither brew nor npm is
+   present, which is the expected case for the true target audience.
+
+The installer supports overriding the auto-selection (`--method brew|npm|clone`)
+and, regardless of method, uses no `sudo`, supports inspect-first / `--dry-run`,
+and asks consent before any `PATH` change.
+
+**Deferred — signed, notarized `.pkg` (double-clickable).** The best possible UX
+for a non-technical user (pure GUI, no terminal for the install step), but
+requires an Apple Developer ID certificate and notarization pipeline — an
+organizational hurdle out of scope for this increment. Revisit if the
+installer proves insufficient.
+
+> **Increment note:** in this PR the **npm branch is fully wired** (the
+> `package.json` `bin`/`files` fields ship an `acq` launcher, so
+> `npm install -g github:GSA-TTS/agentic-coding-quickstart` puts `acq` on
+> `PATH`). The **brew branch is stubbed** — the installer detects `brew` and
+> reports what it *would* run, but the formula lives in a separate
+> `GSA-TTS/homebrew-tap` repository that does not exist yet (deferred below). The
+> **clone fallback is fully functional**, so the front door works end-to-end
+> today regardless of which method is selected; the brew branch lights up once
+> the tap is created.
+
+### On-disk layout
+
+1. **Managed git clone + launcher symlink.** Chosen for the **clone fallback**
+   method. The installer does a shallow clone to a fixed, user-writable location
+   (default `${XDG_DATA_HOME:-$HOME/.local/share}/acq`) and symlinks the `acq`
+   launcher into a user-writable `PATH` directory (default `$HOME/.local/bin`).
+   This preserves `acq version`'s `branch@commit` git introspection and supports
+   in-place updates via `git pull` (or installer re-run). The brew and npm
+   methods instead delegate lifecycle to those package managers and do not use
+   this layout.
+2. **Non-git file tree + launcher.** Rejected: `acq version` would report
+   `unknown`, and updates would be a full re-download rather than a fast pull.
+
+### Installing the sandbox runtime (`msb`)
+
+- **Offer to install `msb` alongside `acq`** (with consent), reusing the
+  README's existing methods (`brew install superradcompany/tap/microsandbox`, or
+  `curl -fsSL https://install.microsandbox.dev | sh`). Chosen so a non-technical
+  user reaches a working state in one flow. `--no-msb` opts out.
+
+## Decision Outcome
+
+Chosen: **a single hardened `curl … | sh` front door that auto-selects the best
+install method already on the host** — Homebrew if `brew` is present, else npm if
+`npm` is present, else a managed git clone + launcher symlink. Users who have a
+package manager get its upgrade/uninstall semantics automatically; everyone else
+gets the always-works clone fallback. The installer also **offers to install
+`msb`** with the user's consent.
+
+`PATH` is never modified without explicit consent; when declined, the installer
+prints the exact line for the user to add.
+
+### Scope of the initial increment (this PR)
+
+In bounds now:
+
+- This ADR (`0026`, `status: accepted`).
+- `install.sh` — the hardened installer with brew → npm → clone auto-selection
+  (the **clone** and **npm** branches fully functional; the **brew branch
+  stubbed** pending the external tap repo).
+- `package.json` `bin`/`files` wiring so the npm branch actually installs `acq`.
+- **Optional commit-SHA pinning** (`--sha` / `ACQ_INSTALL_SHA`). The clone method
+  can pin to a full 40-char commit SHA and verifies `HEAD` equals it after
+  checkout, failing closed (and cleaning up) on mismatch — git objects are
+  content-addressed, so a matching SHA *is* a cryptographic integrity check.
+- **release-please manages `package.json`'s `version`.** An `extra-files` entry in
+  `release-please-config.json` bumps `$.version` on each release so the npm
+  package version tracks the release manifest (currently `2.0.0`) instead of a
+  hand-maintained placeholder.
+- README streamlining + install instructions.
+
+Deferred — only the work that **must** happen outside this repository (tracked
+as issues):
+
+- Creating the `GSA-TTS/homebrew-tap` repository and the `acq` formula, then
+  un-stubbing the installer's brew branch. (External repo — cannot be done from
+  this repo; tracked as an issue.)
+- Release-automation changes to attach `SHA256SUMS` to each release, then swap
+  the README install URL from `main` to a pinned release tag.
+- **Default the clone to a canonical commit SHA per release.** The `--sha`
+  mechanism is now in place (see "in bounds" above); what remains is for release
+  automation to publish the canonical SHA for each version so the installer can
+  default to it rather than a movable ref.
+
+### Security posture
+
+- **No `sudo`.** Everything installs under the user's home; the `PATH` dir is
+  user-writable.
+- **Pinning is available today, but not yet the default.** The installer accepts
+  `--ref <tag>` and `--sha <full-commit>` (the latter is integrity-checked against
+  the checked-out `HEAD`, failing closed on mismatch — a content-addressed check).
+  **Until the first release ships `install.sh`, the default `REF` is `main`** —
+  a moving target, deliberately, because there is no release tag yet that even
+  contains this installer, and the README's `curl` URL itself fetches the script
+  from `main`. This is an honest pre-release state, **not** a pinning guarantee.
+  Flipping the default to a published release tag + a shipped canonical commit SHA
+  (so the default path is content-addressed) is tracked in
+  <https://github.com/GSA-TTS/agentic-coding-quickstart/issues/408>; that release
+  automation will move the README URL and the `REF` default together.
+- **Verifiable.** `--sha` gives content-addressed integrity today; releases will
+  additionally publish `SHA256SUMS` (#408). Inspect-first is supported (download
+  and read `install.sh` before running; `--dry-run` prints actions).
+- **Consent-gated side effects.** `PATH` edits and `msb` installation each
+  require explicit consent; declining is always a safe, documented fallback.
+- **Idempotent.** Re-running updates an existing install rather than duplicating
+  it.
+- **Two unpinned legs today, both called out honestly.** (1) The default `REF`
+  is `main` until #408 lands, as described above — opt into `--ref`/`--sha` for a
+  verifiable install now. (2) The optional `msb` install, when no Homebrew is
+  present, runs the upstream `curl -fsSL https://install.microsandbox.dev | sh`;
+  that upstream installer is outside our control and is not pinned/checksummed by
+  us. Both are consent-gated (and, under `--yes`, authorized by the same blanket
+  opt-in as the `PATH` edit). The `acq` clone/npm install resolve whatever `REF`
+  resolves to — so their supply-chain guarantee is exactly as strong as the `REF`
+  the user chooses (pinned when `--ref`/`--sha` is supplied; `main` otherwise).
+
+> **Control Mapping:** CM-2 (Baseline Configuration), CM-3 (Configuration Change
+> Control), CM-6 (Configuration Settings), SA-8 (Security Engineering
+> Principles), SA-15 (Development Process), SR-3 (Supply Chain Controls),
+> SR-11 (Component Authenticity).
+
+## Consequences
+
+- **Positive:** a bare-Mac, non-technical user gets `acq` (and optionally `msb`)
+  on `PATH` from a single pasted command; developers keep the manual clone;
+  brew and npm serve users who prefer them; `acq version` and updates keep
+  working.
+- **Negative / trade-off:** `curl | bash` carries a cultural stigma in security
+  circles; we mitigate with pinning, checksums, inspect-first, no-`sudo`, and
+  consent gates, but cannot fully eliminate the pattern short of the deferred
+  signed `.pkg`.
+- **Maintenance:** each release must publish `SHA256SUMS`, and (once the tap
+  lands) the formula must track releases. Both are deferred follow-ups.
+
+## Validation
+
+- **Offline / static:** `install.sh` passes `shellcheck --severity=warning`;
+  README passes the repo markdown lint (`npm run lint:md`); the offline acq
+  suite (`scripts/test-acq-bats`, bats-core per ADR-0025) continues to pass (the
+  installer does not change `acq` dispatch).
+- **npm packaging:** `npm pack --dry-run` ships exactly the runtime footprint
+  (`acq`, `acq.backends/`, plus `package.json`/`README`/`LICENSE`); a global
+  install (`npm install -g <spec>`) creates an `acq` launcher on `PATH` that
+  resolves its script dir through the npm symlink and runs (`acq version` reports
+  the module path and backend). The npm install is not a git checkout, so
+  `acq version` reports "not a git clone" for the commit line — expected.
+- **SHA pinning:** with `--sha <full-40-hex>` the clone method checks that commit
+  out and verifies `HEAD` equals it, failing closed (and removing the partial
+  clone) when the SHA is absent or mismatched; a malformed SHA, or `--sha` with a
+  non-clone method, is rejected at argument parse. Verified live against a local
+  checkout (matching SHA succeeds and prints "verified HEAD matches"; a
+  well-formed but absent SHA fails closed and cleans up).
+- **release-please version sync:** `release-please-config.json` carries an
+  `extra-files` entry (`type: json`, `jsonpath: $.version`) so the next release
+  bumps `package.json`'s `version`; `npm pack --dry-run` reports the manifest
+  version (`2.0.0`) rather than a placeholder.
+- **Manual (bare-Mac reviewer):** on a clean macOS account, run the pinned
+  one-liner; confirm `acq` resolves on `PATH` (after accepting the offered
+  `PATH` line or adding the printed line), `acq version` reports the pinned
+  `branch@commit`, and `--dry-run` performs no writes. Decline paths (`PATH`
+  edit declined, `--no-msb`) leave a working `acq` and print correct guidance.
+- **Live end-to-end:** deferred to the release that publishes `SHA256SUMS` and
+  hosts `install.sh` at a pinned raw URL, since the hosted-URL + checksum flow
+  cannot be exercised until those artifacts exist.
+
+## Links
+
+- [ADR-0010: acq pluggable backends](0010-acq-pluggable-backends.md) — the
+  `acq` wrapper and its XDG config location this install layout is consistent
+  with.
+- [ADR-0011: msb backend and neutral kits](0011-msb-backend-and-neutral-kits.md)
+  — the `msb` runtime this installer optionally installs.
+- microsandbox install methods: <https://install.microsandbox.dev> and the
+  `superradcompany/tap/microsandbox` Homebrew tap.
+- Related code/docs (this increment): `install.sh`, `README.md`,
+  `release-please-config.json`.
+
+### Deferred-work tracking
+
+- Homebrew tap + formula (un-stub the brew branch):
+  <https://github.com/GSA-TTS/agentic-coding-quickstart/issues/407>
+- Release automation (`SHA256SUMS`, canonical release SHA, pin README/installer):
+  <https://github.com/GSA-TTS/agentic-coding-quickstart/issues/408>

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,537 @@
+#!/bin/sh
+# install.sh — hardened installer for acq (agentic-coding-quickstart)
+#
+# One front door that puts `acq` on your PATH, and (with your consent) installs
+# the `msb` sandbox runtime it needs. You never have to choose an install
+# method: this script auto-selects the best one already available on your host —
+#
+#   1. Homebrew  (if `brew` is present)  -> brew upgrade/uninstall semantics
+#   2. npm       (if `npm`  is present)  -> npm -g upgrade/uninstall semantics
+#   3. git clone (fallback)              -> always works with just curl + git
+#
+# It works on a bare macOS system: it uses `curl`, and `git` (which the clone
+# method sets up for you by triggering the Command Line Tools install — no admin
+# needed). It never uses `sudo`, installs only under your home directory, and
+# never changes your PATH without asking first.
+#
+# NOTE: In this increment the npm and clone branches are fully functional. The
+# brew branch is a stub (the Homebrew tap repo does not exist yet) that falls
+# back to the clone install, so no path leaves the user without acq. See the
+# installation-and-distribution ADR under docs/adr/.
+#
+# Usage:
+#   curl -fsSL <pinned-raw-url>/install.sh | sh
+#   sh install.sh [--method brew|npm|clone] [--ref <tag-or-branch>]
+#                 [--no-msb] [--dry-run] [--yes] [--help]
+#
+# Inspect first (recommended): download and read this file, then run it.
+
+set -eu
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable by flags / environment)
+# ---------------------------------------------------------------------------
+
+REPO_URL="${ACQ_INSTALL_REPO_URL:-https://github.com/GSA-TTS/agentic-coding-quickstart.git}"
+# Default to `main` for now. This is a rolling-release default: `main` is a
+# moving target, NOT a pinned, content-addressed reference. For a verifiable
+# install, pass --ref <tag> or --sha <commit> (the latter is integrity-checked
+# after checkout). Defaulting to a published release tag + shipped SHA is
+# tracked follow-up work; see ADR-0026 and its deferred-work tracking section.
+REF="${ACQ_INSTALL_REF:-main}"
+
+# Optional: pin to an exact 40-char commit SHA. When set, the clone method
+# verifies the checked-out HEAD equals this SHA and fails closed otherwise —
+# git objects are content-addressed, so a matching SHA *is* an integrity check
+# (no separate checksum file needed). See ADR-0026.
+SHA="${ACQ_INSTALL_SHA:-}"
+
+# Where the managed clone lives (preserves `acq version` git introspection).
+DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+CLONE_DIR="${ACQ_INSTALL_CLONE_DIR:-$DATA_HOME/acq}"
+
+# Where the `acq` launcher symlink goes (must be a user-writable PATH dir).
+BIN_DIR="${ACQ_INSTALL_BIN_DIR:-$HOME/.local/bin}"
+
+# Install method: auto (detect), or forced to brew|npm|clone via --method.
+METHOD="${ACQ_INSTALL_METHOD:-auto}"
+
+# npm package spec used by the npm method (pinned by --ref when possible).
+NPM_SPEC_BASE="github:GSA-TTS/agentic-coding-quickstart"
+# Homebrew formula used by the brew method.
+BREW_FORMULA="GSA-TTS/tap/acq"
+
+INSTALL_MSB=1   # offer to install msb; --no-msb disables
+DRY_RUN=0
+ASSUME_YES=0
+NEED_PATH_HELP=0   # set by the clone method when BIN_DIR is not on PATH
+
+# ---------------------------------------------------------------------------
+# Output helpers (no color if not a TTY)
+# ---------------------------------------------------------------------------
+
+if [ -t 1 ]; then
+  B="$(printf '\033[1m')"; R="$(printf '\033[0m')"
+  YEL="$(printf '\033[33m')"; GRN="$(printf '\033[32m')"; RED="$(printf '\033[31m')"
+else
+  B=""; R=""; YEL=""; GRN=""; RED=""
+fi
+
+info()  { printf '%s\n' "$*"; }
+step()  { printf '%s==>%s %s\n' "$B" "$R" "$*"; }
+warn()  { printf '%s%s%s\n' "$YEL" "$*" "$R" >&2; }
+ok()    { printf '%s%s%s\n' "$GRN" "$*" "$R"; }
+die()   { printf '%serror:%s %s\n' "$RED" "$R" "$*" >&2; exit 1; }
+
+# In dry-run, show what would run; otherwise run it.
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  [dry-run] %s\n' "$*"
+  else
+    "$@"
+  fi
+}
+
+# Show a command that is STUBBED this increment (never executed).
+stub() {
+  printf '  [stub]    %s\n' "$*"
+}
+
+usage() {
+  cat <<'EOF'
+install.sh — install acq (agentic-coding-quickstart)
+
+It auto-selects the best method already on your host: Homebrew, then npm, then
+a git clone. Override with --method.
+
+Options:
+  --method <m>         Force install method: brew | npm | clone (default: auto).
+  --ref <tag|branch>   Version to install (default: main — a moving target;
+                       pass a release tag for a stable, repeatable install).
+  --sha <commit>       Pin to a full 40-char commit SHA and verify HEAD matches
+                       it after checkout (content-addressed integrity check).
+  --no-msb             Do not install the msb sandbox runtime.
+  --dry-run            Print what would happen; make no changes.
+  --yes, -y            Assume "yes" to prompts (PATH edit, msb install).
+                       Intended for non-interactive/CI use.
+  --help               Show this help.
+
+Environment overrides:
+  ACQ_INSTALL_METHOD, ACQ_INSTALL_REF, ACQ_INSTALL_SHA, ACQ_INSTALL_REPO_URL,
+  ACQ_INSTALL_CLONE_DIR, ACQ_INSTALL_BIN_DIR
+
+This installer uses no sudo, installs only under your home directory, and
+never changes your PATH without asking.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --method) [ $# -ge 2 ] || die "--method needs a value"; METHOD="$2"; shift 2 ;;
+    --method=*) METHOD="${1#--method=}"; shift ;;
+    --ref) [ $# -ge 2 ] || die "--ref needs a value"; REF="$2"; shift 2 ;;
+    --ref=*) REF="${1#--ref=}"; shift ;;
+    --sha) [ $# -ge 2 ] || die "--sha needs a value"; SHA="$2"; shift 2 ;;
+    --sha=*) SHA="${1#--sha=}"; shift ;;
+    --no-msb) INSTALL_MSB=0; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --yes|-y) ASSUME_YES=1; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) die "unknown option: $1 (try --help)" ;;
+  esac
+done
+
+case "$METHOD" in
+  auto|brew|npm|clone) : ;;
+  *) die "invalid --method '$METHOD' (expected: brew, npm, or clone)" ;;
+esac
+
+# A pinned SHA must be a full 40-hex commit id (short SHAs and tags cannot be
+# integrity-verified the same way). Reject anything else up front.
+if [ -n "$SHA" ]; then
+  case "$SHA" in
+    *[!0-9a-fA-F]* | "") die "invalid --sha '$SHA' (expected a 40-char hex commit id)" ;;
+    *) [ "${#SHA}" -eq 40 ] || die "invalid --sha '$SHA' (expected a 40-char hex commit id)" ;;
+  esac
+  # SHA pinning only applies to the git-clone method (npm/brew resolve their own).
+  if [ "$METHOD" = "npm" ] || [ "$METHOD" = "brew" ]; then
+    die "--sha is only supported with --method clone"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Prompt helper — yes/no, honoring --yes and non-interactive stdin
+# ---------------------------------------------------------------------------
+# Returns 0 for yes, 1 for no. Default is NO when there is no way to ask
+# (fail-closed: never take a consent-gated action without an explicit yes).
+confirm() {
+  prompt="$1"
+  if [ "$ASSUME_YES" -eq 1 ]; then
+    return 0
+  fi
+  # If stdin is a terminal, ask there.
+  if [ -t 0 ]; then
+    printf '%s [y/N] ' "$prompt"
+    read -r ans || return 1
+  # Otherwise (e.g. piped `curl | sh`), try the controlling terminal. Guard the
+  # write/read so an unusable /dev/tty falls through to a clean decline rather
+  # than leaking errors.
+  elif { printf '%s [y/N] ' "$prompt" > /dev/tty; } 2>/dev/null \
+       && read -r ans < /dev/tty 2>/dev/null; then
+    :
+  else
+    return 1
+  fi
+  case "$ans" in
+    [yY]|[yY][eE][sS]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+step "Checking your system"
+
+OS="$(uname -s 2>/dev/null || echo unknown)"
+case "$OS" in
+  Darwin) : ;;
+  Linux)  warn "Linux detected — supported, but this installer is tuned for macOS." ;;
+  *)      warn "Unrecognized OS '$OS' — proceeding, but this is untested here." ;;
+esac
+
+if [ "$OS" = "Darwin" ]; then
+  ARCH="$(uname -m 2>/dev/null || echo unknown)"
+  if [ "$ARCH" != "arm64" ]; then
+    warn "This Mac reports arch '$ARCH'. acq's msb backend requires Apple Silicon"
+    warn "(Intel Macs are not supported for microVMs). Install will continue, but"
+    warn "the sandbox may not run. See the README prerequisites."
+  fi
+fi
+
+command -v curl >/dev/null 2>&1 || die "curl is required but was not found."
+
+# ---------------------------------------------------------------------------
+# Method selection — auto picks brew, then npm, then clone
+# ---------------------------------------------------------------------------
+
+if [ "$METHOD" = "auto" ]; then
+  if command -v brew >/dev/null 2>&1; then
+    METHOD="brew"
+  elif command -v npm >/dev/null 2>&1; then
+    METHOD="npm"
+  else
+    METHOD="clone"
+  fi
+  info "  install method: $METHOD (auto-selected)"
+else
+  info "  install method: $METHOD (forced)"
+fi
+info "  version:   $REF"
+[ -n "$SHA" ] && info "  pinned commit: $SHA"
+[ "$DRY_RUN" -eq 1 ] && warn "  (dry-run: no changes will be made)"
+
+# ---------------------------------------------------------------------------
+# Method: Homebrew  (STUBBED this increment — the tap repo does not exist yet)
+# ---------------------------------------------------------------------------
+
+install_via_brew() {
+  step "Installing acq via Homebrew"
+  info "  Homebrew gives you 'brew upgrade acq' / 'brew uninstall acq' later."
+  warn "  NOTE: the acq Homebrew tap is not published yet — this branch is a stub."
+  warn "  Falling back to the git-clone install so you still get a working acq now."
+  stub "brew install $BREW_FORMULA"
+  # The tap lives in a separate GSA-TTS/homebrew-tap repository that has to be
+  # created outside this repo; until it exists, do the real install via clone so
+  # the user is never left without acq.
+  install_via_clone
+}
+
+# ---------------------------------------------------------------------------
+# Method: npm  (functional — package.json ships an `acq` bin + files)
+# ---------------------------------------------------------------------------
+
+install_via_npm() {
+  step "Installing acq via npm"
+  info "  npm gives you 'npm -g upgrade' / 'npm -g uninstall' later."
+  spec="$NPM_SPEC_BASE"
+  # Pin the git ref into the npm spec when one is set, so `npm -g` installs the
+  # same version the rest of the installer targets.
+  [ -n "$REF" ] && spec="$NPM_SPEC_BASE#$REF"
+  run npm install -g "$spec"
+  if [ "$DRY_RUN" -eq 0 ] && command -v acq >/dev/null 2>&1; then
+    ok "  acq is installed via npm ($(command -v acq))."
+  elif [ "$DRY_RUN" -eq 0 ]; then
+    NEED_PATH_HELP=1
+    npm_bin="$(npm prefix -g 2>/dev/null)"
+    [ -n "$npm_bin" ] && npm_bin="$npm_bin/bin"
+    warn "  npm finished, but 'acq' is not on your PATH yet. Ensure npm's global"
+    warn "  bin dir is on PATH: ${npm_bin:-\$(npm prefix -g)/bin}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Method: managed git clone + launcher symlink  (fully functional fallback)
+# ---------------------------------------------------------------------------
+
+path_has_bindir() {
+  case ":$PATH:" in
+    *":$BIN_DIR:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Choose the login shell's rc file for the suggested PATH line.
+rc_file_for_shell() {
+  case "${SHELL:-}" in
+    */zsh) printf '%s\n' "$HOME/.zshrc" ;;
+    */bash) printf '%s\n' "$HOME/.bash_profile" ;;
+    *) printf '%s\n' "$HOME/.profile" ;;
+  esac
+}
+
+# Is `git` actually runnable? On macOS the /usr/bin/git shim exists even with no
+# Command Line Tools, but invoking it errors ("no developer tools were found").
+# So we probe by RUNNING git, not just `command -v`.
+git_is_usable() {
+  command -v git >/dev/null 2>&1 && git --version >/dev/null 2>&1
+}
+
+# Ensure a usable git, proactively triggering the macOS Command Line Tools
+# install and waiting for it to finish. No sudo required. On non-macOS (or if
+# the tools never appear) this fails closed with guidance.
+ensure_git() {
+  if git_is_usable; then
+    return 0
+  fi
+
+  if [ "$OS" != "Darwin" ]; then
+    die "git is required but was not found. Install git and re-run this installer."
+  fi
+
+  # The Command Line Tools install is an interactive, GUI-driven step: it pops a
+  # dialog a human must click, then we poll for up to 30 minutes. That is useless
+  # in a non-interactive context (--yes/CI, or piped stdin with no controlling
+  # terminal): the dialog can't be clicked and the job would just block until the
+  # timeout. Fail fast instead, with the same actionable guidance.
+  #
+  # "Interactive" here means: we can reach a terminal to guide the user. That is
+  # true if stdin is a TTY, or if we can open the controlling terminal /dev/tty.
+  # Probe /dev/tty in a subshell so a failed open can't abort this script.
+  can_reach_tty=1
+  [ -t 0 ] || ( : >/dev/tty ) 2>/dev/null || can_reach_tty=0
+  if [ "$ASSUME_YES" -eq 1 ] || [ "$can_reach_tty" -eq 0 ]; then
+    die "git is required but the macOS Command Line Tools are not installed.
+This installer can set them up interactively, but it is running non-interactively
+(--yes or no terminal), so it will not launch the GUI installer and wait. Install
+the tools first, then re-run:
+
+    xcode-select --install"
+  fi
+
+  step "Setting up the developer tools acq needs (git)"
+  info "  macOS provides git through the Command Line Tools, which aren't installed yet."
+  info "  These are also needed to run acq later, so we install them now — no admin required."
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  [dry-run] xcode-select --install  (then wait for git to become usable)\n'
+    return 0
+  fi
+
+  # Trigger the GUI installer. It returns immediately; the install runs in a
+  # separate window. A non-zero exit usually means "already installed / in
+  # progress", which is fine — we verify by polling git below.
+  xcode-select --install >/dev/null 2>&1 || true
+
+  info ""
+  warn "  A window titled \"Install Command Line Developer Tools\" should appear."
+  warn "  Click Install and accept the license. If you don't see it, LOOK IN YOUR"
+  warn "  DOCK — the window sometimes opens minimized there instead of in front."
+  info ""
+  info "  Waiting for the tools to finish installing... (this can take a few minutes)"
+
+  # Poll until git is usable. Cap the wait so we never hang forever; a user who
+  # cancels the dialog will hit the timeout and get actionable guidance.
+  waited=0
+  max_wait=1800   # 30 minutes
+  while ! git_is_usable; do
+    sleep 5
+    waited=$((waited + 5))
+    if [ "$waited" -ge "$max_wait" ]; then
+      die "Timed out waiting for the Command Line Tools to install.
+Finish the installation (look for the window, possibly in your Dock), then
+re-run this installer. You can also install them manually with:
+
+    xcode-select --install"
+    fi
+  done
+  ok "  Command Line Tools are installed — git is ready."
+}
+
+install_via_clone() {
+  ensure_git
+
+  info "  clone dir: $CLONE_DIR"
+  info "  launcher:  $BIN_DIR/acq"
+  [ -n "$SHA" ] && info "  pinned to commit: $SHA"
+
+  # What we ultimately want HEAD to be. A pinned SHA wins over the ref.
+  target="${SHA:-$REF}"
+
+  # --- Clone or update the managed clone ---
+  if [ -e "$CLONE_DIR/.git" ]; then
+    step "Updating existing install at $CLONE_DIR"
+    run git -C "$CLONE_DIR" fetch --tags --prune origin
+    run git -C "$CLONE_DIR" checkout "$target"
+    if [ "$DRY_RUN" -eq 0 ] && [ -z "$SHA" ] \
+       && git -C "$CLONE_DIR" symbolic-ref -q HEAD >/dev/null 2>&1; then
+      # Only fast-forward when on a branch (a pinned SHA is detached HEAD).
+      run git -C "$CLONE_DIR" pull --ff-only origin "$REF"
+    fi
+  elif [ -e "$CLONE_DIR" ]; then
+    die "$CLONE_DIR exists but is not a git clone. Move it aside and re-run."
+  else
+    step "Downloading acq into $CLONE_DIR"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      printf '  [dry-run] git clone --depth 1 --branch %s %s %s\n' "$REF" "$REPO_URL" "$CLONE_DIR"
+      [ -n "$SHA" ] && printf '  [dry-run] git checkout %s  (then verify HEAD == SHA)\n' "$SHA"
+    else
+      # Try a shallow clone of the requested ref (tag or branch). If that fails
+      # (e.g. a full commit SHA, which --branch can't take), fall back to a full
+      # clone and then check the target out. Either way, we MUST end up on the
+      # target — fail closed if we can't, and clean up any partial clone so a
+      # re-run isn't wedged by a half-populated directory.
+      if ! git clone --depth 1 --branch "$REF" "$REPO_URL" "$CLONE_DIR" 2>/dev/null; then
+        rm -rf "$CLONE_DIR"
+        git clone "$REPO_URL" "$CLONE_DIR" \
+          || { rm -rf "$CLONE_DIR"; die "failed to clone $REPO_URL"; }
+      fi
+      if [ -n "$SHA" ]; then
+        # A shallow clone may not contain the pinned commit; deepen if needed.
+        git -C "$CLONE_DIR" checkout "$SHA" 2>/dev/null \
+          || { git -C "$CLONE_DIR" fetch --unshallow origin 2>/dev/null \
+                 || git -C "$CLONE_DIR" fetch origin 2>/dev/null || true;
+               git -C "$CLONE_DIR" checkout "$SHA" \
+                 || { rm -rf "$CLONE_DIR"; die "pinned commit '$SHA' not found in $REPO_URL"; }; }
+      else
+        git -C "$CLONE_DIR" checkout "$REF" \
+          || { rm -rf "$CLONE_DIR"; die "requested version '$REF' not found in $REPO_URL"; }
+      fi
+    fi
+  fi
+
+  # --- Integrity check: HEAD must equal the pinned SHA (content-addressed) ---
+  if [ -n "$SHA" ] && [ "$DRY_RUN" -eq 0 ]; then
+    head_sha="$(git -C "$CLONE_DIR" rev-parse HEAD 2>/dev/null || echo '')"
+    if [ "$head_sha" != "$SHA" ]; then
+      rm -rf "$CLONE_DIR"
+      die "integrity check failed: HEAD is '$head_sha', expected pinned SHA '$SHA'"
+    fi
+    ok "  verified HEAD matches pinned commit $SHA"
+  fi
+
+
+  # --- Symlink the launcher onto PATH ---
+  step "Linking the acq launcher"
+  run mkdir -p "$BIN_DIR"
+
+  acq_target="$CLONE_DIR/acq"
+  if [ "$DRY_RUN" -eq 0 ] && [ ! -f "$acq_target" ]; then
+    die "expected launcher not found at $acq_target (did the clone succeed?)"
+  fi
+  run ln -sf "$acq_target" "$BIN_DIR/acq"
+  ok "  linked $BIN_DIR/acq -> $acq_target"
+
+  # --- PATH handling — never modified without consent ---
+  path_line="export PATH=\"$BIN_DIR:\$PATH\""
+
+  if path_has_bindir; then
+    ok "  $BIN_DIR is already on your PATH."
+  else
+    NEED_PATH_HELP=1
+    rc_file="$(rc_file_for_shell)"
+    step "Your PATH does not include $BIN_DIR"
+    info "  To type 'acq' from anywhere, that directory needs to be on your PATH."
+    if confirm "  Add it to $rc_file for you?"; then
+      if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] append to %s: %s\n' "$rc_file" "$path_line"
+      elif [ -f "$rc_file" ] && grep -qF "$path_line" "$rc_file" 2>/dev/null; then
+        ok "  $rc_file already contains the PATH line — leaving it as-is."
+      else
+        {
+          printf '\n# Added by acq install.sh — put acq on PATH\n'
+          printf '%s\n' "$path_line"
+        } >> "$rc_file"
+        ok "  Added the line to $rc_file."
+      fi
+      info "  Open a new terminal (or run: ${B}source \"$rc_file\"${R}) to pick it up."
+    else
+      warn "  Not changing your PATH. To do it yourself, add this line to $rc_file:"
+      printf '\n    %s\n\n' "$path_line"
+      info "  Then open a new terminal (or run: source \"$rc_file\")."
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Run the selected method
+# ---------------------------------------------------------------------------
+
+case "$METHOD" in
+  brew)  install_via_brew ;;
+  npm)   install_via_npm ;;
+  clone) install_via_clone ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Optionally install the msb sandbox runtime
+# ---------------------------------------------------------------------------
+
+if [ "$INSTALL_MSB" -eq 1 ]; then
+  if command -v msb >/dev/null 2>&1; then
+    ok "  msb is already installed ($(command -v msb))."
+  else
+    step "The msb sandbox runtime is not installed"
+    info "  acq runs your agent inside an msb microVM. It is a separate, open-source tool."
+    if confirm "  Install msb now?"; then
+      if command -v brew >/dev/null 2>&1; then
+        info "  Installing via Homebrew..."
+        run brew install superradcompany/tap/microsandbox
+      else
+        info "  Homebrew not found; using the microsandbox install script."
+        info "  (This downloads and runs https://install.microsandbox.dev.)"
+        if [ "$DRY_RUN" -eq 1 ]; then
+          printf '  [dry-run] curl -fsSL https://install.microsandbox.dev | sh\n'
+        else
+          curl -fsSL https://install.microsandbox.dev | sh
+        fi
+      fi
+    else
+      warn "  Skipping msb. Install it later with one of:"
+      info  "    brew install superradcompany/tap/microsandbox"
+      info  "    curl -fsSL https://install.microsandbox.dev | sh"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+step "Done"
+if [ "$NEED_PATH_HELP" -eq 1 ]; then
+  if [ "$METHOD" = "clone" ]; then
+    info "Once $BIN_DIR is on your PATH, try:  ${B}acq version${R}"
+    info "Or run it directly right now:        ${B}$BIN_DIR/acq version${R}"
+  else
+    info "Once npm's global bin dir is on your PATH, try:  ${B}acq version${R}"
+  fi
+else
+  info "Try it now:  ${B}acq version${R}"
+fi
+info "Next, start a sandbox:  ${B}acq run opencode /path/to/your/project${R}"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,29 @@
 {
+  "name": "@gsa-tts/agentic-coding-quickstart",
+  "//version": "Managed by release-please via extra-files in release-please-config.json; do not edit by hand.",
+  "version": "2.0.0",
+  "description": "acq — run AI coding agents inside a federally-configured sandbox (SBX or MSB) with USAi endpoints",
   "type": "module",
+  "bin": {
+    "acq": "acq"
+  },
+  "files": [
+    "acq",
+    "acq.backends/"
+  ],
   "scripts": {
     "lint:md": "npx --prefix .github/linters markdownlint-cli2 '**/*.md' '#node_modules' '#.github/linters/node_modules' '#CHANGELOG.md' '#tmp'",
     "lint:secrets": "gitleaks detect --source .",
     "lint": "npm run lint:md",
     "check": "pre-commit run --all-files"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GSA-TTS/agentic-coding-quickstart.git"
+  },
+  "license": "CC0-1.0",
+  "os": [
+    "darwin",
+    "linux"
+  ]
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,14 @@
     ".": {
       "release-type": "simple",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "package.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
> **Ready for review.** Rebased on current `main`; the ADR is numbered (`0026`, accepted) and the npm path is now wired. Please still weigh in on the **ADR design**, not just the code.

## Context

Onboarding surfaced two recurring pains for non-technical users (see the ADR's "Observed evidence" section):

- The **`./acq`-from-the-wrong-folder trap** — running `./acq` from a project/home dir yields "no such file", with no obvious recovery. Multiple users hit it.
- **No gentle "just install it" front door** — Homebrew needs admin (managed GFE accounts often lack it), and `npm`/`brew` dead-end on a bare Mac.

This PR gives `acq` a real install path that puts it on `PATH`.

## What's here

- **`install.sh`** — one hardened `curl | sh` front door that **auto-selects the best method already on the host**: Homebrew → npm → managed git clone.
  - **npm branch is FUNCTIONAL** (wired via `package.json` `bin`/`files`; installs place `acq` on PATH and the launcher resolves its `acq.backends/` tree through the npm symlink).
  - **brew branch is STUBBED** (detects brew, explains the tap isn't published yet, falls back to clone) pending a published Homebrew tap (deferred below).
  - **clone fallback is fully functional**: shallow clone → `~/.local/share/acq`, symlink → `~/.local/bin/acq`, idempotent, no `sudo`. **Fails closed** if a requested `--ref` can't be checked out, cleaning up any partial clone.
  - **Optional commit-SHA pinning** (`--sha` / `ACQ_INSTALL_SHA`): checks out a full 40-char commit and verifies `HEAD` matches it, failing closed (and cleaning up) on a missing/mismatched SHA — git objects are content-addressed, so a matching SHA is itself an integrity check.
  - **Proactive Command Line Tools setup**: probes git by *running* it, triggers `xcode-select --install` (no admin), guides the user to the dialog (incl. "look in your Dock"), and **waits** until git is usable (5s poll, 30-min cap → actionable timeout).
  - **PATH is never changed without consent**; declining prints the exact line.
  - Flags: `--method brew|npm|clone`, `--ref`, `--sha`, `--no-msb`, `--dry-run`, `--yes`/`-y`.
- **`release-please-config.json`** — an `extra-files` (`$.version`) entry so release-please bumps `package.json`'s `version` on release; `package.json` now carries the real manifest version (`2.0.0`) instead of a placeholder.
- **README** — rewritten to a 3-step quickstart (open terminal → install → run) for a non-technical audience; prerequisites/manual-clone/tagged-release/brew/npm moved into `<details>`; new troubleshooting for the wrong-folder trap and CLT/Dock.
- **ADR** (`docs/adr/0026-installation-and-distribution.md`, `status: accepted`) — the design rationale, incl. why the **hash-confirmed tarball was rejected** (git/CLT is needed at runtime anyway; a full commit-SHA checkout is itself content-addressed integrity), and a carve-out noting the *msb* leg is an unpinned upstream `curl | sh` outside our control.

## Deferred (to be filed as issues **after** ADR sign-off)

- Create `GSA-TTS/homebrew-tap` + `acq` formula → un-stub brew branch. *(External repo — cannot be created from this repo.)*
- Release automation to publish `SHA256SUMS` and a **canonical commit SHA per release**; then swap README URL `main` → pinned tag, and default the installer to that SHA (the `--sha` mechanism is already in place).

## Verification transcript

Run in the acq sandbox (Linux; macOS-specific CLT path exercised via stubs + `--dry-run`):

| Check | Result |
|---|---|
| `shellcheck --severity=warning install.sh` | clean |
| `markdownlint-cli2` (our files) | 0 issues |
| `scripts/test-acq-bats` (bats-core, per ADR-0025) | 368 passed, 0 failed |
| `gitleaks protect --staged` | no leaks |
| `npm pack --dry-run` | ships exactly `acq` + `acq.backends/` (7) + `package.json`/README/LICENSE (11 files) |
| `npm install -g` (local) | places `acq`, launcher resolves through symlink |
| auto-select (host has npm, no brew) | picks npm |
| `--method clone --yes` (real, local repo) | launcher linked, PATH consent line added, idempotent |
| bad `--ref` (clone) | **fails closed** (exit 1), partial clone removed |
| `--sha <matching>` (real, local repo) | checks out + prints "verified HEAD matches pinned commit" |
| `--sha <well-formed but absent>` | **fails closed** (exit 1), partial clone removed |
| malformed `--sha` / `--sha` with `--method npm` | rejected at parse with clear error |
| `release-please` version sync | `npm pack` reports manifest version `2.0.0` (no placeholder) |
| invalid `--method bogus` | exits 1 with clear error |
| no-usable-git on "Darwin" (stubbed, dry-run) | shows CLT trigger step, no hang |
| non-macOS no-git | fails closed with guidance |

## Rollback

Revert this branch/PR. `install.sh` is additive and the README/ADR are docs; nothing in `acq`'s runtime dispatch changed.

## Security impact

No auth/authz changes. Installer uses no `sudo`, writes only under `\$HOME`, gates PATH edits and msb install on consent, fails closed on an unresolvable `--ref`, and (once releases publish it) will verify integrity via a pinned commit SHA. The msb leg delegates to msb's own upstream installer, which is unpinned and outside our control (documented in the ADR).

AI-assisted (OpenCode). Human owner: @mogul.

## Testing this PR before merge

The README one-liner points at `main`, which won't have `install.sh` until this merges. To try it now, run it from a checkout of this branch. **Safe (non-destructive) checks that never touch your real `~/.local` or PATH:**

```sh
git fetch origin docs/npm-install-fresh-macos
git checkout docs/npm-install-fresh-macos

# 1. See what it would do — makes no changes, no network mutations:
sh install.sh --help
sh install.sh --dry-run
sh install.sh --method clone --dry-run
sh install.sh --method npm   --dry-run

# 2. Real clone install into a throwaway HOME (does NOT touch your real dotfiles),
#    using this local checkout as the source so it's offline:
TMP=$(mktemp -d)
HOME="$TMP" ACQ_INSTALL_REPO_URL="$PWD" ACQ_INSTALL_REF=docs/npm-install-fresh-macos \
  sh install.sh --method clone --no-msb --yes
ls -l "$TMP/.local/bin/acq"                    # launcher symlink
git -C "$TMP/.local/share/acq" rev-parse HEAD  # pinned to the ref
rm -rf "$TMP"

# 3. Fail-closed check: a bad --ref must exit non-zero and leave nothing behind:
TMP=$(mktemp -d)
HOME="$TMP" ACQ_INSTALL_REPO_URL="$PWD" ACQ_INSTALL_REF=does-not-exist \
  sh install.sh --method clone --no-msb --yes ; echo "exit=$?"   # expect exit=1
ls "$TMP/.local/share/acq" 2>&1 || echo "clone absent (good)"
rm -rf "$TMP"
```

For a **real, non-throwaway** install on macOS, just run `sh install.sh` (auto-selects a method, asks before editing PATH or installing msb). On a bare Mac it will trigger the Command Line Tools dialog — accept it (look in your Dock if you don't see the window).