### PR TITLE
feat(kits): synthesize chmod from hybrid/v1 mode fields into generated setup.install

### DIFF
--- a/acq.backends/kit-translate.sh
+++ b/acq.backends/kit-translate.sh
@@ -397,8 +397,10 @@ _kit_pp_validate() {
 # mounts at create) and mount UNSEEDED: an empty filesystem shadows any image
 # content at the path, so a kit needing seeded content ships its own first-boot
 # copy step. Multiple kits union by path, last wins — sbx resolves that itself.
-# The neutral schema carries no `mode` (msb has no equivalent; kits chmod in a
-# startup step instead — see ADR-0023).
+# The neutral schema carries no volume `mode` (msb has no equivalent; kits
+# chmod in a startup step instead — see ADR-0023). files[].mode is different:
+# the translator synthesizes its chmod into setup.install itself (#381,
+# _kit_sbx_mode_chmod_script).
 #
 # VALIDATION (SI-10): these values reach a generated sbx-v2 spec and an msb
 # create argv, so they are untrusted. path must be absolute, charset-restricted
@@ -853,6 +855,10 @@ kit_spec_agent_context() {
 #     -> /home/... at create time. The neutral `phase:` hint (e.g. initFiles) is
 #     NOT re-emitted as a command — the static file-drop is sbx's create-time
 #     mechanism and already lands the payload before setup hooks run.
+#   files[].mode (home-staged)      -> setup.install[] combined chmod step
+#     sbx pins every files/ payload to 0644 at materialization (docker/
+#     sbx-releases#499), so declared modes are synthesized into one chmod
+#     install command — see _kit_sbx_mode_chmod_script (#381).
 #   commands[phase=install]         -> setup.install[]
 #   commands[phase=initFiles]       -> setup.startup[]
 #   commands[phase=startup]         -> setup.startup[]
@@ -986,14 +992,84 @@ kit_translate_to_sbx() {
   printf '%s\n' "$out"
 }
 
+# Build the combined chmod script for kit-declared file modes (#381). sbx pins
+# every kit files/ payload to 0644 at materialization (content-addressed,
+# reproducible layers — docker/sbx-releases#499; v0.39 extended the pin to
+# local/git kit loads), so a declared `mode:` only takes effect through the
+# maintainer-sanctioned workaround: a setup.install chmod that runs after
+# files/home/ staging. Emits one `chmod && echo || echo` line per home-staged
+# mode-bearing files[] entry, in SPEC ORDER (deterministic output). Non-home
+# (workspace-targeted) modes get a translate-time WARNING and no chmod:
+# files/workspace/ is written AFTER install commands run, so a chmod there
+# would always fail (same sbx#499 thread).
+#
+# VALIDATION (SI-10, mirroring _kit_vol_validate): mode reaches a generated
+# sbx-v2 spec as a root shell command, so it is untrusted input. Only a
+# 0-prefixed 4-digit octal string (0[0-7]{3}) is accepted — kit_spec_files
+# already drops non-octal modes, and this tighter gate additionally refuses
+# 3-digit and setuid/setgid/sticky (4-digit non-0-prefixed) forms; offenders
+# are dropped with a stderr warning (`acq kit validate` reports them as
+# errors). Paths were charset-validated by kit_spec_files ([A-Za-z0-9._/-]);
+# single-quote them anyway.
+_kit_sbx_mode_chmod_script() {
+  local spec="$1" fline fpath fmode script=""
+  while IFS= read -r fline; do
+    [ -n "$fline" ] || continue
+    fpath=$(printf '%s' "$fline" | cut -f1)
+    fmode=$(printf '%s' "$fline" | cut -f2)
+    [ -n "$fpath" ] && [ -n "$fmode" ] || continue
+    case "$fpath" in
+      /home/agent/*) ;;
+      *)
+        echo "kit-translate: warning: mode ${fmode} on ${fpath} cannot be applied on sbx (only home-staged files can be chmodded in setup.install; files/workspace/ is written after install commands — docker/sbx-releases#499)" >&2
+        continue
+        ;;
+    esac
+    case "$fmode" in
+      0[0-7][0-7][0-7]) ;;
+      *)
+        echo "kit-translate: skipping chmod for ${fpath}: mode must be a 0-prefixed octal string like \"0755\" (got: ${fmode})" >&2
+        continue
+        ;;
+    esac
+    script="${script:+${script}
+}chmod ${fmode} '${fpath}' && echo \"acq kit-modes: ${fmode} ${fpath}\" || echo \"acq kit-modes: FAILED ${fmode} ${fpath}\""
+  done <<EOF
+$(kit_spec_files "$spec")
+EOF
+  printf '%s' "$script"
+}
+
 # Emit setup.install/setup.startup blocks into an sbx-v2 spec from the neutral
 # commands. v2 has no initFiles command phase, so neutral initFiles commands are
 # emitted before startup commands under setup.startup.
+#
+# The synthesized file-mode chmod (#381, _kit_sbx_mode_chmod_script) is emitted
+# as ONE combined setup.install entry BEFORE the kit's own install commands, so
+# an install command may exec a kit-shipped script. One line per file (no set
+# -e) so a missing file doesn't skip the rest, and each line prints what it did
+# — sbx install-command failures are NON-fatal at create time (sbx#499), so the
+# startup log is the only place a failed chmod surfaces. Nothing is emitted for
+# a mode-less kit: its generated spec must stay byte-identical.
 _kit_sbx_emit_setup() {
   local spec="$1" out="$2"
   local phases="install initFiles startup"
   local phase have_setup=0 have_install=0 have_startup=0 tmp
   tmp=$(mktemp)
+
+  local chmod_script
+  chmod_script=$(_kit_sbx_mode_chmod_script "$spec")
+  if [ -n "$chmod_script" ]; then
+    printf 'setup:\n  install:\n' >> "$tmp"
+    have_setup=1; have_install=1
+    printf '    - command: |\n' >> "$tmp"
+    printf '%s\n' "$chmod_script" | while IFS= read -r cl; do
+      printf '        %s\n' "$cl" >> "$tmp"
+    done
+    printf '      user: "0"\n' >> "$tmp"
+    printf '      description: %s\n' \
+      "$(_kit_yaml_quote 'Apply kit-declared file modes (sbx pins files/ payloads to 0644 — see docker/sbx-releases#499)')" >> "$tmp"
+  fi
 
   for phase in $phases; do
     local cur_phase="" cur_user="" cur_bg="false" argv=() reading=0 line
@@ -1175,24 +1251,31 @@ kit_validate() {
 $(kit_spec_files "$spec")
 EOF
 
-  # Raw-spec scan: any `mode:` value that is not 3-4 octal digits is rejected
-  # (it would break out of the root `chmod $mode` in the msb adapter).
+  # Raw-spec scan: any `mode:` value that is not a 0-prefixed 4-digit octal
+  # string is rejected — it reaches the root `chmod $mode` in the msb adapter
+  # AND the synthesized sbx setup.install chmod (#381), so the accepted grammar
+  # is the strict intersection both emit safely (no 3-digit shorthand, no
+  # setuid/setgid/sticky leading digit).
   local bad_mode
   bad_mode=$(awk '
     /^[[:space:]]+mode:/ {
       v=$0; sub(/^[^:]*:[[:space:]]*/,"",v); sub(/[[:space:]]*#.*/,"",v)
       gsub(/^["'\'' ]+|["'\'' ]+$/,"",v)
-      # Longhand /^[0-7][0-7][0-7][0-7]?$/, NOT the interval /^[0-7]{3,4}$/:
-      # mawk (Debian/Ubuntu default awk) has no interval expressions, so the
-      # interval form matches NOTHING under mawk. Here the test is INVERTED
-      # (collect modes that FAIL the pattern, to reject the spec), so under mawk
-      # EVERY mode looks invalid and the whole spec is wrongly rejected. See the
-      # detailed note in the files[] parser above. Do not "simplify" to {3,4}.
-      if (v !~ /^[0-7][0-7][0-7][0-7]?$/) print v
+      # Longhand /^0[0-7][0-7][0-7]$/, NOT an interval ({n,m}): mawk
+      # (Debian/Ubuntu default awk) has no interval expressions, so an interval
+      # form matches NOTHING there. The test is INVERTED (collect modes that
+      # FAIL the pattern, to reject the spec), so under mawk EVERY mode would
+      # look invalid and the whole spec would be wrongly rejected. See the
+      # detailed note in the files[] parser above; do not "simplify" to {n,m}.
+      # Stricter than the parser gate on purpose (#381): the leading zero is
+      # required and setuid/setgid/sticky forms are rejected — this value
+      # reaches a root chmod in the msb adapter AND the synthesized sbx
+      # setup.install chmod.
+      if (v !~ /^0[0-7][0-7][0-7]$/) print v
     }' "$spec")
   if [ -n "$bad_mode" ]; then
     while IFS= read -r m; do
-      [ -n "$m" ] && { echo "kit: validate: file mode must be octal (3-4 digits): '$m'" >&2; errs=$((errs + 1)); }
+      [ -n "$m" ] && { echo "kit: validate: file mode must be a 4-digit octal string with a leading zero (e.g. \"0755\"): '$m'" >&2; errs=$((errs + 1)); }
     done <<EOF
 $bad_mode
 EOF

--- a/test/bats/100-kit-translate.bats
+++ b/test/bats/100-kit-translate.bats
@@ -302,15 +302,17 @@ SPEC
   refute_regex "$spec" '1BAD'
 }
 
-# Regression guard: the files[].mode validator must NOT use a brace-interval
-# quantifier (/^[0-7]{3,4}$/). mawk — the default awk on Debian/Ubuntu — has no
-# interval-expression support, so that form matches NOTHING under mawk and every
-# kit's files are silently dropped. Both validator sites must stay longhand
-# (/^[0-7][0-7][0-7][0-7]?$/). This source-level check catches a regression
-# regardless of which awk the test runner ships (gawk/BSD-awk would not
-# reproduce the failure at runtime).
+# Regression guard: the files[].mode validators must NOT use a brace-interval
+# quantifier (/^[0-7]{3,4}$/ or /^0[0-7]{3}$/). mawk — the default awk on
+# Debian/Ubuntu — has no interval-expression support, so that form matches
+# NOTHING under mawk and every kit's files are silently dropped (parser site)
+# or every valid mode is reported invalid (kit_validate raw-scan site, whose
+# stricter leading-zero pattern is /^0[0-7][0-7][0-7]$/ — #381). All mode
+# validator sites must stay longhand. This source-level check catches a
+# regression regardless of which awk the test runner ships (gawk/BSD-awk would
+# not reproduce the failure at runtime).
 @test "kit-translate: mode validator uses no {n,m} interval regex (mawk-safe)" {
-  run grep -nE 'cur_mode !~ /\^\[0-7\]\{|v !~ /\^\[0-7\]\{' "$REPO_ROOT/acq.backends/kit-translate.sh"
+  run grep -nE '(cur_mode|v) !~ /\^0?\[0-7\]\{' "$REPO_ROOT/acq.backends/kit-translate.sh"
   assert_failure   # no match -> exit 1 -> the interval form is absent
 }
 

--- a/test/bats/100-kit-translate.bats
+++ b/test/bats/100-kit-translate.bats
@@ -116,6 +116,116 @@ SPEC
   assert_regex "$spec" 'echo hello'
 }
 
