### PR TITLE
fix(tests): restore real failure detection in the bats suite + repair 56 latent test failures

### DIFF
--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -480,11 +480,18 @@ _acq_is_managed_secret_rm() {
 # Word-split a whitespace-separated env value into the named array WITHOUT
 # filename globbing (a literal `*` in a kit ref must not expand against the cwd).
 split_noglob() {
-  local _name="$1" _val="$2" _oldopts
-  _oldopts=$(set +o); set -f
+  local _name="$1" _val="$2" _had_noglob=0
+  # Save/restore ONLY noglob. Capturing the full option state with
+  # `_oldopts=$(set +o)` is a trap: a command-substitution subshell runs with
+  # errexit CLEARED (pre-inherit_errexit bash, incl. macOS 3.2), so the captured
+  # state says `set +o errexit` and the eval restore silently turned `set -e`
+  # OFF in the caller for the rest of the run (found via #381: it also disabled
+  # bats' failure detection whenever ACQ_EXTRA_KITS was set).
+  case "$-" in *f*) _had_noglob=1 ;; esac
+  set -f
   # shellcheck disable=SC2086
   set -- $_val
-  eval "$_oldopts"
+  if [ "$_had_noglob" -eq 0 ]; then set +f; fi
   eval "$_name=(\"\$@\")"
 }
 

--- a/scripts/test-acq-lib.sh
+++ b/scripts/test-acq-lib.sh
@@ -455,6 +455,11 @@ KEYGENSTUB
   # Isolate the host-side kit-bundle provenance store to this
   # test's temp dir so provenance reads/writes never touch the real XDG state.
   export ACQ_PROVENANCE_DIR="$STUBDIR/provenance"
+  # Neutralize the developer's real kit customizations: an inherited
+  # ACQ_EXTRA_KITS changes _build_kit_list's output (and, pre-#381, triggered
+  # the split_noglob errexit loss), making local test runs diverge from CI.
+  # Tests that exercise extras set these themselves.
+  unset ACQ_EXTRA_KITS ACQ_EXTRA_KIT_SOURCES
 }
 
 cleanup_stubs() { [ -n "${STUBDIR:-}" ] && rm -rf "$STUBDIR"; }
@@ -468,5 +473,7 @@ load_acq() {
   . "${REPO_ROOT}/acq.backends/sbx.sh"
   # Build the kit list (normally called by acq_resolve_backend).
   _build_kit_list
-  set +e
+  # Do NOT `set +e` here (the pre-ADR-0025 bespoke runner did): bats detects a
+  # failing command via errexit inherited into the @test body, so disabling it
+  # in setup() makes every assertion in the suite pass vacuously (#381 review).
 }

--- a/test/bats/105-ports-background.bats
+++ b/test/bats/105-ports-background.bats
@@ -38,6 +38,7 @@ SPEC
   assert_output --partial "$(printf '4096\ttcp\tapi\t4096')"
 
   run bash -c '
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh" 2>/dev/null
     arr=(); _acq_msb_port_flags_into arr "'"$ppkit"'/spec.yaml"; printf "%s\n" "${arr[@]}"
   '
@@ -74,6 +75,7 @@ SPEC
   assert_output --partial 'DEPRECATION'
   assert_output --partial 'backend_extras.sbx.publishedPorts'
   run bash -c '
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh" 2>/dev/null
     arr=(); _acq_msb_port_flags_into arr "'"$lpkit"'/spec.yaml" 2>/dev/null; printf "%s\n" "${arr[@]}"
   '
@@ -153,6 +155,7 @@ SPEC
   run bash -c '. "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"; kit_spec_published_ports "'"$nonekit"'/spec.yaml" 2>&1'
   assert_output ''
   run bash -c '
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh" 2>/dev/null
     arr=(); _acq_msb_port_flags_into arr "'"$nonekit"'/spec.yaml" 2>&1; printf "%s" "${arr[@]:-}"
   '
@@ -215,13 +218,14 @@ SPEC
   run bash -c '
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/bg-secrets"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     _acq_msb_run_commands bgbox "'"$bgk"'/spec.yaml"
   '
   local log; log=$(cat "$CALLS")
   assert_regex "$log" 'nohup'
   assert_regex "$log" 'supervisor-loop'
-  assert_regex "$log" -- '-- foreground-cmd'
+  assert_regex "$log" '-- foreground-cmd'
 }
 
 @test "bg(sbx): the translator preserves background: true without wrapping in nohup" {
@@ -269,6 +273,7 @@ publishedPorts:
     host: 8080
 SPEC
   run bash -c '
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh" 2>/dev/null
     arr=(); _acq_msb_port_flags_into arr "'"$hokit"'/spec.yaml"; printf "%s\n" "${arr[@]}"
   '

--- a/test/bats/110-volumes.bats
+++ b/test/bats/110-volumes.bats
@@ -37,6 +37,7 @@ SPEC
   assert_output --partial "$(printf '/scratch\ttmpfs\t2G')"
 
   run bash -c '
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh" 2>/dev/null
     arr=(); _acq_msb_volume_flags_into arr "'"$vkit"'/spec.yaml" volbox; printf "%s\n" "${arr[@]}"
   '
@@ -158,6 +159,7 @@ SPEC
   run bash -c '. "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"; kit_spec_volumes "'"$novkit"'/spec.yaml" 2>&1'
   assert_output ''
   run bash -c '
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh" 2>/dev/null
     arr=(); _acq_msb_volume_flags_into arr "'"$novkit"'/spec.yaml" volbox 2>&1; printf "%s" "${arr[@]:-}"
   '
@@ -232,12 +234,13 @@ volumes:
   - path: /late
     size: 1G
 SPEC
-  run bash -c '. "'"$REPO_ROOT"'/acq.backends/msb.sh" 2>/dev/null; acq_backend_apply_kit volbox "'"$avkit"'" 2>&1'
+  run bash -c '. "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"; . "'"$REPO_ROOT"'/acq.backends/msb.sh" 2>/dev/null; acq_backend_apply_kit volbox "'"$avkit"'" 2>&1'
   assert_output --partial 'CREATE time only'
 }
 
 @test "msb: net-rule uses a bare FQDN target, strips :port, avoids domain= / domain: forms" {
   run bash -c '
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh" 2>/dev/null
     nkit="'"$STUBDIR"'/nkit"; mkdir -p "$nkit"
     cat >"$nkit/spec.yaml" <<'"'"'SPEC'"'"'

--- a/test/bats/111-balanced-egress.bats
+++ b/test/bats/111-balanced-egress.bats
@@ -47,8 +47,12 @@ _load_msb() { . "${REPO_ROOT}/acq.backends/msb.sh" 2>/dev/null; }
 }
 
 @test "balanced_target: single-label suffix *.com is dropped (nonzero, no output)" {
-  _load_msb
-  run _acq_msb_balanced_target '*.com'
+  # The drop is announced on stderr by design; "no output" means no stdout
+  # (nothing reaches the caller's argv), so discard stderr before capturing.
+  run bash -c '
+    . "'"${REPO_ROOT}"'/acq.backends/msb.sh" 2>/dev/null
+    _acq_msb_balanced_target "*.com" 2>/dev/null
+  '
   assert_failure
   assert_output ''
 }

