### PR TITLE
chore(kits): pin the patterns kit to the v1.9.0 release tag

### DIFF
--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -36,7 +36,7 @@ PATTERNS_KIT_REPO="git+https://github.com/GSA-TTS/agentic-coding-patterns.git"
 # the bundle-version anchor recorded in a sandbox's host-side provenance record
 # (see ACQ_BUILTIN_BUNDLE below + the provenance helpers) so acq can tell a
 # stale sandbox from a current one.
-PATTERNS_KIT_REF="f60a805f9a3efb8596043d11d8d508859d80d9b4"  # agentic-coding-patterns main as of PR #386 merging
+PATTERNS_KIT_REF="6c6753c60a2b24322fb2e8c0d8e8af60c56ede8f"  # agentic-coding-patterns v1.9.0
 PATTERNS_KIT_DIR="integrations/isolation/acq-kits"
 
 USAI_KIT="${PATTERNS_KIT_REPO}#ref=${PATTERNS_KIT_REF}&dir=${PATTERNS_KIT_DIR}/usai-provider"


### PR DESCRIPTION
Follow-up to the USAi model-id fix. The pin was moved to a **mid-main commit** (`f60a805`) to pick up that fix; this repoints it at the **`v1.9.0` release tag** (`6c6753c`), which contains the same fix plus the release metadata.

## Why the tag rather than a main SHA
The comment block directly above this line frames the ref as *"the bundle-version anchor recorded in a sandbox's host-side provenance record … so acq can tell a stale sandbox from a current one."* A release tag is what that anchor means — a mid-main SHA gives provenance a version no release corresponds to, and the established convention (including the prior pin, `# agentic-coding-patterns v1.8.0`) is a tagged version.

## Verified
- `6c6753c` resolves to a real commit, and the model-fix commit **is an ancestor of it** (`merge-base --is-ancestor`) — so users still get the fix.
- The tree at that ref carries the corrected ids: `gpt_5_5_default_v2` / `gpt_5_2_default_v2` for the agent roles (the two that were returning 403 `model_not_found`) and `claude-opus-5` as the default model, plus the new claude-5 / gemini-3.x entries.
- **No other file** pins the old ref.
- Tests read `PATTERNS_KIT_REF` **dynamically** (no hardcoded SHA), so no test update is needed — the pin-touching suites (`55-version`, `85-kit-provenance`, `95-kit-ref-persistence`) pass.
- shellcheck clean; ref is a full 40-hex SHA as `acq` requires; pre-commit (incl. the bats suite + gitleaks) green.

One-line change.

AI-assisted (OpenCode).