+@test "#381: home-staged mode fields synthesize ONE combined setup.install chmod step" {
+  local mkit="$STUBDIR/mkit" mout="$STUBDIR/mout"
+  mkdir -p "$mkit/files/home/tool"
+  printf '#!/bin/sh\necho hi\n' > "$mkit/files/home/tool/run.sh"
+  printf 'cfg\n' > "$mkit/files/home/tool/config"
+  cat >"$mkit/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: mode-kit
+displayName: Mode Kit
+description: kit with declared file modes
+files:
+  - path: /home/agent/tool/run.sh
+    mode: "0755"
+    source: files/home/tool/run.sh
+  - path: /home/agent/tool/config
+    mode: "0644"
+    source: files/home/tool/config
+SPEC
+  run bash -c '. "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"; kit_translate_to_sbx "'"$mkit"'" "'"$mout"'" >/dev/null 2>&1'
+  local spec; spec=$(cat "$mout/spec.yaml")
+  assert_regex "$spec" 'setup:'
+  assert_regex "$spec" '  install:'
+  assert_regex "$spec" "chmod 0755 '/home/agent/tool/run\.sh'"
+  assert_regex "$spec" "chmod 0644 '/home/agent/tool/config'"
+  assert_regex "$spec" 'user: "0"'
+  assert_regex "$spec" 'description: .*sbx pins files/ payloads to 0644'
+  # ONE combined install entry, not one per file.
+  assert_equal "$(grep -c '    - command:' "$mout/spec.yaml")" "1"
+}
+
+@test "#381: the chmod install step is emitted BEFORE the kit's own install commands" {
+  local okit="$STUBDIR/okit" oout="$STUBDIR/oout"
+  mkdir -p "$okit/files/home"
+  printf '#!/bin/sh\n' > "$okit/files/home/tool.sh"
+  cat >"$okit/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: order-kit
+displayName: Order Kit
+description: chmod must precede kit install commands
+files:
+  - path: /home/agent/tool.sh
+    mode: "0755"
+    source: files/home/tool.sh
+commands:
+  - phase: install
+    user: "0"
+    command:
+      - sh
+      - -c
+      - |
+        /home/agent/tool.sh
+SPEC
+  run bash -c '. "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"; kit_translate_to_sbx "'"$okit"'" "'"$oout"'" >/dev/null 2>&1'
+  local chmod_line install_line
+  chmod_line=$(grep -n "chmod 0755" "$oout/spec.yaml" | head -1 | cut -d: -f1)
+  install_line=$(grep -n '/home/agent/tool\.sh$' "$oout/spec.yaml" | tail -1 | cut -d: -f1)
+  assert [ -n "$chmod_line" ]
+  assert [ -n "$install_line" ]
+  assert [ "$chmod_line" -lt "$install_line" ]
+}
+
+@test "#381: a mode-less kit emits no chmod step (output unchanged)" {
+  local nkit="$STUBDIR/nkit" nout="$STUBDIR/nout"
+  mkdir -p "$nkit/files/home"
+  printf 'x\n' > "$nkit/files/home/f"
+  cat >"$nkit/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: nomode-kit
+displayName: Nomode Kit
+description: kit with no file modes
+files:
+  - path: /home/agent/f
+    source: files/home/f
+SPEC
+  run bash -c '. "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"; kit_translate_to_sbx "'"$nkit"'" "'"$nout"'" >/dev/null 2>&1'
+  local spec; spec=$(cat "$nout/spec.yaml")
+  refute_regex "$spec" 'chmod'
+  refute_regex "$spec" 'setup:'
+}
+
+@test "#381: a workspace-targeted mode warns and gets no chmod" {
+  local wkit="$STUBDIR/wkit" wout="$STUBDIR/wout"
+  mkdir -p "$wkit/files/home" "$wkit/files/workspace"
+  printf '#!/bin/sh\n' > "$wkit/files/home/h.sh"
+  printf '#!/bin/sh\n' > "$wkit/files/workspace/w.sh"
+  cat >"$wkit/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: wsmode-kit
+displayName: Wsmode Kit
+description: workspace-targeted modes cannot be applied on sbx
+files:
+  - path: /home/agent/h.sh
+    mode: "0755"
+    source: files/home/h.sh
+  - path: /workspace/w.sh
+    mode: "0755"
+    source: files/workspace/w.sh
+SPEC
+  run bash -c '. "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"; kit_translate_to_sbx "'"$wkit"'" "'"$wout"'" 2>&1 >/dev/null'
+  assert_output --partial 'mode'
+  assert_output --partial '/workspace/w.sh'
+  local spec; spec=$(cat "$wout/spec.yaml")
+  assert_regex "$spec" "chmod 0755 '/home/agent/h\.sh'"
+  refute_regex "$spec" "chmod 0755 '/workspace/w\.sh'"
+}
+
 @test "#207: a git+https kit fetch is non-interactive and neutralizes credentials" {
   local gitlog="$STUBDIR/git-invocations.log"; : >"$gitlog"
   cat >"$STUBDIR/git" <<GITSTUB

--- a/test/bats/75-msb-kit-security.bats
+++ b/test/bats/75-msb-kit-security.bats
@@ -116,7 +116,7 @@ commands:
 SPEC
     kit_validate "$vk" 2>&1; echo "RC=$?"
   '
-  assert_output --partial 'mode must be octal'
+  assert_output --partial 'mode must be a 4-digit octal string'
   assert_output --partial 'unknown command phase'
   assert_output --partial 'RC=1'
 }

