### PR TITLE
fix(msb): re-drive ssh-agent forward on running reattach

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3246,6 +3246,82 @@ _acq_msb_ssh_auth_sock_for() {
     </dev/null 2>/dev/null | tr -d '[:space:]'
 }
 
+# _acq_msb_ensure_ssh_agent_forward NAME — (re)establish the host ssh-agent
+# forward on a RUNNING sandbox that acq is re-attaching to. See ADR-0021.
+#
+# WHY THIS EXISTS: the provision path wires the forward (emit --vsock, start the
+# socat bridge, write the /var/lib/acq/ssh-auth-sock marker), and the
+# stopped→resume path (acq_backend_start) restarts the bridge from that marker.
+# But re-attaching to an ALREADY-RUNNING sandbox goes through neither: the heal
+# loop skips acq_backend_start (the sandbox is already running), so nothing
+# re-drives forwarding. That left two live gaps where the guest process env got
+# NO `SSH_AUTH_SOCK` on re-attach (attach/exec/kit only inject it when the marker
+# is non-empty):
+#   1. the marker had never been written (sandbox created before forwarding was
+#      configured, or provision skipped the bridge), yet the host agent is now
+#      available and the create-time --vsock route is present; and
+#   2. the bridge process had died in-flight on a long-lived running sandbox.
+# Re-driving here, keyed off the SAME opt-in signal as provision (a host
+# SSH_AUTH_SOCK that yields a forward), closes both.
+#
+# Gated so it is a cheap no-op in the common case:
+#   - host forward requested? (acq_host_socket_forwards emits an ssh-agent line)
+#   - guest actually has the create-time --vsock route? (the route is create-time
+#     only — it cannot be added to a running sandbox, so if it is absent, a bridge
+#     would be inert and we must NOT write a misleading marker)
+# When both hold, flip the module forwarding flag (so _acq_msb_check_socat and
+# the bridge starter resolve the guest sock from the constant, not a possibly
+# empty marker), verify socat, then start the bridge + write the marker — exactly
+# the provision sequence. Fail-soft throughout: this is convenience, never fatal.
+_acq_msb_ensure_ssh_agent_forward() {
+  local name="$1"
+  # Cheap opt-out: no host forward requested => nothing to do. Reuse the neutral
+  # emitter's decision so this tracks the SSH_AUTH_SOCK opt-in exactly (a set,
+  # existing host socket on a supported port). Suppress the emitter's advisory
+  # stderr here; provision/attach already surface the trust-boundary notice.
+  local _fwd
+  _fwd=$(acq_host_socket_forwards 2>/dev/null)
+  # Each emitted line is TAB-separated "PATH<TAB>PORT<TAB>KIND<TAB>LABEL"; the
+  # ssh-agent forward is the line whose LABEL is exactly "ssh-agent". Match the
+  # tab+label token so a custom forward alone (LABEL=custom) does not trigger it.
+  case "$_fwd" in
+    *"	ssh-agent"*) : ;;             # an ssh-agent forward line was emitted
+    *) return 0 ;;                     # no ssh-agent forward requested
+  esac
+
+  # The --vsock route is create-time only. If this sandbox was created WITHOUT
+  # it, a socat bridge would be inert and the marker would falsely advertise a
+  # working agent, so require the route to actually be present before wiring.
+  _acq_msb_has_ssh_agent_vsock_route "$name" || return 0
+
+  # From here, treat forwarding as active: point the bridge starter at the guest
+  # sock constant (not the possibly-empty marker) and gate on socat as provision
+  # does. Set the module flag so _acq_msb_check_socat / the bridge starter both
+  # resolve from the constant. It is process-scoped and already reset per run.
+  _ACQ_MSB_SSH_AGENT_FORWARDING=1
+  _acq_msb_check_socat "$name" && _acq_msb_start_ssh_agent_bridge "$name"
+}
+
+# _acq_msb_has_ssh_agent_vsock_route NAME — return 0 iff the sandbox's persisted
+# config carries the ssh-agent --vsock route (guest AF_VSOCK CID 2:PORT for the
+# ssh-agent port). The route is create-time only, so its presence is the
+# authoritative signal that this sandbox CAN carry a forward. Read from
+# `msb inspect NAME --format json`; best-effort (a missing tool/field returns
+# non-zero, never hard-fails). See ADR-0021.
+_acq_msb_has_ssh_agent_vsock_route() {
+  local name="$1" json _port="$ACQ_MSB_SSH_AGENT_VSOCK_PORT"
+  json=$(msb inspect "$name" --format json 2>/dev/null) || return 1
+  [ -n "$json" ] || return 1
+  # The route serializes with the ssh-agent guest port; matching the port digits
+  # is enough to distinguish "route present" from "no vsock route at all".
+  # Flatten quotes/whitespace so a `port: 3552` or `"port":3552` both match, and
+  # anchor on the digits as a whole token so 3552 can't match e.g. 35521.
+  printf '%s' "$json" \
+    | tr -d '" ' \
+    | tr ',{}[]' '\n\n\n\n\n' \
+    | grep -Eq "(vsock|port)[:=]${_port}\$" 2>/dev/null
+}
+
 # ---------------------------------------------------------------------------
 # _acq_msb_grant_oci_devs NAME — grant the agent access to the device nodes
 #                                rootless podman needs (/dev/net/tun, /dev/fuse)