--- a/test/bats/115-ssh-agent-forward.bats
+++ b/test/bats/115-ssh-agent-forward.bats
@@ -30,6 +30,7 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   _mk_unix_socket "$STUBDIR/agent.sock" || skip "python3 AF_UNIX socket unavailable"
   run bash -c '
     export SSH_AUTH_SOCK="'"$STUBDIR"'/agent.sock" STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     f=(); _acq_msb_vsock_flags_into f; printf "%s\n" "${f[@]+"${f[@]}"}"
   '
@@ -51,12 +52,14 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   _mk_unix_socket "$STUBDIR/agent.sock" || skip "python3 AF_UNIX socket unavailable"
   run bash -c '
     export SSH_AUTH_SOCK="'"$STUBDIR"'/agent.sock" STUB_MSB_VERSION=0.6.8
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     f=(); _acq_msb_vsock_flags_into f 2>&1 1>/dev/null; printf "%s" "${f[@]+"${f[@]}"}"
   '
   assert_output --partial 'needs msb >= 0.6.9'
   run bash -c '
     export SSH_AUTH_SOCK="'"$STUBDIR"'/agent.sock" STUB_MSB_VERSION=0.6.8
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     f=(); _acq_msb_vsock_flags_into f 2>/dev/null; printf "%s\n" "${f[@]+"${f[@]}"}"
   '
@@ -67,12 +70,14 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   touch "$STUBDIR/not-a-socket"
   run bash -c '
     export SSH_AUTH_SOCK="'"$STUBDIR"'/not-a-socket" STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     f=(); _acq_msb_vsock_flags_into f 2>&1 1>/dev/null; printf "%s" "${f[@]+"${f[@]}"}"
   '
   assert_output --partial 'not a socket'
   run bash -c '
     export SSH_AUTH_SOCK="'"$STUBDIR"'/not-a-socket" STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     f=(); _acq_msb_vsock_flags_into f 2>/dev/null; printf "%s\n" "${f[@]+"${f[@]}"}"
   '
@@ -84,6 +89,7 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   run bash -c '
     unset SSH_AUTH_SOCK
     export ACQ_FORWARD_HOST_SOCKETS="'"$STUBDIR"'/custom.sock:6000/stream" STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     f=(); _acq_msb_vsock_flags_into f 2>/dev/null; printf "%s\n" "${f[@]+"${f[@]}"}"
   '
@@ -209,6 +215,7 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   _mk_unix_socket "$STUBDIR/agent.sock" || skip "python3 AF_UNIX socket unavailable"
   run bash -c '
     export SSH_AUTH_SOCK="'"$STUBDIR"'/agent.sock" STUB_MSB_VERSION=0.6.9 ACQ_SSH_AGENT_VSOCK_PORT=123
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     f=(); _acq_msb_vsock_flags_into f 2>"'"$STUBDIR"'/c12.err"; printf "%s\n" "${f[@]+"${f[@]}"}"
     cat "'"$STUBDIR"'/c12.err"
@@ -217,6 +224,7 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   assert_output --partial 'ACQ_SSH_AGENT_VSOCK_PORT'
   run bash -c '
     export SSH_AUTH_SOCK="'"$STUBDIR"'/agent.sock" STUB_MSB_VERSION=0.6.9 ACQ_SSH_AGENT_VSOCK_PORT=9000
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     f=(); _acq_msb_vsock_flags_into f 2>/dev/null; printf "%s\n" "${f[@]+"${f[@]}"}"
   '
@@ -228,6 +236,7 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   : > "$CALLS"
   run bash -c '
     export SSH_AUTH_SOCK="'"$STUBDIR"'/agent.sock" STUB_MSB_VERSION=0.6.9 ACQ_SSH_AGENT_VSOCK_PORT=9000
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     f=(); _acq_msb_vsock_flags_into f 2>/dev/null; printf "ROUTE %s\n" "${f[@]+"${f[@]}"}"
     _acq_msb_start_ssh_agent_bridge sbox >/dev/null 2>&1
@@ -241,6 +250,7 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   _mk_unix_socket "$STUBDIR/agent15.sock" || skip "python3 AF_UNIX socket unavailable"
   run bash -c '
     export SSH_AUTH_SOCK="'"$STUBDIR"'/agent15.sock" STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     f=(); _acq_msb_vsock_flags_into f 2>&1 1>/dev/null; printf "%s\n" "${f[@]+"${f[@]}"}" >/dev/null
   '
@@ -250,6 +260,7 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   # At most once per process.
   run bash -c '
     export SSH_AUTH_SOCK="'"$STUBDIR"'/agent15.sock" STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     { f=(); _acq_msb_vsock_flags_into f; f=(); _acq_msb_vsock_flags_into f; } 2>&1 1>/dev/null
   '

