### PR TITLE
test(bats): filter _acq_coreutils_path to absolute dirs, assert absence premise

### DIFF
--- a/test/bats/20-backend-resolution.bats
+++ b/test/bats/20-backend-resolution.bats
@@ -133,6 +133,10 @@ _resolve() { # ADAPTER EXPLICIT  -> prints "<resolved>|<stderr-note>"
   coreutils_path="$(_acq_coreutils_path)"
   export HOME="$fake_home"
   export PATH="$coreutils_path"
+  # Premise: with PATH narrowed to coreutils, the backend MUST be absent —
+  # otherwise the self-repair path never exercises and the test is vacuous.
+  run command -v msb
+  assert_failure
   # shellcheck source=acq
   ACQ_SOURCE_ONLY=1 . "$ACQ"
   # shellcheck source=acq.backends/msb.sh

--- a/test/bats/helper.bash
+++ b/test/bats/helper.bash
@@ -51,11 +51,18 @@ acq_teardown_stubs() {
 # the test AND `rm` in bats-exec-test's own teardown. Union the dirs of every
 # tool we actually rely on so the narrowed PATH is complete regardless of layout.
 # De-dupes while preserving first-seen order. bash 3.2 safe.
+#
+# Only absolute paths are unioned: `command -v` resolves shell builtins (e.g.
+# printf) to a bare name with no directory, and `dirname` of a bare name yields
+# ".", which would silently put the *current directory* on the narrowed PATH —
+# a stray file in the CWD would then become callable and defeat the "backend
+# provably absent" premise. Skipping non-/-prefixed results keeps PATH clean.
 _acq_coreutils_path() {
   local _tools="env rm cat mkdir mv chmod dirname sh grep sed awk printf"
   local _t _d _seen="" _out=""
   for _t in $_tools; do
     _d=$(command -v "$_t" 2>/dev/null) || continue
+    case "$_d" in /*) ;; *) continue ;; esac
     _d=$(dirname "$_d")
     case ":$_seen:" in *":$_d:"*) continue ;; esac
     _seen="${_seen:+$_seen:}$_d"


### PR DESCRIPTION
## Context

Follow-up to #392 (merged). Review feedback on the `_acq_coreutils_path` test helper introduced there:

> `_acq_coreutils_path` still unions dirname of 12 tools without filtering non-absolute entries — `command -v printf` hits the builtin and yields `.`, so the current directory ends up on the "just coreutils" PATH (reproduced: a stray `msb` file in the CWD becomes callable). And on a Homebrew-coreutils host the union pulls in `/opt/homebrew/bin` — the same dir as `msb`/`sbx` — so the test meant to prove "the backend CLI is provably absent" can silently have it present. Filter to absolute paths, and assert the premise (`command -v msb`; `assert_failure`).

This is the small follow-up in the spirit of #393's repair of vacuous assertions.

## Plan / Changes

- **`test/bats/helper.bash`** — `_acq_coreutils_path` now skips any `command -v` result that is not absolute (`/`-prefixed) before taking its `dirname`. Shell builtins like `printf` resolve to a bare name whose `dirname` is `.`, which would otherwise put the CWD on the narrowed PATH.
- **`test/bats/20-backend-resolution.bats`** — the self-repair test now asserts its premise: after narrowing PATH to coreutils, `run command -v msb; assert_failure`. If the narrowed PATH ever exposes the backend, the test fails loudly instead of passing hollowly.

## Verification

```
$ ./scripts/test-acq-bats
... 1..345 all ok (exit 0)

$ ./scripts/test-acq-bats test/bats/20-backend-resolution.bats
1..10 ... ok 9 self-repair: backend in ~/.local/bin is detected + hinted (premise now asserted)

$ shellcheck --severity=warning test/bats/helper.bash
(clean)
```

## Rollback

Revert this commit; the helper returns to unioning all `command -v` dirnames.

## Security Impact

None. Test-only change; hardens a test premise. No runtime/auth/data-handling surface.

AI-assisted (OpenCode).