@@ -4106,6 +4182,16 @@ acq_backend_ensure_kits_applied() {
     acq_backend_start "$name" >/dev/null || \
       echo "acq(msb): warning: 'msb start $name' failed (see the error above); healing may not apply." >&2
   fi
+  # Re-establish the host ssh-agent forward on THIS re-attach (ADR-0021). The
+  # provision path wires it and acq_backend_start restarts the bridge on a
+  # stopped→resume; but a re-attach to an ALREADY-RUNNING sandbox reaches neither
+  # (the start-if-stopped block above is a no-op), so nothing would (re)start the
+  # bridge or write the SSH_AUTH_SOCK marker that attach/exec/kit injection keys
+  # off. Without this, re-attaching to a running sandbox left the guest process
+  # env with no SSH_AUTH_SOCK even though the create-time --vsock route was
+  # present — the reported "have to export SSH_AUTH_SOCK by hand" symptom. Cheap
+  # no-op when no host forward is requested or the sandbox has no vsock route.
+  _acq_msb_ensure_ssh_agent_forward "$name"
   local kits=("$ZSCALER_KIT" "$USAI_KIT" "$PLAYBOOK_KIT" "$GITSSHSIGN_KIT")
   local builtin_count="${#kits[@]}"
   if [ -n "${ACQ_EXTRA_KITS:-}" ]; then

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3312,14 +3312,20 @@ _acq_msb_has_ssh_agent_vsock_route() {
   local name="$1" json _port="$ACQ_MSB_SSH_AGENT_VSOCK_PORT"
   json=$(msb inspect "$name" --format json 2>/dev/null) || return 1
   [ -n "$json" ] || return 1
-  # The route serializes with the ssh-agent guest port; matching the port digits
-  # is enough to distinguish "route present" from "no vsock route at all".
-  # Flatten quotes/whitespace so a `port: 3552` or `"port":3552` both match, and
-  # anchor on the digits as a whole token so 3552 can't match e.g. 35521.
-  printf '%s' "$json" \
-    | tr -d '" ' \
-    | tr ',{}[]' '\n\n\n\n\n' \
-    | grep -Eq "(vsock|port)[:=]${_port}\$" 2>/dev/null
+  # Require BOTH a `vsock` key AND the ssh-agent guest-port token, so a published
+  # `ports:[{port:<vsock-port>}]` that merely happens to equal the (user-
+  # overridable) vsock port cannot masquerade as a route on a sandbox that has no
+  # vsock forwarding at all. We do not have a JSON parser here, so flatten the
+  # document (strip quotes/spaces; turn structural punctuation into newlines) and
+  # test the two facts independently against the whole flattened form. The real
+  # shape is `"vsock":{"routes":[{…,"port":3552}]}` — after flattening, `vsock:`
+  # and `port:3552` land on separate lines, so both greps must be run over the
+  # full text (not a single line). The port is anchored as a whole token so 3552
+  # can't match e.g. 35521. See ADR-0021; shape confirmed against msb 0.6.12.
+  local _flat
+  _flat=$(printf '%s' "$json" | tr -d '" ' | tr ',{}[]' '\n\n\n\n\n')
+  printf '%s\n' "$_flat" | grep -Eq '(^|:)vsock:?$' 2>/dev/null || return 1
+  printf '%s\n' "$_flat" | grep -Eq "port[:=]${_port}\$" 2>/dev/null
 }
 
 # ---------------------------------------------------------------------------

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -3,7 +3,7 @@ title: "Known Failure Modes"
 description: "Real-world failure patterns when using Docker SBX + USAi + agent frameworks"
 status: canonical
 tier: 2
-last_updated: "2026-08-18"
+last_updated: "2026-08-25"
 audience: "developers"
 keywords: ["debugging", "troubleshooting", "sbx", "usai", "failures"]
 ---
@@ -1782,6 +1782,30 @@ running on the host (or no key is loaded), there is nothing to forward.
 Then re-run `acq run …`; the forward is applied automatically. See
 [ADR-0021](adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md) for the full
 mechanism and the trust-boundary discussion.
+
+### Variant: `SSH_AUTH_SOCK` unset on re-attach to a running sandbox
+
+A distinct signature of the same feature: signing works right after the initial
+`acq run` but **fails on a later re-attach** to the *same, still-running*
+sandbox, and it starts working again as soon as you
+`export SSH_AUTH_SOCK=/home/agent/.acq/ssh-agent.sock` by hand. Here the vsock
+route and the `socat` bridge are fine — what is missing is the
+**`SSH_AUTH_SOCK` env var in the agent's process**. acq injects that var
+(`-e SSH_AUTH_SOCK=…`) only when the persisted `/var/lib/acq/ssh-auth-sock`
+marker is present, and before the fix nothing re-established the bridge or wrote
+that marker when re-attaching to an already-running sandbox (the heal's
+start-if-stopped block is a no-op on a running sandbox, and only that path — or
+provision — wrote the marker).
+
+Fixed in `acq.backends/msb.sh`: `acq_backend_ensure_kits_applied` now calls
+`_acq_msb_ensure_ssh_agent_forward` at the top of the heal, which re-drives the
+forward (restart the bridge + write the marker) on every re-attach when both a
+host forward is requested (`SSH_AUTH_SOCK` set) **and** the sandbox carries the
+create-time `--vsock` route. The route is create-time only, so a sandbox created
+*without* a host agent still needs a recreate to gain forwarding — but one
+created *with* the route now re-injects `SSH_AUTH_SOCK` on every re-attach without
+a manual export. See [ADR-0021](adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md)
+("Re-attach to a running sandbox").
 
 ---
 

--- a/docs/adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md
+++ b/docs/adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md
@@ -264,15 +264,26 @@ point of use, not only in this ADR.
 
 - Offline unit coverage in `test/bats/115-ssh-agent-forward.bats` (stubbed
   `msb`/`socat`, no Docker or network; run via `scripts/test-acq-bats`), cases
-  **10c1–10c17**: the version gate (warn+skip on msb < 0.6.9),
+  **10c1–10c18**: the version gate (warn+skip on msb < 0.6.9),
   `--vsock` flag emission when `SSH_AUTH_SOCK` is set, the `socat` prereq check,
   bridge start on **provision** and on **start** (resume), the re-attach re-drive
   on an **already-running** sandbox (**10c16**: bridge started + marker written
-  without an `msb start`; **10c17**: strict no-op when no forward is requested, or
-  when the sandbox has no create-time `--vsock` route), `SSH_AUTH_SOCK` injection
-  on attach/`acq exec`/kit commands, and SI-10 validation of the host socket path
+  without an `msb start`; **10c17**: strict no-op when no forward is requested,
+  when the sandbox has no create-time `--vsock` route, or when a published port
+  merely equals the vsock port with no `vsock` key present), the route probe's
+  match against the **real msb 0.6.12** `vsock` shape and its rejection of a
+  same-port published port (**10c18**), `SSH_AUTH_SOCK` injection on
+  attach/`acq exec`/kit commands, and SI-10 validation of the host socket path
   (absolute + existing socket) and the vsock port (integer in `1..4294967294`,
   `!= 123`) — invalid values are rejected before reaching `msb create`.