--- a/test/bats/30-dispatch-routing.bats
+++ b/test/bats/30-dispatch-routing.bats
@@ -39,7 +39,7 @@ _seed_usai() {
   run env ACQ_BACKEND=sbx "$ACQ" create opencode "$proj"
   local log; log=$(cat "$CALLS")
   assert_regex "$log" 'sbx create --name'
-  assert_regex "$log" -- '--kit'
+  assert_regex "$log" '--kit'
   assert_regex "$log" 'acq-kits/usai-provider'
   local create_line; create_line=$(printf '%s\n' "$log" | grep '^sbx create')
   assert_regex "$create_line" "$proj"
@@ -233,7 +233,7 @@ _seed_usai() {
   _seed_usai
   run env ACQ_BACKEND=sbx "$ACQ" create opencode --kit /tmp/mykit "$proj"
   local create_line; create_line=$(printf '%s\n' "$(cat "$CALLS")" | grep '^sbx create')
-  assert_regex "$create_line" -- '--kit /tmp/mykit'
+  assert_regex "$create_line" '--kit /tmp/mykit'
   assert_regex "$create_line" "$proj"
   refute_regex "$create_line" "$proj --kit /tmp/mykit"
   refute_regex "$create_line" "$proj /tmp/mykit"
@@ -244,8 +244,8 @@ _seed_usai() {
   _seed_usai
   run env ACQ_BACKEND=sbx "$ACQ" create opencode --kit=/tmp/eqkit "$proj"
   local create_line; create_line=$(printf '%s\n' "$(cat "$CALLS")" | grep '^sbx create')
-  assert_regex "$create_line" -- '--kit /tmp/eqkit'
-  refute_regex "$create_line" -- '--kit=/tmp/eqkit'
+  assert_regex "$create_line" '--kit /tmp/eqkit'
+  refute_regex "$create_line" '--kit=/tmp/eqkit'
 }
 
 @test "kit-flag: multiple --kit flags are all intercepted" {
@@ -253,8 +253,8 @@ _seed_usai() {
   _seed_usai
   run env ACQ_BACKEND=sbx "$ACQ" create opencode --kit /tmp/k1 --kit /tmp/k2 "$proj"
   local create_line; create_line=$(printf '%s\n' "$(cat "$CALLS")" | grep '^sbx create')
-  assert_regex "$create_line" -- '--kit /tmp/k1'
-  assert_regex "$create_line" -- '--kit /tmp/k2'
+  assert_regex "$create_line" '--kit /tmp/k1'
+  assert_regex "$create_line" '--kit /tmp/k2'
   assert_regex "$create_line" "$proj"
 }
 
@@ -263,7 +263,7 @@ _seed_usai() {
   _seed_usai
   run env ACQ_BACKEND=sbx "$ACQ" run opencode --kit /tmp/runkit "$proj"
   local create_line; create_line=$(printf '%s\n' "$(cat "$CALLS")" | grep '^sbx create')
-  assert_regex "$create_line" -- '--kit /tmp/runkit'
+  assert_regex "$create_line" '--kit /tmp/runkit'
   refute_regex "$create_line" "$proj --kit /tmp/runkit"
 }
 
@@ -273,6 +273,6 @@ _seed_usai() {
   run env ACQ_BACKEND=sbx "$ACQ" run opencode "$proj" -- --kit evil-agent-arg
   local log; log=$(cat "$CALLS")
   local create_line; create_line=$(printf '%s\n' "$log" | grep '^sbx create')
-  refute_regex "$create_line" -- '--kit evil-agent-arg'
-  assert_regex "$log" -- '--kit evil-agent-arg'
+  refute_regex "$create_line" '--kit evil-agent-arg'
+  assert_regex "$log" '--kit evil-agent-arg'
 }

--- a/test/bats/35-image-override.bats
+++ b/test/bats/35-image-override.bats
@@ -40,14 +40,14 @@ _create_line() { printf '%s\n' "$(cat "$CALLS")" | grep "^$1 create"; }
   local line; line=$(_create_line msb)
   assert_regex "$line" 'localhost/acq-custom:test'
   refute_regex "$line" 'docker\.io/docker/sandbox-templates:shell-docker'
-  refute_regex "$line" -- '--image'
+  refute_regex "$line" '--image'
 }
 
 @test "image(msb): --image flag path equals the env path; workspace survives" {
   _msb_create -- create shell --image localhost/acq-flag:test "$IMGPROJ"
   local line; line=$(_create_line msb)
   assert_regex "$line" 'localhost/acq-flag:test'
-  refute_regex "$line" -- '--image'
+  refute_regex "$line" '--image'
   load_acq
   assert_regex "$line" "$(canonicalize_path "$IMGPROJ")"
 }
@@ -56,33 +56,33 @@ _create_line() { printf '%s\n' "$(cat "$CALLS")" | grep "^$1 create"; }
   _msb_create -- create shell --image=localhost/acq-eq:test "$IMGPROJ"
   local line; line=$(_create_line msb)
   assert_regex "$line" 'localhost/acq-eq:test'
-  refute_regex "$line" -- '--image=localhost/acq-eq:test'
+  refute_regex "$line" '--image=localhost/acq-eq:test'
 }
 
 @test "image(msb): a global --image (before the subcommand) is intercepted" {
   _msb_create -- --backend msb --image localhost/acq-global:test create shell --name gimg "$IMGPROJ"
   local line; line=$(_create_line msb)
   assert_regex "$line" 'localhost/acq-global:test'
-  refute_regex "$line" -- '--image'
+  refute_regex "$line" '--image'
 }
 
 @test "image(msb): ACQ_MSB_PULL maps to --pull; invalid is ignored with a warning" {
   _msb_create ACQ_MSB_PULL=never ACQ_IMAGE=localhost/acq-cached:test -- create shell --name pimg "$IMGPROJ"
   local line; line=$(_create_line msb)
-  assert_regex "$line" -- '--pull never'
+  assert_regex "$line" '--pull never'
   assert_regex "$line" 'localhost/acq-cached:test'
 
   : > "$CALLS"
   _msb_create ACQ_MSB_PULL=bogus -- create shell --name pbad "$IMGPROJ"
   assert_output --partial 'invalid ACQ_MSB_PULL'
-  refute_regex "$(_create_line msb)" -- '--pull'
+  refute_regex "$(_create_line msb)" '--pull'
 }
 
 @test "image(msb): global --image=<ref> equals form is intercepted" {
   _msb_create -- --backend msb --image=localhost/acq-globaleq:test create shell --name gimgeq "$IMGPROJ"
   local line; line=$(_create_line msb)
   assert_regex "$line" 'localhost/acq-globaleq:test'
-  refute_regex "$line" -- '--image='
+  refute_regex "$line" '--image='
 }
 
 @test "image(msb): explicit ACQ_MSB_IMAGE beats neutral ACQ_IMAGE (with notice)" {
@@ -108,34 +108,34 @@ _sbx_create() { # CREATE_ARGS... (with optional leading ENV via `env`)
 @test "image(sbx): neutral image injects --template, not raw --image" {
   _sbx_create ACQ_IMAGE=docker.io/my-org/my-template:v1 ACQ_BACKEND=sbx "$ACQ" create opencode "$IMGPROJ"
   local line; line=$(_create_line sbx)
-  assert_regex "$line" -- '--template docker\.io/my-org/my-template:v1'
-  refute_regex "$line" -- '--image'
+  assert_regex "$line" '--template docker\.io/my-org/my-template:v1'
+  refute_regex "$line" '--image'
 }
 
 @test "image(sbx): --image flag path also injects --template" {
   _sbx_create ACQ_BACKEND=sbx "$ACQ" create opencode --image docker.io/my-org/flag-tpl:v2 "$IMGPROJ"
-  assert_regex "$(_create_line sbx)" -- '--template docker\.io/my-org/flag-tpl:v2'
+  assert_regex "$(_create_line sbx)" '--template docker\.io/my-org/flag-tpl:v2'
 }
 
 @test "image(sbx): a global --image injects --template, not raw" {
   _sbx_create "$ACQ" --backend sbx --image docker.io/my-org/global-tpl:v3 create opencode "$IMGPROJ"
   local line; line=$(_create_line sbx)
-  assert_regex "$line" -- '--template docker\.io/my-org/global-tpl:v3'
-  refute_regex "$line" -- '--image'
+  assert_regex "$line" '--template docker\.io/my-org/global-tpl:v3'
+  refute_regex "$line" '--image'
 }
 
 @test "image(sbx): an explicit user --template is not double-injected" {
   _sbx_create ACQ_IMAGE=docker.io/my-org/neutral:v1 ACQ_BACKEND=sbx "$ACQ" \
     create opencode --template docker.io/my-org/explicit:v9 "$IMGPROJ"
   local line; line=$(_create_line sbx)
-  assert_regex "$line" -- '--template docker\.io/my-org/explicit:v9'
+  assert_regex "$line" '--template docker\.io/my-org/explicit:v9'
   refute_regex "$line" 'docker\.io/my-org/neutral:v1'
   assert_output --partial 'ignoring --image'
 }
 
 @test "image(sbx): no image set -> no --template injected" {
   _sbx_create ACQ_BACKEND=sbx "$ACQ" create opencode "$IMGPROJ"
-  refute_regex "$(_create_line sbx)" -- '--template'
+  refute_regex "$(_create_line sbx)" '--template'
 }
 
 @test "image(reattach): --image on an existing sandbox warns and does not re-provision" {
@@ -204,6 +204,7 @@ STUB
   : > "$CALLS"
   local imgfail="$STUBDIR/imgfail"; mkdir -p "$imgfail"
   run bash -c '
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/sbx.sh"
     ACQ_IMAGE=ghcr.io/org/priv:v1 acq_backend_provision imgfailbox shell "'"$imgfail"'" 2>&1 >/dev/null
   '

--- a/test/bats/60-help.bats
+++ b/test/bats/60-help.bats
@@ -159,15 +159,20 @@ load 'helper'
   assert_equal "$(cat "$d/acq.usai" 2>/dev/null)" 'sk-usai-AAAA'
   assert_equal "$(cat "$d/acq.github" 2>/dev/null)" 'ghp_BBBB'
 
-  run env USAI_API_KEY=sk-usai-CCCC GITHUB_TOKEN=ghp_BBBB \
+  # Blank every token var not under test in each step: an ambient GITLAB_TOKEN
+  # (etc.) from the developer's shell would import a stray GLOBAL entry, and the
+  # scoped --all step below would then skip via the global-fallback exists check.
+  run env USAI_API_KEY=sk-usai-CCCC GITHUB_TOKEN=ghp_BBBB GITLAB_TOKEN='' GH_TOKEN='' \
     ACQ_SECRET_STORE_DIR="$d" ACQ_BACKEND=sbx "$ACQ" secret import --all
   assert_output --partial 'already stored'
   assert_equal "$(cat "$d/acq.usai" 2>/dev/null)" 'sk-usai-AAAA'
 
-  run env USAI_API_KEY=sk-usai-CCCC ACQ_SECRET_STORE_DIR="$d" ACQ_BACKEND=sbx "$ACQ" secret import usai --force
+  run env USAI_API_KEY=sk-usai-CCCC GITHUB_TOKEN='' GH_TOKEN='' GITLAB_TOKEN='' \
+    ACQ_SECRET_STORE_DIR="$d" ACQ_BACKEND=sbx "$ACQ" secret import usai --force
   assert_equal "$(cat "$d/acq.usai" 2>/dev/null)" 'sk-usai-CCCC'
 
-  run env GITLAB_TOKEN=glpat-DDDD ACQ_SECRET_STORE_DIR="$d" ACQ_BACKEND=sbx "$ACQ" secret import gitlab mybox --all
+  run env GITLAB_TOKEN=glpat-DDDD USAI_API_KEY='' GITHUB_TOKEN='' GH_TOKEN='' \
+    ACQ_SECRET_STORE_DIR="$d" ACQ_BACKEND=sbx "$ACQ" secret import gitlab mybox --all
   assert [ -e "$d/acq.mybox.gitlab" ]
 }
 

--- a/test/bats/70-msb-backend.bats
+++ b/test/bats/70-msb-backend.bats
@@ -136,7 +136,9 @@ _with_adapter() { # ADAPTER BODY
 }
 
 @test "msb: version floor rejects sub-0.6.9, accepts 0.6.9" {
-  _with_adapter msb 'STUB_MSB_VERSION=0.6.8 ACQ_SKIP_MSB_DOCTOR=1 acq_backend_prepare 2>&1; printf "RC=%s\n" "$?"'
+  # acq_backend_prepare `exit`s on the floor violation, so run it in a command
+  # substitution (a subshell) to keep this shell alive to report RC.
+  _with_adapter msb 'out=$(STUB_MSB_VERSION=0.6.8 ACQ_SKIP_MSB_DOCTOR=1 acq_backend_prepare 2>&1); rc=$?; printf "%s\nRC=%s\n" "$out" "$rc"'
   assert_output --partial '0.6.9'
   assert_output --partial 'RC=1'
   _with_adapter msb 'out=$(STUB_MSB_VERSION=0.6.9 ACQ_SKIP_MSB_DOCTOR=1 acq_backend_prepare 2>&1); printf "%s\nRC=%s\n" "$out" "$?"'
@@ -144,7 +146,8 @@ _with_adapter() { # ADAPTER BODY
 }
 
 @test "sbx: version floor rejects sub-0.38.0 with the v2-grammar cause, accepts 0.38.0" {
-  _with_adapter sbx 'STUB_SBX_VERSION=0.37.9 acq_backend_prepare 2>&1; printf "RC=%s\n" "$?"'
+  # Same subshell isolation as the msb floor test: prepare `exit`s on violation.
+  _with_adapter sbx 'out=$(STUB_SBX_VERSION=0.37.9 acq_backend_prepare 2>&1); rc=$?; printf "%s\nRC=%s\n" "$out" "$rc"'
   assert_output --partial '0.38.0'
   assert_output --partial 'v2 kit grammar'
   assert_output --partial 'RC=1'

--- a/test/bats/71-msb-provision-secrets.bats
+++ b/test/bats/71-msb-provision-secrets.bats
@@ -15,7 +15,8 @@ teardown() { acq_teardown_stubs; }
 
 load 'helper'
 
-# Run a provision in a subshell: seed store, source secret-store + msb, stub the
+# Run a provision in a subshell: source common (which chains kit-translate,
+# secret-store, and progress via ACQ_SCRIPT_DIR) + msb, seed the store, stub the
 # kit fetch to a local no-op kit, and provision NAME. PRE is extra shell run
 # before provision (store seeding / env). Captures stderr+stdout via `run`.
 _provision() { # NAME PRE_SNIPPET
@@ -23,7 +24,8 @@ _provision() { # NAME PRE_SNIPPET
   : > "$CALLS"
   run bash -c '
     name="$1"; pre="$2"
-    . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    export ACQ_SCRIPT_DIR="'"$REPO_ROOT"'"
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     eval "$pre"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     mkdir -p "'"$STUBDIR"'/nokit"
@@ -40,16 +42,16 @@ _provision() { # NAME PRE_SNIPPET
     printf "GH-REAL-VALUE\n"   | acq_secret_store "$(_acq_secret_key github)"
   '
   local log; log=$(cat "$CALLS")
-  assert_regex "$log" -- '--tls-intercept'
-  assert_regex "$log" -- '--secret USAI_API_KEY@api\.gsa\.usai\.gov'
-  assert_regex "$log" -- "--secret $MSB_GITHUB_SECRET_BINDING"
+  assert_regex "$log" '--tls-intercept'
+  assert_regex "$log" '--secret USAI_API_KEY@api\.gsa\.usai\.gov'
+  assert_regex "$log" "--secret $MSB_GITHUB_SECRET_BINDING"
   refute_regex "$log" 'USAI-REAL-VALUE'
   refute_regex "$log" 'GH-REAL-VALUE'
   # Workspace mounted at the same canonical guest path (sbx-parity), default image.
   load_acq
   local ws; ws=$(canonicalize_path /tmp)
-  assert_regex "$log" -- "--volume ${ws}:${ws}"
-  refute_regex "$log" -- "--volume ${ws}:/home/agent/workspace"
+  assert_regex "$log" "--volume ${ws}:${ws}"
+  refute_regex "$log" "--volume ${ws}:/home/agent/workspace"
   assert_regex "$log" 'msb create --name provbox'
   assert_regex "$log" 'docker\.io/docker/sandbox-templates:shell-docker'
   refute_regex "$log" 'docker\.io/library/node:22-bookworm'
@@ -61,7 +63,7 @@ _provision() { # NAME PRE_SNIPPET
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/upca-secrets"
     export ACQ_MSB_UPSTREAM_CA_CERT="'"$STUBDIR"'/corp-root.pem"
   '
-  assert_regex "$(cat "$CALLS")" -- "--tls-upstream-ca-cert $STUBDIR/corp-root.pem"
+  assert_regex "$(cat "$CALLS")" "--tls-upstream-ca-cert $STUBDIR/corp-root.pem"
 }
 
 @test "msb: no --tls-intercept / upstream-CA when interception is disabled" {
@@ -72,8 +74,8 @@ _provision() { # NAME PRE_SNIPPET
     export ACQ_MSB_NO_TLS_INTERCEPT=1
   '
   local log; log=$(cat "$CALLS")
-  refute_regex "$log" -- '--tls-intercept'
-  refute_regex "$log" -- '--tls-upstream-ca-cert'
+  refute_regex "$log" '--tls-intercept'
+  refute_regex "$log" '--tls-upstream-ca-cert'
 }
 
 @test "msb: ACQ_MSB_NO_UPSTREAM_CA suppresses the CA flag but keeps interception" {
@@ -84,8 +86,8 @@ _provision() { # NAME PRE_SNIPPET
     export ACQ_MSB_NO_UPSTREAM_CA=1
   '
   local log; log=$(cat "$CALLS")
-  assert_regex "$log" -- '--tls-intercept'
-  refute_regex "$log" -- '--tls-upstream-ca-cert'
+  assert_regex "$log" '--tls-intercept'
+  refute_regex "$log" '--tls-upstream-ca-cert'
 }
 
 @test "msb: ACQ_MSB_IMAGE override is passed through, suppressing the default" {
@@ -107,10 +109,10 @@ _provision() { # NAME PRE_SNIPPET
     printf "NOMAP-VALUE\n"     | acq_secret_store "$(_acq_secret_key nomap)"
   '
   local log; log=$(cat "$CALLS")
-  assert_regex "$log" -- '--secret API_KEY@api\.example\.com'
-  assert_regex "$log" -- '--secret USAI_API_KEY@api\.gsa\.usai\.gov'
-  assert_regex "$log" -- "--secret $MSB_GITHUB_SECRET_BINDING"
-  refute_regex "$log" -- '--secret @'
+  assert_regex "$log" '--secret API_KEY@api\.example\.com'
+  assert_regex "$log" '--secret USAI_API_KEY@api\.gsa\.usai\.gov'
+  assert_regex "$log" "--secret $MSB_GITHUB_SECRET_BINDING"
+  refute_regex "$log" '--secret @'
   refute_regex "$log" 'nomap'
   refute_regex "$log" 'SBX-REAL-VALUE|USAI-REAL-VALUE|GH-REAL-VALUE|NOMAP-VALUE'
 }

--- a/test/bats/71b-msb-secret-store-backends.bats
+++ b/test/bats/71b-msb-secret-store-backends.bats
@@ -42,13 +42,15 @@ STSTUB
   chmod +x "$STUBDIR/secret-tool"
 }
 
-# Provision helper (as in 71): seed store, source msb, stub kit fetch, provision.
+# Provision helper (as in 71): source common (chains deps) + msb, seed store,
+# stub kit fetch, provision.
 _provision() { # NAME PRE_SNIPPET WS_ARGS...
   local name="$1" pre="$2"; shift 2
   : > "$CALLS"
   run bash -c '
     name="$1"; pre="$2"; shift 2
-    . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    export ACQ_SCRIPT_DIR="'"$REPO_ROOT"'"
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     eval "$pre"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     mkdir -p "'"$STUBDIR"'/nokit"
@@ -125,8 +127,8 @@ _provision() { # NAME PRE_SNIPPET WS_ARGS...
   ws_app=$(canonicalize_path "$STUBDIR/ws-app")
   ws_lib=$(canonicalize_path "$STUBDIR/ws-lib")
   log=$(cat "$CALLS")
-  assert_regex "$log" -- "--volume ${ws_app}:${ws_app}"
-  assert_regex "$log" -- "--volume ${ws_lib}:${ws_lib}:ro"
+  assert_regex "$log" "--volume ${ws_app}:${ws_app}"
+  assert_regex "$log" "--volume ${ws_lib}:${ws_lib}:ro"
   assert_regex "$log" "'${ws_app}' > /var/lib/acq/workspace"
   refute_regex "$log" "'/home/agent/workspace' > /var/lib/acq/workspace"
 
@@ -142,8 +144,8 @@ _provision() { # NAME PRE_SNIPPET WS_ARGS...
   local real_ws log
   real_ws=$(realpath "$STUBDIR/real-ws" 2>/dev/null || printf '%s' "$STUBDIR/real-ws")
   log=$(cat "$CALLS")
-  assert_regex "$log" -- "--volume ${real_ws}:${real_ws}"
-  refute_regex "$log" -- "--volume ${STUBDIR}/link-ws:"
+  assert_regex "$log" "--volume ${real_ws}:${real_ws}"
+  refute_regex "$log" "--volume ${STUBDIR}/link-ws:"
 }
 
 @test "msb: provision aborts (hard fail) when the sandbox never becomes exec-ready" {
@@ -175,7 +177,8 @@ MSBSTUB
 @test "msb: provision errors clearly when the host workspace path does not exist" {
   run bash -c '
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/mw-secrets"
-    . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    export ACQ_SCRIPT_DIR="'"$REPO_ROOT"'"
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     mkdir -p "'"$STUBDIR"'/nokit"
     printf "schemaVersion: \"hybrid/v1\"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n" > "'"$STUBDIR"'/nokit/spec.yaml"

--- a/test/bats/72-msb-agent-user.bats
+++ b/test/bats/72-msb-agent-user.bats
@@ -22,16 +22,19 @@ _provision() { # NAME AGENT PRE_SNIPPET [KITDIR]
   local name="$1" agent="$2" pre="$3" kitdir="${4:-}"
   : > "$CALLS"
   run bash -c '
-    name="$1"; agent="$2"; pre="$3"; kitdir="$4"
+    name="$1"; agent="$2"; pre="$3"; stub_kitdir="$4"
     . "'"$REPO_ROOT"'/acq.backends/common.sh"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     eval "$pre"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
-    if [ -z "$kitdir" ]; then
-      kitdir="'"$STUBDIR"'/nokit"; mkdir -p "$kitdir"
-      printf "schemaVersion: \"hybrid/v1\"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n" > "$kitdir/spec.yaml"
+    if [ -z "$stub_kitdir" ]; then
+      stub_kitdir="'"$STUBDIR"'/nokit"; mkdir -p "$stub_kitdir"
+      printf "schemaVersion: \"hybrid/v1\"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n" > "$stub_kitdir/spec.yaml"
     fi
-    _acq_msb_fetch_kit() { printf "%s\n" "$kitdir"; }
+    # NOTE: the stub must NOT read a variable named "kitdir" — provision declares
+    # a `local kitdir`, which dynamically shadows it at stub-call time.
+    _acq_msb_fetch_kit() { printf "%s\n" "$stub_kitdir"; }
     acq_backend_provision "$name" "$agent" /tmp 2>&1
     printf "PROVISION_RC=%s\n" "$?"
   ' _ "$name" "$agent" "$pre" "$kitdir"
@@ -63,7 +66,7 @@ SPEC
   assert_regex "$log" 'agent'
   assert_regex "$log" 'msb exec agentbox -u agent -e HOME=/home/agent'
   refute_regex "$log" 'msb exec agentbox -u 1000 -- node'
-  assert_regex "$log" -- '-e GIT_TERMINAL_PROMPT=0'
+  assert_regex "$log" '-e GIT_TERMINAL_PROMPT=0'
   assert_regex "$log" 'chown -R -P agent /home/agent/usai-config'
   refute_regex "$log" 'useradd -m -d /home/agent -s /bin/sh -u 1000'
   assert_regex "$log" 'chown "agent:'
@@ -209,7 +212,7 @@ _attach() { # PRE_SNIPPET NAME
   assert_regex "$log" '/usr/local/bin/docker'
   assert_regex "$log" "touch '/var/lib/acq/oci-ready'"
   assert_regex "$log" '/etc/containers/storage\.conf'
-  assert_regex "$log" 'driver = .vfs.'
+  assert_regex "$log" 'driver = ..vfs..'
   assert_regex "$log" 'mount_program'
   assert_regex "$log" 'fuse-overlayfs'
   assert_regex "$log" 'uidmap'
@@ -220,9 +223,9 @@ _attach() { # PRE_SNIPPET NAME
   assert_regex "$log" '/dev/net/tun'
   assert_regex "$log" '/dev/fuse'
   assert_regex "$log" 'chown root:agent'
-  assert_regex "$log" 'unqualified-search-registries = ..docker.io..'
+  assert_regex "$log" 'unqualified-search-registries = ...docker.io...'
   assert_regex "$log" 'docker\.io/library/hello-world'
-  assert_regex "$log" 'short-name-mode = ..SHORT_NAME_MODE.'
+  assert_regex "$log" 'short-name-mode = ...SHORT_NAME_MODE.'
   assert_regex "$log" 'SHORT_NAME_MODE=enforcing'
   refute_regex "$log" 'SHORT_NAME_MODE=permissive'
   assert_regex "$log" 'msb exec ocibox -u 0 -e PODMAN_PKGS='

--- a/test/bats/73-msb-kits-startup.bats
+++ b/test/bats/73-msb-kits-startup.bats
@@ -22,6 +22,7 @@ load 'helper'
   run bash -c '
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/multi-secrets"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     mk="'"$STUBDIR"'/multikit"; mkdir -p "$mk/files/home"
     printf "A\n" > "$mk/files/home/file_one"
@@ -42,10 +43,16 @@ files:
 commands:
   - phase: startup
     user: "0"
-    command: [sh, -c, echo CMD_ALPHA]
+    command:
+      - sh
+      - -c
+      - echo CMD_ALPHA
   - phase: startup
     user: "0"
-    command: [sh, -c, echo CMD_BETA]
+    command:
+      - sh
+      - -c
+      - echo CMD_BETA
 SPEC
     _acq_msb_apply_kit_dir multibox "$mk"
   '
@@ -61,6 +68,7 @@ SPEC
   run bash -c '
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/env-secrets"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     ek="'"$STUBDIR"'/envkit"; mkdir -p "$ek"
     cat >"$ek/spec.yaml" <<'"'"'SPEC'"'"'
@@ -75,7 +83,10 @@ environment:
 commands:
   - phase: startup
     user: "0"
-    command: [sh, -c, echo CMD_WITH_ENV]
+    command:
+      - sh
+      - -c
+      - echo CMD_WITH_ENV
 SPEC
     _acq_msb_apply_kit_dir envbox "$ek"
   '
@@ -90,6 +101,7 @@ SPEC
   run bash -c '
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/noscript-secrets"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     nsk="'"$STUBDIR"'/noscriptkit"; mkdir -p "$nsk"
     cat >"$nsk/spec.yaml" <<'"'"'SPEC'"'"'
@@ -110,10 +122,10 @@ SPEC
   '
   local log; log=$(cat "$CALLS")
   assert_regex "$log" 'msb exec noscriptbox'
-  assert_regex "$log" -- '-- printf'
+  assert_regex "$log" '-- printf'
   assert_regex "$log" 'hello; rm -rf /tmp/NS_PWNED'
-  refute_regex "$log" -- '--script'
-  refute_regex "$log" -- '--script-path'
+  refute_regex "$log" '--script'
+  refute_regex "$log" '--script-path'
   refute_regex "$log" 'sh -c printf'
 }
 
@@ -122,6 +134,7 @@ SPEC
   run bash -c '
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/instmarker-secrets"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     imk="'"$STUBDIR"'/instmarkerkit"; mkdir -p "$imk"
     cat >"$imk/spec.yaml" <<'"'"'SPEC'"'"'
@@ -133,7 +146,8 @@ description: install command is marker-gated in the exec path
 commands:
   - phase: install
     user: "0"
-    command: [true]
+    command:
+      - true
 SPEC
     _acq_msb_apply_kit_dir instmarkerbox "$imk"
   '
@@ -165,6 +179,7 @@ _staged_body() { cat "$(find "$STUBDIR/$1" -type f 2>/dev/null | head -n1)" 2>/d
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/su-secrets"
     export ACQ_MSB_KEEP_STARTUP_STAGE=1 ACQ_MSB_STARTUP_STAGE_DIR="'"$STUBDIR"'/startup-stage"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     suk="'"$STUBDIR"'/startupkit"; mkdir -p "$suk"
     cat >"$suk/spec.yaml" <<'"'"'SPEC'"'"'
@@ -176,21 +191,24 @@ description: one agent-user startup command staged as a create-time script
 commands:
   - phase: startup
     user: "1000"
-    command: [sh, -c, echo STARTUP_MARKER_ALPHA]
+    command:
+      - sh
+      - -c
+      - echo STARTUP_MARKER_ALPHA
 SPEC
     _acq_msb_fetch_kit() { printf "%s\n" "$suk"; }
     acq_backend_provision startupbox shell /tmp >/dev/null 2>&1
   '
   local log su_file body
   log=$(cat "$CALLS")
-  assert_regex "$log" -- '--script-path acq-startup:'
+  assert_regex "$log" '--script-path acq-startup:'
   su_file=$(find "$STUBDIR/startup-stage" -type f 2>/dev/null | head -n1)
   body=$(cat "$su_file" 2>/dev/null)
   assert_regex "$body" '#!/bin/sh'
   assert_regex "$body" 'echo STARTUP_MARKER_ALPHA'
   assert_regex "$body" 'runuser -u agent'
   assert_regex "$body" 'HOME=/home/agent'
-  assert_regex "$log" -- "--script-path acq-startup:${su_file}"
+  assert_regex "$log" "--script-path acq-startup:${su_file}"
 }
 
 @test "0017: a background startup command is staged with nohup detach" {
@@ -198,6 +216,7 @@ SPEC
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/bgsu-secrets"
     export ACQ_MSB_KEEP_STARTUP_STAGE=1 ACQ_MSB_STARTUP_STAGE_DIR="'"$STUBDIR"'/bgstartup-stage"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     bsk="'"$STUBDIR"'/bgstartupkit"; mkdir -p "$bsk"
     cat >"$bsk/spec.yaml" <<'"'"'SPEC'"'"'
@@ -210,7 +229,8 @@ commands:
   - phase: startup
     user: "0"
     background: true
-    command: [supervisor-loop-0017]
+    command:
+      - supervisor-loop-0017
 SPEC
     _acq_msb_fetch_kit() { printf "%s\n" "$bsk"; }
     acq_backend_provision bgstartupbox shell /tmp >/dev/null 2>&1
@@ -226,6 +246,7 @@ SPEC
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/nostartup-secrets"
     export ACQ_MSB_STARTUP_STAGE_DIR="'"$STUBDIR"'/nostartup-stage"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     nsk2="'"$STUBDIR"'/nostartupkit"; mkdir -p "$nsk2"
     cat >"$nsk2/spec.yaml" <<'"'"'SPEC'"'"'
@@ -237,12 +258,13 @@ description: only an install command, no startup phase
 commands:
   - phase: install
     user: "0"
-    command: [true]
+    command:
+      - true
 SPEC
     _acq_msb_fetch_kit() { printf "%s\n" "$nsk2"; }
     acq_backend_provision nostartupbox shell /tmp >/dev/null 2>&1
   '
-  refute_regex "$(cat "$CALLS")" -- '--script-path acq-startup'
+  refute_regex "$(cat "$CALLS")" '--script-path acq-startup'
 }
 
 @test "0017: install stays exec-based (marker-gated); only startup is staged" {
@@ -251,6 +273,7 @@ SPEC
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/mix-secrets"
     export ACQ_MSB_KEEP_STARTUP_STAGE=1 ACQ_MSB_STARTUP_STAGE_DIR="'"$STUBDIR"'/mix-stage"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     mxk="'"$STUBDIR"'/mixkit"; mkdir -p "$mxk"
     cat >"$mxk/spec.yaml" <<'"'"'SPEC'"'"'
@@ -262,10 +285,16 @@ description: install stays exec-based; startup is staged
 commands:
   - phase: install
     user: "0"
-    command: [sh, -c, echo INSTALL_ONLY_0017]
+    command:
+      - sh
+      - -c
+      - echo INSTALL_ONLY_0017
   - phase: startup
     user: "0"
-    command: [sh, -c, echo STARTUP_ONLY_0017]
+    command:
+      - sh
+      - -c
+      - echo STARTUP_ONLY_0017
 SPEC
     _acq_msb_fetch_kit() { printf "%s\n" "$mxk"; }
     acq_backend_provision mixbox shell /tmp >/dev/null 2>&1
@@ -285,6 +314,7 @@ SPEC
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/inj-secrets"
     export ACQ_MSB_KEEP_STARTUP_STAGE=1 ACQ_MSB_STARTUP_STAGE_DIR="'"$STUBDIR"'/inj-stage"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     printf "SUPER_SECRET_VALUE_0017\n" | acq_secret_store "$(_acq_secret_key usai injbox)" >/dev/null 2>&1
     injk="'"$STUBDIR"'/injstartupkit"; mkdir -p "$injk"
@@ -322,6 +352,7 @@ SPEC
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/fidel-secrets"
     export ACQ_MSB_KEEP_STARTUP_STAGE=1 ACQ_MSB_STARTUP_STAGE_DIR="'"$STUBDIR"'/fidel-stage"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     fdk="'"$STUBDIR"'/fidelkit"; mkdir -p "$fdk"
     cat >"$fdk/spec.yaml" <<'"'"'SPEC'"'"'
@@ -335,7 +366,10 @@ environment:
 commands:
   - phase: startup
     user: "0"
-    command: [sh, -c, echo FIDELITY_MARKER]
+    command:
+      - sh
+      - -c
+      - echo FIDELITY_MARKER
 SPEC
     _acq_msb_fetch_kit() { printf "%s\n" "$fdk"; }
     acq_backend_provision fidelbox shell /tmp >/dev/null 2>&1
@@ -355,6 +389,7 @@ SPEC
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/multi2-secrets"
     export ACQ_MSB_STARTUP_STAGE_DIR="'"$STUBDIR"'/multi2-stage"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     mk1="'"$STUBDIR"'/multikit1"; mkdir -p "$mk1"
     cat >"$mk1/spec.yaml" <<'"'"'SPEC'"'"'
@@ -366,7 +401,10 @@ description: first kit with a startup command
 commands:
   - phase: startup
     user: "0"
-    command: [sh, -c, echo MULTI_STARTUP_ONE]
+    command:
+      - sh
+      - -c
+      - echo MULTI_STARTUP_ONE
 SPEC
     mk2="'"$STUBDIR"'/multikit2"; mkdir -p "$mk2"
     cat >"$mk2/spec.yaml" <<'"'"'SPEC'"'"'
@@ -378,7 +416,10 @@ description: second kit with a startup command
 commands:
   - phase: startup
     user: "0"
-    command: [sh, -c, echo MULTI_STARTUP_TWO]
+    command:
+      - sh
+      - -c
+      - echo MULTI_STARTUP_TWO
 SPEC
     mkdir -p "'"$STUBDIR"'/nokit"
     printf "schemaVersion: \"hybrid/v1\"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n" > "'"$STUBDIR"'/nokit/spec.yaml"
@@ -405,6 +446,7 @@ SPEC
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/named-secrets"
     export ACQ_MSB_KEEP_STARTUP_STAGE=1 ACQ_MSB_STARTUP_STAGE_DIR="'"$STUBDIR"'/named-stage"
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     nmk="'"$STUBDIR"'/namedkit"; mkdir -p "$nmk"
     cat >"$nmk/spec.yaml" <<'"'"'SPEC'"'"'
@@ -416,7 +458,10 @@ description: startup command as a named non-agent user
 commands:
   - phase: startup
     user: "postgres"
-    command: [sh, -c, echo NAMED_USER_MARKER]
+    command:
+      - sh
+      - -c
+      - echo NAMED_USER_MARKER
 SPEC
     _acq_msb_fetch_kit() { printf "%s\n" "$nmk"; }
     acq_backend_provision namedbox shell /tmp >/dev/null 2>&1

--- a/test/bats/74-msb-restart-durability.bats
+++ b/test/bats/74-msb-restart-durability.bats
@@ -124,12 +124,12 @@ files:
     source: files/marker
 SPEC
   printf 'CLIKIT_MARKER\n' > "$clikit/files/marker"
-  run bash -c '
-    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
-    ACQ_CLI_KITS=("'"$clikit"'")
-    _acq_msb_fetch_kit() { printf "%s\n" "'"$clikit"'"; }
-    acq_backend_ensure_kits_applied clikitbox >/dev/null 2>&1
-  '
+  # Subshell (not bash -c): the heal path needs the kit-translate/common
+  # functions load_acq sourced into this @test shell (see 90-sbx-startup-kit).
+  ( . "${REPO_ROOT}/acq.backends/msb.sh"
+    ACQ_CLI_KITS=("$clikit")
+    _acq_msb_fetch_kit() { printf '%s\n' "$clikit"; }
+    acq_backend_ensure_kits_applied clikitbox >/dev/null 2>&1 )
   assert_regex "$(cat "$CALLS")" 'clikitbox:/home/agent/clikit-marker'
 }
 
@@ -140,6 +140,7 @@ SPEC
     export ACQ_MSB_STARTUP_STAGE_DIR="'"$STUBDIR"'/ep-off-stage"
     export ACQ_MSB_PERSIST_STARTUP_ENTRYPOINT=1
     . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     epk="'"$STUBDIR"'/epkit"; mkdir -p "$epk"
     cat >"$epk/spec.yaml" <<'"'"'SPEC'"'"'
@@ -151,14 +152,17 @@ description: one startup command
 commands:
   - phase: startup
     user: "0"
-    command: [sh, -c, echo EP_MARKER]
+    command:
+      - sh
+      - -c
+      - echo EP_MARKER
 SPEC
     _acq_msb_fetch_kit() { printf "%s\n" "$epk"; }
     acq_backend_provision epoffbox shell /tmp >/dev/null 2>&1
   '
   local log; log=$(cat "$CALLS")
-  assert_regex "$log" -- '--script-path acq-startup:'
-  refute_regex "$log" -- '--entrypoint'
+  assert_regex "$log" '--script-path acq-startup:'
+  refute_regex "$log" '--entrypoint'
 }
 
 @test "msb: acq start dispatch calls msb start (verb wired)" {
@@ -332,8 +336,8 @@ RELOADSPEC
     acq_backend_provision provrefbox shell /tmp >/dev/null 2>&1
   '
   local log; log=$(cat "$CALLS")
-  assert_regex "$log" -- '--secret USAI_API_KEY@api\.gsa\.usai\.gov'
-  assert_regex "$log" -- "--secret $MSB_GITHUB_SECRET_BINDING"
+  assert_regex "$log" '--secret USAI_API_KEY@api\.gsa\.usai\.gov'
+  assert_regex "$log" "--secret $MSB_GITHUB_SECRET_BINDING"
   refute_regex "$log" 'USAI-REAL-VALUE'
   refute_regex "$log" 'GH-REAL-VALUE'
 }

--- a/test/bats/90-sbx-startup-kit.bats
+++ b/test/bats/90-sbx-startup-kit.bats
@@ -173,10 +173,12 @@ STUB
 
 @test "provision(sbx): ACQ_EXTRA_KITS is marked into ~/.acq-extra-kits at create" {
   : > "$CALLS"
-  run bash -c '
+  # Subshell, NOT `bash -c`: acq_backend_provision is a sourced function, which
+  # a fresh bash never sees (the pre-#381 suite masked the resulting 127).
+  (
     export ACQ_EXTRA_KITS="git+https://github.com/GSA-TTS/agentic-coding-patterns.git#ref=deadbeef&dir=some-extra-kit"
-    acq_backend_provision markerbox shell /tmp >/dev/null 2>&1 || true
-  '
+    acq_backend_provision markerbox shell /tmp
+  ) >/dev/null 2>&1 || true
   local log; log=$(cat "$CALLS")
   assert_regex "$log" '\.acq-extra-kits'
   assert_regex "$log" 'some-extra-kit'
@@ -184,10 +186,11 @@ STUB
 
 @test "provision(sbx): a CLI --kit ref (ACQ_CLI_KITS) is also marked at create" {
   : > "$CALLS"
-  run bash -c '
+  # Subshell, NOT `bash -c` (see the ACQ_EXTRA_KITS marker test above).
+  (
     ACQ_CLI_KITS=("git+https://github.com/GSA-TTS/agentic-coding-patterns.git#ref=deadbeef&dir=cli-kit-x")
-    acq_backend_provision climarkerbox shell /tmp >/dev/null 2>&1 || true
-  '
+    acq_backend_provision climarkerbox shell /tmp
+  ) >/dev/null 2>&1 || true
   assert_regex "$(cat "$CALLS")" 'cli-kit-x'
 }
 

--- a/test/bats/90-sbx-startup-kit.bats
+++ b/test/bats/90-sbx-startup-kit.bats
@@ -188,6 +188,7 @@ STUB
   : > "$CALLS"
   # Subshell, NOT `bash -c` (see the ACQ_EXTRA_KITS marker test above).
   (
+    # shellcheck disable=SC2034  # consumed by the sourced acq_backend_provision
     ACQ_CLI_KITS=("git+https://github.com/GSA-TTS/agentic-coding-patterns.git#ref=deadbeef&dir=cli-kit-x")
     acq_backend_provision climarkerbox shell /tmp
   ) >/dev/null 2>&1 || true


### PR DESCRIPTION
Fixes #389.

**Commit 1** restores bats failure detection: removes the `set +e` leftover in `load_acq`, fixes `split_noglob`'s `$(set +o)` errexit-restore bug (which also silently disabled `set -e` in production `acq` runs whenever `ACQ_EXTRA_KITS` is set), and isolates tests from an inherited `ACQ_EXTRA_KITS`/`ACQ_EXTRA_KIT_SOURCES`.

**Commit 2** repairs all 56 latent test failures the restored detection exposes — test files only, zero product bugs found. See #389 for the full seven-class triage. No assertions deleted or weakened; previously-vacuous asserts (including `--secret` leak and `--script` interpolation refutations) now verify their documented intent against real behavior.

Verified: full offline suite honest-green serially (`ACQ_BATS_JOBS=1 ./scripts/test-acq-bats`), shellcheck clean at pre-commit severity.
