### PR TITLE
fix(kits): Pull in updated USAi kit with fixed opencode.jsonc config

### DIFF
--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -36,7 +36,7 @@ PATTERNS_KIT_REPO="git+https://github.com/GSA-TTS/agentic-coding-patterns.git"
 # the bundle-version anchor recorded in a sandbox's host-side provenance record
 # (see ACQ_BUILTIN_BUNDLE below + the provenance helpers) so acq can tell a
 # stale sandbox from a current one.
-PATTERNS_KIT_REF="f5fb88759aa3007e24186a25e5f2d5d4a8b6e573"  # agentic-coding-patterns v1.8.0
+PATTERNS_KIT_REF="f60a805f9a3efb8596043d11d8d508859d80d9b4"  # agentic-coding-patterns main as of PR #386 merging
 PATTERNS_KIT_DIR="integrations/isolation/acq-kits"
 
 USAI_KIT="${PATTERNS_KIT_REPO}#ref=${PATTERNS_KIT_REF}&dir=${PATTERNS_KIT_DIR}/usai-provider"


### PR DESCRIPTION
## Summary

Pull in the updated version of the USAi kit that accounts for breakage from upstream USAi API changes and adds newly-available models.

## Related Issues

GSA-TTS/agentic-coding-patterns#386

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits format](../CONTRIBUTING.md#commit-message-guidelines) (e.g., `feat:`, `fix:`, `docs:`)
- [x] I have tested my changes locally
- [x] I have updated documentation as needed
- [x] I have not included any secrets, API keys, or sensitive information

## Test Results

🤞 

## Additional Notes

See Slack discussions starting [here](https://gsa-tts.slack.com/archives/C0B44531QLE/p1787670685843349)