+- **Route JSON shape CONFIRMED** against a live msb 0.6.12 sandbox created with a
+  host forward:
+  ```json
+  "vsock": { "routes": [ { "host_socket": "…/Listeners", "port": 3552 } ] }
+  ```
+  `_acq_msb_has_ssh_agent_vsock_route` requires **both** a `vsock` key and the
+  ssh-agent guest-port token in the flattened document, so a published port that
+  merely equals the (overridable) vsock port cannot be mistaken for a route.
 - **Live end-to-end VERIFIED** on a macOS/HVF host (2026-08-17) via
   `scripts/verify-backends`, which forwards a hermetic throwaway agent and
   confirms the guest's forwarded agent exposes that exact ephemeral key

--- a/docs/adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md
+++ b/docs/adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md
@@ -93,6 +93,12 @@ forward as the automatic special case built on top of it.
     image, warning (not aborting) if missing;
   - `_acq_msb_start_ssh_agent_bridge` — starts the in-guest
     `socat UNIX-LISTEN:<sock>,fork,reuseaddr VSOCK-CONNECT:2:3552` bridge;
+  - `_acq_msb_ensure_ssh_agent_forward` — re-establishes the forward on a
+    re-attach to an **already-running** sandbox (re-starts the bridge + writes the
+    marker), gated on a requested host forward *and* the sandbox actually carrying
+    the create-time `--vsock` route (`_acq_msb_has_ssh_agent_vsock_route`, read
+    from `msb inspect --format json`); called at the top of
+    `acq_backend_ensure_kits_applied`. See "Re-attach to a running sandbox" below;
   - `_acq_msb_ssh_auth_sock_for` — resolves the guest `SSH_AUTH_SOCK` value
     injected on attach, `acq exec`, and kit commands.
   - Constants: `ACQ_MSB_SSH_AGENT_VSOCK_PORT` (default `3552`),