--- a/test/bats/80-kit-subcommands.bats
+++ b/test/bats/80-kit-subcommands.bats
@@ -85,6 +85,27 @@ SPEC
   assert_output --partial 'unknown command phase'
 }
 
+@test "#381: kit validate rejects a file mode without the leading zero" {
+  local zkit="$STUBDIR/zkit"
+  mkdir -p "$zkit/files/home"
+  printf '#!/bin/sh\n' > "$zkit/files/home/t.sh"
+  cat >"$zkit/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: zeroless-kit
+displayName: Zeroless Kit
+description: mode without a leading zero must be rejected
+files:
+  - path: /home/agent/t.sh
+    mode: "755"
+    source: files/home/t.sh
+SPEC
+  run "$ACQ" kit validate "$zkit"
+  assert_failure
+  assert_output --partial "'755'"
+  assert_output --partial 'leading zero'
+}
+
 @test "kit apply (msb): runs msb exec and stages NO create-time script (ADR-0017)" {
   local applykit="$STUBDIR/applykit"
   mkdir -p "$applykit"


### PR DESCRIPTION
Fixes #381.

sbx pins every kit `files/` payload to 0644 at materialization (docker/sbx-releases#499; v0.39 extended the pin to local/git kit loads), so kit-shipped executables arrive non-executable — first casualty: git-ssh-sign's key-resolver helper, breaking `git commit` in every fresh sandbox. This translates the hybrid/v1 `mode:` vocabulary into the maintainer-sanctioned workaround:

- One combined `setup.install` chmod entry (`user: "0"`), emitted **before** the kit's own install commands; one defensive `chmod && echo || echo` line per home-staged file, so a missing file doesn't skip the rest and the step surfaces in the create log (sbx install failures are non-fatal).
- Workspace-targeted modes get a translate-time warning, no chmod (`files/workspace/` is written after install commands run).
- SI-10: only `0[0-7]{3}` reaches the generated spec; `acq kit validate` rejects any other mode grammar (all four pinned built-in kits validate OK).
- Mode-less kits produce byte-identical specs to today's output.
- msb unchanged — its adapter already applies `mode:` via root chmod after each verified copy.

**Verified E2E on sbx v0.39.0:** a plain `acq create` sandbox shows `-rwxr-xr-x` on `/home/agent/.config/git/ssh-signing-key-command` and on a minimal local kit's 0755 script.

Note: the offline suite currently cannot detect test failures (#389) — the five new bats tests here were verified red→green locally with detection restored; the E2E above is the decisive check.