@@ -120,6 +126,44 @@ The `--vsock` route persists across `msb stop`/`start` (it is part of the sandbo
 config), but the `socat` bridge **process** dies on stop. So the bridge is
 re-started in `acq_backend_start`, the same way the OCI device-node re-grant is
 re-applied on resume.
+
+### Re-attach to a running sandbox (bridge + `SSH_AUTH_SOCK` must be re-driven)
+
+The guest-side `SSH_AUTH_SOCK` value is injected into the guest process env only
+when acq passes `-e SSH_AUTH_SOCK=<sock>` to `msb exec` on attach/`acq exec`/kit
+commands, and acq only does that when the persisted
+`/var/lib/acq/ssh-auth-sock` marker is non-empty. That marker is written solely
+by `_acq_msb_start_ssh_agent_bridge`. Provision runs the bridge starter directly,
+and the **stopped→resume** path runs it via `acq_backend_start`.
+
+A re-attach to an **already-running** sandbox (`acq run <name>` /
+`acq run <agent> .` against an existing, running sandbox) previously reached
+**neither**: the heal's start-if-stopped block is a no-op on a running sandbox, so
+nothing re-started the bridge or wrote the marker. The result was that the guest
+process env had **no `SSH_AUTH_SOCK`** on re-attach even though the create-time
+`--vsock` route was present and the host agent was available — the operator had to
+`export SSH_AUTH_SOCK=/home/agent/.acq/ssh-agent.sock` by hand before signing.
+(The socket/bridge worked; only the *env var injection* was missing — the two are
+independent: the `-e` flag names the socket, the bridge backs it.)
+
+`acq_backend_ensure_kits_applied` now calls `_acq_msb_ensure_ssh_agent_forward`
+at the top of the heal (right after the start-if-stopped block, before kit
+application), so every re-attach — running or resumed — re-establishes the
+forward. It is a cheap no-op unless **both** hold:
+
+1. a host ssh-agent forward is requested (`acq_host_socket_forwards` emits an
+   `ssh-agent` line — i.e. the same set `SSH_AUTH_SOCK` opt-in as provision), and
+2. the sandbox actually carries the create-time `--vsock` route
+   (`_acq_msb_has_ssh_agent_vsock_route`, read from `msb inspect --format json`).
+
+The `--vsock` route is **create-time only** — it cannot be added to a running
+sandbox — so a sandbox created *without* a forward still cannot gain one on
+re-attach (recreate it with `SSH_AUTH_SOCK` set to add the route). Requiring the
+route before wiring also prevents writing a **misleading** marker (which would
+advertise a working agent behind an inert bridge). When both conditions hold, the
+re-drive runs the exact provision sequence (`_acq_msb_check_socat` then
+`_acq_msb_start_ssh_agent_bridge`), which restarts the bridge and writes the
+marker, so the subsequent attach injects `SSH_AUTH_SOCK`.
 
 ### Version gate (MIN_MSB_VERSION stays 0.6.8)
 
@@ -218,20 +262,26 @@ point of use, not only in this ADR.
 
 ## Validation
 
-- Offline unit coverage in `scripts/test-acq` (stubbed `msb`/`socat`, no Docker or
-  network), cases **10c1–10c14**: the version gate (warn+skip on msb < 0.6.9),
+- Offline unit coverage in `test/bats/115-ssh-agent-forward.bats` (stubbed
+  `msb`/`socat`, no Docker or network; run via `scripts/test-acq-bats`), cases
+  **10c1–10c17**: the version gate (warn+skip on msb < 0.6.9),
   `--vsock` flag emission when `SSH_AUTH_SOCK` is set, the `socat` prereq check,
-  bridge start on **provision** and on **start** (resume), `SSH_AUTH_SOCK`
-  injection on attach/`acq exec`/kit commands, and SI-10 validation of the host
-  socket path (absolute + existing socket) and the vsock port (integer in
-  `1..4294967294`, `!= 123`) — invalid values are rejected before reaching
-  `msb create`.
+  bridge start on **provision** and on **start** (resume), the re-attach re-drive
+  on an **already-running** sandbox (**10c16**: bridge started + marker written
+  without an `msb start`; **10c17**: strict no-op when no forward is requested, or
+  when the sandbox has no create-time `--vsock` route), `SSH_AUTH_SOCK` injection
+  on attach/`acq exec`/kit commands, and SI-10 validation of the host socket path
+  (absolute + existing socket) and the vsock port (integer in `1..4294967294`,
+  `!= 123`) — invalid values are rejected before reaching `msb create`.
 - **Live end-to-end VERIFIED** on a macOS/HVF host (2026-08-17) via
   `scripts/verify-backends`, which forwards a hermetic throwaway agent and
   confirms the guest's forwarded agent exposes that exact ephemeral key
   (`guest ssh-add -L exposes the ephemeral host key`). Re-run on the ADR-0011
   periodic-validation cadence (it cannot run in CI / inside a sandbox — no nested
-  sandboxes).
+  sandboxes). NOTE: `scripts/verify-backends` exercises the **provision** path;
+  the running-re-attach re-drive (`_acq_msb_ensure_ssh_agent_forward`) still needs
+  a live end-to-end check on a KVM/HVF host — tracked in
+  [`GSA-TTS/agentic-coding-quickstart#388`](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/388).
 
 ## Links
 

--- a/scripts/verify-backends
+++ b/scripts/verify-backends
@@ -237,6 +237,16 @@ run_acq() {
   else
     LAST_OUT=$("$ACQ" "$@" 2>&1); _rc=$?
   fi
+  # Normalize CRLF -> LF in the captured output. Guest command output reaches us
+  # over msb's PTY/ssh transport, which terminates lines with CRLF; the trailing
+  # CR survives into LAST_OUT and silently breaks downstream parses that compare
+  # or index the LAST field of a line (e.g. `awk '{print $6}'` on a df row keeps
+  # the CR, so a mountpoint compare `"/acq-verify-vol\r" = "/acq-verify-vol"`
+  # fails, and the CR then overwrites the closing quote in any diagnostic — the
+  # "not a dedicated block mountpoint" false negative). Strip CR once here so
+  # every consumer sees clean LF-delimited text; callers that already tolerated
+  # it (tr -dc, anchored sed) are unaffected. bash 3.2 safe.
+  LAST_OUT=${LAST_OUT//$'\r'/}
   trace "DONE  ${desc}: rc=${_rc}"
   return "$_rc"
 }

--- a/test/bats/115-ssh-agent-forward.bats
+++ b/test/bats/115-ssh-agent-forward.bats
@@ -295,7 +295,7 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   # port; a local empty kit dir so the heal's kit loop does no network fetch.
   printf 'reattachbox\n' >"$STUBDIR/.msb_sandbox_list"
   printf 'reattachbox\n' >"$STUBDIR/.msb_running_list"
-  printf '{"active_config":{"vsock":[{"port":3552}]}}\n' >"$STUBDIR/.msb_inspect_json"
+  printf '{"active_config":{"vsock":{"routes":[{"host_socket":"/private/var/run/x/Listeners","port":3552}]}}}\n' >"$STUBDIR/.msb_inspect_json"
   mkdir -p "$STUBDIR/nokit"
   printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' >"$STUBDIR/nokit/spec.yaml"
   : > "$CALLS"
@@ -319,7 +319,7 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   printf 'rbox\n' >"$STUBDIR/.msb_sandbox_list"
   printf 'rbox\n' >"$STUBDIR/.msb_running_list"
   # (a) route present, but NO host forward requested -> no bridge.
-  printf '{"active_config":{"vsock":[{"port":3552}]}}\n' >"$STUBDIR/.msb_inspect_json"
+  printf '{"active_config":{"vsock":{"routes":[{"host_socket":"/private/var/run/x/Listeners","port":3552}]}}}\n' >"$STUBDIR/.msb_inspect_json"
   : > "$CALLS"
   run bash -c '
     unset SSH_AUTH_SOCK ACQ_FORWARD_HOST_SOCKETS
@@ -341,6 +341,45 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
     wait
   '
   refute_regex "$(cat "$CALLS")" 'socat UNIX-LISTEN'
+  # (c) forward requested, and a PUBLISHED PORT equals the vsock port but there is
+  #     NO vsock route: the route probe requires a `vsock` key too, so this must
+  #     NOT be mistaken for a route (review nit: tighten anchoring). No bridge.
+  printf '{"active_config":{"network":{"ports":[{"port":3552}]}}}\n' >"$STUBDIR/.msb_inspect_json"
+  : > "$CALLS"
+  run bash -c '
+    export SSH_AUTH_SOCK="'"$STUBDIR"'/agent17.sock" STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _acq_msb_ensure_ssh_agent_forward rbox >/dev/null 2>&1
+    wait
+  '
+  refute_regex "$(cat "$CALLS")" 'socat UNIX-LISTEN'
+}
+
+@test "vsock(10c18): the route probe matches the real msb 0.6.12 vsock shape" {
+  # The real shape (confirmed on msb 0.6.12) is
+  #   "vsock":{"routes":[{"host_socket":"…/Listeners","port":3552}]}
+  # The probe must accept it (has both a `vsock` key and the port token) and must
+  # reject a same-port published port with no `vsock` key.
+  printf 'pbox\n' >"$STUBDIR/.msb_sandbox_list"
+  printf 'pbox\n' >"$STUBDIR/.msb_running_list"
+  printf '%s\n' '{"vsock":{"routes":[{"host_socket":"/private/var/run/x/Listeners","port":3552}]}}' \
+    >"$STUBDIR/.msb_inspect_json"
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _acq_msb_has_ssh_agent_vsock_route pbox; printf "RC=%s\n" "$?"
+  '
+  assert_output --partial 'RC=0'
+  printf '%s\n' '{"network":{"ports":[{"port":3552}]}}' >"$STUBDIR/.msb_inspect_json"
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _acq_msb_has_ssh_agent_vsock_route pbox; printf "RC=%s\n" "$?"
+  '
+  assert_output --partial 'RC=1'
 }
 
 @test "msb: the base-image prereq check warns on missing tools, silent when present or skipped" {

--- a/test/bats/115-ssh-agent-forward.bats
+++ b/test/bats/115-ssh-agent-forward.bats
@@ -289,6 +289,60 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   assert_output '/home/agent/.acq/ssh-agent.sock'
 }
 
+@test "vsock(10c16): re-attach to a RUNNING sandbox re-drives the forward (bridge + marker, no 'msb start')" {
+  _mk_unix_socket "$STUBDIR/agent16.sock" || skip "python3 AF_UNIX socket unavailable"
+  # Running sandbox that carries the create-time --vsock route on the ssh-agent
+  # port; a local empty kit dir so the heal's kit loop does no network fetch.
+  printf 'reattachbox\n' >"$STUBDIR/.msb_sandbox_list"
+  printf 'reattachbox\n' >"$STUBDIR/.msb_running_list"
+  printf '{"active_config":{"vsock":[{"port":3552}]}}\n' >"$STUBDIR/.msb_inspect_json"
+  mkdir -p "$STUBDIR/nokit"
+  printf 'schemaVersion: "hybrid/v1"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n' >"$STUBDIR/nokit/spec.yaml"
+  : > "$CALLS"
+  run bash -c '
+    export SSH_AUTH_SOCK="'"$STUBDIR"'/agent16.sock" STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _acq_msb_fetch_kit() { printf "%s\n" "'"$STUBDIR"'/nokit"; }
+    acq_backend_ensure_kits_applied reattachbox >/dev/null 2>&1
+    wait
+  '
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" "socat UNIX-LISTEN:'/home/agent/\.acq/ssh-agent\.sock'"
+  assert_regex "$log" '/var/lib/acq/ssh-auth-sock'
+  # A running sandbox must NOT be routed through acq_backend_start.
+  refute_regex "$log" 'msb start'
+}
+
+@test "vsock(10c17): the re-drive is a strict no-op without both a forward AND a --vsock route" {
+  _mk_unix_socket "$STUBDIR/agent17.sock" || skip "python3 AF_UNIX socket unavailable"
+  printf 'rbox\n' >"$STUBDIR/.msb_sandbox_list"
+  printf 'rbox\n' >"$STUBDIR/.msb_running_list"
+  # (a) route present, but NO host forward requested -> no bridge.
+  printf '{"active_config":{"vsock":[{"port":3552}]}}\n' >"$STUBDIR/.msb_inspect_json"
+  : > "$CALLS"
+  run bash -c '
+    unset SSH_AUTH_SOCK ACQ_FORWARD_HOST_SOCKETS
+    export STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _acq_msb_ensure_ssh_agent_forward rbox >/dev/null 2>&1
+    wait
+  '
+  refute_regex "$(cat "$CALLS")" 'socat UNIX-LISTEN'
+  # (b) forward requested, but the sandbox has NO --vsock route -> no bridge.
+  printf '{"active_config":{"network":{}}}\n' >"$STUBDIR/.msb_inspect_json"
+  : > "$CALLS"
+  run bash -c '
+    export SSH_AUTH_SOCK="'"$STUBDIR"'/agent17.sock" STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _acq_msb_ensure_ssh_agent_forward rbox >/dev/null 2>&1
+    wait
+  '
+  refute_regex "$(cat "$CALLS")" 'socat UNIX-LISTEN'
+}
+
 @test "msb: the base-image prereq check warns on missing tools, silent when present or skipped" {
   local pq="$STUBDIR/pq"; mkdir -p "$pq"
   cat >"$pq/msb" <<'PQ'

--- a/test/bats/20-backend-resolution.bats
+++ b/test/bats/20-backend-resolution.bats
@@ -129,10 +129,10 @@ _resolve() { # ADAPTER EXPLICIT  -> prints "<resolved>|<stderr-note>"
   local fake_home="$STUBDIR/home"
   mkdir -p "$fake_home/.local/bin"
   mv "$STUBDIR/msb" "$fake_home/.local/bin/msb"
-  local coreutils_dir
-  coreutils_dir="$(dirname "$(command -v env)")"
+  local coreutils_path
+  coreutils_path="$(_acq_coreutils_path)"
   export HOME="$fake_home"
-  export PATH="$coreutils_dir"
+  export PATH="$coreutils_path"
   # shellcheck source=acq
   ACQ_SOURCE_ONLY=1 . "$ACQ"
   # shellcheck source=acq.backends/msb.sh
@@ -156,9 +156,9 @@ _resolve() { # ADAPTER EXPLICIT  -> prints "<resolved>|<stderr-note>"
   printf '#!/bin/sh\necho DECOY\n' > "$fake_home/.local/bin/msb"
   chmod +x "$fake_home/.local/bin/msb"
   export HOME="$fake_home"
-  local coreutils_dir
-  coreutils_dir="$(dirname "$(command -v env)")"
-  export PATH="$STUBDIR:$coreutils_dir"
+  local coreutils_path
+  coreutils_path="$(_acq_coreutils_path)"
+  export PATH="$STUBDIR:$coreutils_path"
   export ACQ_BACKEND=msb
   # shellcheck source=acq
   ACQ_SOURCE_ONLY=1 . "$ACQ"

--- a/test/bats/helper.bash
+++ b/test/bats/helper.bash
@@ -41,3 +41,25 @@ acq_setup_stubs() {
 acq_teardown_stubs() {
   cleanup_stubs || true
 }
+
+# _acq_coreutils_path — echo a ':'-joined PATH holding the directories of the
+# core tools a test (and bats' own teardown, which runs `rm`) needs. Tests that
+# want to prove PATH self-repair narrow PATH down to "just coreutils" so the
+# backend CLI is provably absent; naively using `dirname $(command -v env)` can
+# yield a directory that lacks `rm`/`cat` on hosts where coreutils are split
+# across dirs (Homebrew, Nix, some distros) — which then breaks `run cat …` in
+# the test AND `rm` in bats-exec-test's own teardown. Union the dirs of every
+# tool we actually rely on so the narrowed PATH is complete regardless of layout.
+# De-dupes while preserving first-seen order. bash 3.2 safe.
+_acq_coreutils_path() {
+  local _tools="env rm cat mkdir mv chmod dirname sh grep sed awk printf"
+  local _t _d _seen="" _out=""
+  for _t in $_tools; do
+    _d=$(command -v "$_t" 2>/dev/null) || continue
+    _d=$(dirname "$_d")
+    case ":$_seen:" in *":$_d:"*) continue ;; esac
+    _seen="${_seen:+$_seen:}$_d"
+    _out="${_out:+$_out:}$_d"
+  done
+  printf '%s' "$_out"
+}


### PR DESCRIPTION
> AI-assisted (OpenCode). Human-owned and reviewed per repo AI-contribution policy.

## Context

On the **msb** backend, the host ssh-agent is forwarded into the guest over a create-time `--vsock` route plus an in-guest `socat` bridge (ADR-0021). Guest `git`/`ssh` see the agent only because acq injects `SSH_AUTH_SOCK` into the guest process (`-e SSH_AUTH_SOCK=<sock>`) on attach / `acq exec` / kit commands — and it does that **only when the persisted `/var/lib/acq/ssh-auth-sock` marker is non-empty**.

That marker is written solely by `_acq_msb_start_ssh_agent_bridge`, which on a reattach ran **only** via `acq_backend_start` — and `acq_backend_start` runs **only when the sandbox was stopped**. Re-attaching to an *already-running* sandbox (`acq run <name>` / `acq run <agent> .` against an existing running sandbox) skipped it: the heal's start-if-stopped block is a no-op on a running sandbox, so nothing re-started the bridge or wrote the marker. Result: the attached agent got **no `SSH_AUTH_SOCK`**, and the operator had to `export SSH_AUTH_SOCK=/home/agent/.acq/ssh-agent.sock` by hand before signing. (The socket/bridge worked; only the env-var injection was missing — the two are independent.)

## Change

- Add `_acq_msb_ensure_ssh_agent_forward` and a `_acq_msb_has_ssh_agent_vsock_route` probe (reads `msb inspect --format json`), and call the former at the top of `acq_backend_ensure_kits_applied` so **every** reattach — running or resumed — re-drives the forward.
- Strict no-op unless **both**: (1) a host forward is requested (`SSH_AUTH_SOCK` set — the same opt-in as provision), and (2) the sandbox carries the create-time `--vsock` route. The route is create-time only, so a sandbox created *without* a forward still needs a recreate; requiring the route also avoids writing a **misleading** marker behind an inert bridge.
- The route probe requires **both** a `vsock` key **and** the ssh-agent guest-port token in the flattened `msb inspect` document, so a published port that merely equals the (overridable) vsock port cannot be mistaken for a route (addresses the review's anchoring nit). Shape confirmed against real msb 0.6.12: `"vsock":{"routes":[{"host_socket":"…/Listeners","port":3552}]}`.

## Additional fixes folded in (test/verify tooling)

Small, unrelated breakages surfaced while running the suite on a real host; kept here rather than tracked separately (per maintainer direction):

- **`fix(verify): strip CRLF from captured guest output in run_acq`** — guest output reaches `scripts/verify-backends` over msb's PTY/ssh transport as CRLF; the trailing `\r` broke the kit-volumes `df` parse (`awk '$6'` → `"/acq-verify-vol\r"`), reporting a correct mount as "not a dedicated block mountpoint". Normalized CRLF→LF once in `run_acq`.
- **`fix(tests): build a complete coreutils PATH for the self-repair tests`** — the two PATH self-repair tests narrowed `PATH` via `dirname $(command -v env)`, which on split-coreutils hosts (Homebrew/Nix) omits `rm`/`cat`; the exported narrow PATH leaked into bats `teardown()` and broke its `rm` cleanup (`rm: command not found`) and the in-test `run cat` (BW01 exit 127). Added `_acq_coreutils_path` to `test/bats/helper.bash` (unions the dirs of every tool the tests + teardown use) and switched both tests to it.

## Verification

- `scripts/test-acq-bats` (the bats suite; the bespoke `scripts/test-acq` runner was retired by the ADR-0025 migration): **343 passed, 0 failed, 0 BW01 warnings**. Re-run on current `main` (post-#393, which restored honest bats failure detection), so this is a meaningful green, not a vacuous pass. New/updated ssh-agent cases in `test/bats/115-ssh-agent-forward.bats`:
  - **10c16** — running reattach starts the socat bridge + writes the `SSH_AUTH_SOCK` marker, and does **not** call `msb start`.
  - **10c17** — strict no-op when no forward is requested, when the sandbox has no `--vsock` route, or when a published port merely equals the vsock port with no `vsock` key.
  - **10c18** — the route probe matches the real msb 0.6.12 `vsock` shape and rejects a same-port published port.
- `shellcheck --severity=warning` clean on `acq.backends/msb.sh`, `acq.backends/common.sh`, `scripts/verify-backends`, `test/bats/helper.bash`, and the bats files.
- `scripts/verify-backends` kit-volumes + self-repair test noise confirmed clean on the reporter's host.

## Rollback

Revert the commits. The core change is additive (a new helper + one call site in `acq_backend_ensure_kits_applied`); reverting restores the prior stopped-only re-drive behavior. The tooling fixes are test/verify-only. No config/data migration.

## Security impact

Touches the ssh-agent forwarding path (ADR-0021). No new external service or data-classification change. The re-drive keys off the same `SSH_AUTH_SOCK` opt-in and requires the create-time `--vsock` route to already be present, so it cannot forward an agent into a sandbox that wasn't created for one, and it never writes a marker that would advertise a working agent behind an inert bridge. Host-side gated, SI-10-validated port/socket inputs unchanged.

## Follow-up

Live end-to-end verification of the **running-reattach re-drive** (`_acq_msb_ensure_ssh_agent_forward`) on a KVM/HVF host — cannot run in CI / inside a sandbox. Tracked in GSA-TTS/agentic-coding-quickstart#388. (The `msb inspect` vsock JSON shape the probe matches is no longer part of that gap — it is now confirmed against msb 0.6.12 and covered by 10c18.)
