### PR TITLE
fix(secrets): honor explicit --host for built-in services; unbreak rm -g on bash 3.2

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -186,11 +186,12 @@ ACQ_MSB_GITHUB_HOST="${ACQ_MSB_GITHUB_HOST:-github.com,api.github.com,codeload.g
 # The optional SANDBOX arg gives scoped-sidecar precedence over the global one.
 _acq_msb_service_binding() {
   local _service="$1" _sandbox="${2:-}" _meta _host _env
-  case "$_service" in
-    usai)   printf '%s\t%s\n' "USAI_API_KEY" "$ACQ_MSB_USAI_HOST"; return 0 ;;
-    github) printf '%s\t%s\n' "GITHUB_TOKEN" "$ACQ_MSB_GITHUB_HOST"; return 0 ;;
-  esac
-  # Generic path: read the persisted (host, env) sidecar for a custom endpoint.
+  # Sidecar FIRST (#384): an explicit `--host` recorded at `acq secret set`
+  # must win over the compiled-in usai/github mapping — the sbx backend gives
+  # the user's host the same precedence, and a compiled-in short-circuit here
+  # silently re-bound a self-hosted token to the default endpoint. Absent
+  # sidecar => compiled-in mapping for usai/github, empty (no binding) for
+  # anything else — prior behavior unchanged.
   if command -v acq_secret_meta_resolve >/dev/null 2>&1; then
     if _meta=$(acq_secret_meta_resolve "$_service" "$_sandbox" 2>/dev/null) && [ -n "$_meta" ]; then
       _host=$(printf '%s' "$_meta" | cut -f1)
@@ -201,6 +202,10 @@ _acq_msb_service_binding() {
       fi
     fi
   fi
+  case "$_service" in
+    usai)   printf '%s\t%s\n' "USAI_API_KEY" "$ACQ_MSB_USAI_HOST"; return 0 ;;
+    github) printf '%s\t%s\n' "GITHUB_TOKEN" "$ACQ_MSB_GITHUB_HOST"; return 0 ;;
+  esac
   printf '\t\n'
 }
 
@@ -773,26 +778,39 @@ _acq_msb_bind_secrets_into() {
   local _arrn="$1" _namesn="$2" _name="$3"
 
   if command -v acq_secret_resolve >/dev/null 2>&1; then
+    # usai/github hosts resolve through the SAME binding table set/rm/refeed use
+    # (_acq_msb_service_binding), so a `--host` sidecar recorded at `acq secret
+    # set` overrides the compiled-in endpoint here too (#384) instead of being
+    # written-but-ignored at provision.
+    local _usai_binding _usai_env _usai_host
+    _usai_binding=$(_acq_msb_service_binding usai "$_name")
+    _usai_env=$(printf '%s' "$_usai_binding" | cut -f1)
+    _usai_host=$(printf '%s' "$_usai_binding" | cut -f2)
+
     # USAi: acq store first, else a pre-exported USAI_API_KEY (e.g. CI).
-    if ! _acq_msb_bind_one "$_arrn" "$_namesn" usai "$_name" USAI_API_KEY "$ACQ_MSB_USAI_HOST"; then
+    if ! _acq_msb_bind_one "$_arrn" "$_namesn" usai "$_name" "$_usai_env" "$_usai_host"; then
       if [ -n "${USAI_API_KEY:-}" ]; then
-        eval "$_arrn+=(--secret \"USAI_API_KEY@\${ACQ_MSB_USAI_HOST}\")"
-        acq_debug "msb secret: binding USAI_API_KEY@${ACQ_MSB_USAI_HOST} (from env)"
+        eval "$_arrn+=(--secret \"\${_usai_env}@\${_usai_host}\")"
+        acq_debug "msb secret: binding ${_usai_env}@${_usai_host} (from env)"
       fi
     fi
 
     # GitHub: bind the token to the API and git-transport hosts. acq store first,
     # then a pre-exported GITHUB_TOKEN, then GH_TOKEN (CI). Absent token => no
     # binding; the playbook kit then degrades gracefully (warns, no rules/skills).
-    if ! _acq_msb_bind_one "$_arrn" "$_namesn" github "$_name" GITHUB_TOKEN "$ACQ_MSB_GITHUB_HOST"; then
+    local _gh_binding _gh_env _gh_host
+    _gh_binding=$(_acq_msb_service_binding github "$_name")
+    _gh_env=$(printf '%s' "$_gh_binding" | cut -f1)
+    _gh_host=$(printf '%s' "$_gh_binding" | cut -f2)
+    if ! _acq_msb_bind_one "$_arrn" "$_namesn" github "$_name" "$_gh_env" "$_gh_host"; then
       if [ -n "${GITHUB_TOKEN:-}" ]; then
-        eval "$_arrn+=(--secret \"GITHUB_TOKEN@\${ACQ_MSB_GITHUB_HOST}\")"
-        acq_debug "msb secret: binding GITHUB_TOKEN@${ACQ_MSB_GITHUB_HOST} (from env)"
+        eval "$_arrn+=(--secret \"\${_gh_env}@\${_gh_host}\")"
+        acq_debug "msb secret: binding ${_gh_env}@${_gh_host} (from env)"
       elif [ -n "${GH_TOKEN:-}" ]; then
         export GITHUB_TOKEN="$GH_TOKEN"
         eval "$_namesn+=(\"GITHUB_TOKEN\")"
-        eval "$_arrn+=(--secret \"GITHUB_TOKEN@\${ACQ_MSB_GITHUB_HOST}\")"
-        acq_debug "msb secret: binding GITHUB_TOKEN@${ACQ_MSB_GITHUB_HOST} (from GH_TOKEN env)"
+        eval "$_arrn+=(--secret \"\${_gh_env}@\${_gh_host}\")"
+        acq_debug "msb secret: binding ${_gh_env}@${_gh_host} (from GH_TOKEN env)"
       fi
     fi
 

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -863,12 +863,14 @@ acq_backend_secret_set() {
     exit 1
   fi
 
-  # Collect remaining flags; detect --host and --env presence.
-  local host="" env_var="" extra_flags=()
+  # Collect remaining flags; detect --host and --env presence. host_explicit
+  # marks a --host the USER supplied (vs one filled from the service mapping
+  # below): an explicit host must win over any compiled-in binding (#384).
+  local host="" env_var="" extra_flags=() host_explicit=0
   local prev=""
   for arg in "$@"; do
     if [ "$prev" = "--host" ]; then
-      host="$arg"
+      host="$arg"; host_explicit=1
       extra_flags+=("$arg")
       prev=""
       continue
@@ -879,7 +881,7 @@ acq_backend_secret_set() {
       continue
     fi
     case "$arg" in
-      --host=*) host="${arg#--host=}"; extra_flags+=("$arg") ;;
+      --host=*) host="${arg#--host=}"; host_explicit=1; extra_flags+=("$arg") ;;
       --env=*)  env_var="${arg#--env=}"; extra_flags+=("$arg") ;;
       --host)   prev="--host"; extra_flags+=("$arg") ;;
       --env)    prev="--env";  extra_flags+=("$arg") ;;
@@ -888,11 +890,14 @@ acq_backend_secret_set() {
   done
 
   # Fill in defaults for known custom-endpoint services. NOTE: services that are
-  # sbx BUILT-INS (github, anthropic, ...) must NOT be given a host/env here —
-  # they use `sbx secret set <service>` so the sbx proxy injects them natively.
-  # Only non-built-in services (usai) get a host/env mapping → set-custom.
+  # sbx BUILT-INS (github, anthropic, ...) must NOT be given a DEFAULT host/env
+  # here — they use `sbx secret set <service>` so the sbx proxy injects them
+  # natively. Only non-built-in services (usai) get a host/env mapping →
+  # set-custom. An EXPLICIT --host is different (#384): it survives untouched
+  # for any service and forces the set-custom route below, but a built-in still
+  # gets no auto-filled env, so the --env requirement is enforced next.
   case "$_ACQ_SBX_BUILTIN_SERVICES" in
-    *" $service "*) : ;;   # built-in: leave host/env empty
+    *" $service "*) : ;;   # built-in: no default host/env
     *)
       local svc_hosts svc_env
       svc_hosts=$(_acq_service_hosts_env "$service" | cut -f1)
@@ -901,6 +906,16 @@ acq_backend_secret_set() {
       [ -z "$env_var" ] && [ -n "$svc_env" ] && env_var="$svc_env"
       ;;
   esac
+
+  # An explicit --host with no env var (neither --env nor a service mapping)
+  # cannot be bound: the custom-secret path injects by ENV placeholder. Fail
+  # BEFORE storing anything — silently discarding the flags bound the token to
+  # the wrong endpoint with exit 0 (#384), the worst of the options.
+  if [ "$host_explicit" -eq 1 ] && [ -z "$env_var" ]; then
+    echo "acq: secret set: --host ${host} needs --env ENV as well ('$service' has no env mapping)." >&2
+    echo "     usage: acq secret set [-g | SANDBOX] <service> [--host HOST --env ENV]" >&2
+    return 1
+  fi
 
   # --- Step 1: store the value in the acq-owned secret store (keychain/file). --
   # This is the source of truth both backends read from. The value is read from
@@ -939,6 +954,11 @@ acq_backend_secret_set() {
   case "$_ACQ_SBX_BUILTIN_SERVICES" in
     *" $service "*) is_builtin=1 ;;
   esac
+  # An explicit --host overrides the compiled-in service binding (#384): a
+  # self-hosted endpoint (e.g. gitlab.<agency>.gov) must go through set-custom.
+  # Feeding `sbx secret set gitlab` would bind the token to sbx's gitlab.com
+  # proxy service and silently discard the requested host.
+  if [ "$host_explicit" -eq 1 ]; then is_builtin=0; fi
 
   # Existence pre-check (idempotency): sbx errors/prompts if the secret exists.
   # We list and match by service (built-in) or env var (custom). If present,
@@ -1013,8 +1033,13 @@ acq_backend_secret_set() {
     # scope-flag change".
     if [ -z "$scope_flag" ]; then cmd_args+=(--sandbox "$scope_name"); fi
     local svc_hosts h
-    svc_hosts=$(_acq_service_hosts_env "$service" | cut -f1)
-    [ -z "$svc_hosts" ] && svc_hosts="$host"
+    if [ "$host_explicit" -eq 1 ]; then
+      # The user's --host wins over the static service mapping (#384).
+      svc_hosts="$host"
+    else
+      svc_hosts=$(_acq_service_hosts_env "$service" | cut -f1)
+      [ -z "$svc_hosts" ] && svc_hosts="$host"
+    fi
     local _oldifs="$IFS"; IFS=','
     for h in $svc_hosts; do [ -n "$h" ] && cmd_args+=("--host" "$h"); done
     IFS="$_oldifs"
@@ -1105,6 +1130,14 @@ acq_backend_secret_rm() {
   local acq_sandbox=""
   [ -n "$scope_name" ] && acq_sandbox="$scope_name"
 
+  # Capture the endpoint sidecar BEFORE step 1 deletes it: a built-in name set
+  # with an explicit --host (#384) was fed to sbx as a CUSTOM secret, and its
+  # sidecar env is the only key that can find that placeholder in step 2.
+  local sidecar_env=""
+  if command -v acq_secret_meta_resolve >/dev/null 2>&1; then
+    sidecar_env=$(acq_secret_meta_resolve "$service" "$acq_sandbox" 2>/dev/null | cut -f2) || sidecar_env=""
+  fi
+
   # 1) Remove from the acq store (source of truth). Idempotent.
   local removed_store=0
   if command -v acq_secret_delete >/dev/null 2>&1; then
@@ -1134,20 +1167,35 @@ acq_backend_secret_rm() {
   case "$_ACQ_SBX_BUILTIN_SERVICES" in
     *" $service "*) is_builtin=1 ;;
   esac
+  # Empty-array-safe expansion below: for the GLOBAL scope scope_args stays
+  # empty, and `"${arr[@]}"` on an empty array is a fatal "unbound variable"
+  # under `set -u` on bash 3.2 (the macOS system bash) — the same class as the
+  # builtin_scope_args guard in the set path. Every `acq secret rm -g <built-in>`
+  # on stock macOS crashed here before the guard (#384).
   local scope_args=()
   [ -z "$scope_flag" ] && scope_args+=(--sandbox "$scope_name")
 
   if [ "$is_builtin" -eq 1 ]; then
-    sbx secret rm "$service" "${scope_args[@]}" -f </dev/null >/dev/null 2>&1 || true
+    sbx secret rm "$service" ${scope_args[@]+"${scope_args[@]}"} -f </dev/null >/dev/null 2>&1 || true
+    # A built-in set with an explicit --host lives in sbx as a CUSTOM secret
+    # (#384): if the sidecar recorded an env for it, clear that placeholder too.
+    if [ -n "$sidecar_env" ]; then
+      local placeholder
+      placeholder=$(_acq_sbx_custom_placeholder "$scope_flag" "$scope_name" "$sidecar_env")
+      if [ -n "$placeholder" ]; then
+        sbx secret rm --placeholder "$placeholder" ${scope_args[@]+"${scope_args[@]}"} -f </dev/null >/dev/null 2>&1 || true
+      fi
+    fi
   else
     # Custom endpoint (usai, ...): sbx removes a custom secret by its PLACEHOLDER
     # (there is no --host on `secret rm`). Look up the placeholder from the custom
-    # secrets table for this scope + env var, then remove it by --placeholder.
+    # secrets table for this scope + env var — the sidecar env wins over the
+    # static mapping (it records what was actually bound) — then remove it.
     local env_var placeholder
-    env_var=$(_acq_service_hosts_env "$service" | cut -f2)
+    env_var="${sidecar_env:-$(_acq_service_hosts_env "$service" | cut -f2)}"
     placeholder=$(_acq_sbx_custom_placeholder "$scope_flag" "$scope_name" "$env_var")
     if [ -n "$placeholder" ]; then
-      sbx secret rm --placeholder "$placeholder" "${scope_args[@]}" -f </dev/null >/dev/null 2>&1 || true
+      sbx secret rm --placeholder "$placeholder" ${scope_args[@]+"${scope_args[@]}"} -f </dev/null >/dev/null 2>&1 || true
     fi
   fi
 

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -870,7 +870,9 @@ acq_backend_secret_set() {
   local prev=""
   for arg in "$@"; do
     if [ "$prev" = "--host" ]; then
-      host="$arg"; host_explicit=1
+      # Repeated --host flags ACCUMULATE (comma-joined, the multi-host form
+      # set-custom already takes) — last-wins would silently drop endpoints.
+      host="${host:+${host},}$arg"; host_explicit=1
       extra_flags+=("$arg")
       prev=""
       continue
@@ -881,7 +883,7 @@ acq_backend_secret_set() {
       continue
     fi
     case "$arg" in
-      --host=*) host="${arg#--host=}"; host_explicit=1; extra_flags+=("$arg") ;;
+      --host=*) host="${host:+${host},}${arg#--host=}"; host_explicit=1; extra_flags+=("$arg") ;;
       --env=*)  env_var="${arg#--env=}"; extra_flags+=("$arg") ;;
       --host)   prev="--host"; extra_flags+=("$arg") ;;
       --env)    prev="--env";  extra_flags+=("$arg") ;;
@@ -916,6 +918,26 @@ acq_backend_secret_set() {
     echo "     usage: acq secret set [-g | SANDBOX] <service> [--host HOST --env ENV]" >&2
     return 1
   fi
+  # Validate the env var name BEFORE storing: it reaches sbx set-custom argv and
+  # the endpoint sidecar (whose own charset refusal is best-effort — a swallowed
+  # refusal would leave rm with no key to find the placeholder later).
+  if [ -n "$env_var" ] && ! printf '%s' "$env_var" | LC_ALL=C grep -qE '^[A-Za-z_][A-Za-z0-9_]*$'; then
+    echo "acq: secret set: invalid env var name '$env_var' (must match [A-Za-z_][A-Za-z0-9_]*)." >&2
+    return 1
+  fi
+  # --env ALONE on a built-in name is a contradiction: the native service route
+  # ignores env, but a set env var would steer the existence pre-check into the
+  # CUSTOM table — missing an existing native entry, whose overwrite prompt
+  # would then eat the piped secret value. Bind host+env together or neither.
+  case "$_ACQ_SBX_BUILTIN_SERVICES" in
+    *" $service "*)
+      if [ "$host_explicit" -eq 0 ] && [ -n "$env_var" ]; then
+        echo "acq: secret set: --env on built-in '$service' needs --host HOST too (a custom" >&2
+        echo "     endpoint binds host+env); omit both to feed sbx's native service." >&2
+        return 1
+      fi
+      ;;
+  esac
 
   # --- Step 1: store the value in the acq-owned secret store (keychain/file). --
   # This is the source of truth both backends read from. The value is read from
@@ -950,15 +972,22 @@ acq_backend_secret_set() {
   # In all cases the real value is already safely in the acq store; sbx is just
   # the injection runtime. We never place the value on argv.
   local exit_code=0
-  local is_builtin=0
+  local is_builtin=0 builtin_name=0
   case "$_ACQ_SBX_BUILTIN_SERVICES" in
-    *" $service "*) is_builtin=1 ;;
+    *" $service "*) is_builtin=1; builtin_name=1 ;;
   esac
   # An explicit --host overrides the compiled-in service binding (#384): a
   # self-hosted endpoint (e.g. gitlab.<agency>.gov) must go through set-custom.
   # Feeding `sbx secret set gitlab` would bind the token to sbx's gitlab.com
   # proxy service and silently discard the requested host.
   if [ "$host_explicit" -eq 1 ]; then is_builtin=0; fi
+
+  # A hostless (native) re-set supersedes any earlier --host mapping: drop a
+  # stale endpoint sidecar so msb provisioning and `acq secret rm` stop
+  # honoring an endpoint the user no longer intends.
+  if [ "$is_builtin" -eq 1 ] && command -v acq_secret_meta_delete >/dev/null 2>&1; then
+    acq_secret_meta_delete "$service" "$acq_sandbox" || true
+  fi
 
   # Existence pre-check (idempotency): sbx errors/prompts if the secret exists.
   # We list and match by service (built-in) or env var (custom). If present,
@@ -970,6 +999,19 @@ acq_backend_secret_set() {
   # scope-flag change" note in docs/VERIFY_BACKENDS_HANDOFF.md).
   local scope_desc rm_scope
   if [ -n "$scope_flag" ]; then scope_desc="global"; rm_scope=""; else scope_desc="sandbox '$scope_name'"; rm_scope="--sandbox $scope_name"; fi
+
+  # When a built-in NAME takes the custom route (explicit --host), also refuse
+  # on a stale NATIVE entry for that name — e.g. one created by the pre-#384
+  # behavior that discarded --host. Left in place, sbx would keep injecting the
+  # token to its native endpoint even after set-custom succeeds.
+  if [ "$builtin_name" -eq 1 ] && [ "$is_builtin" -eq 0 ] && \
+     _acq_sbx_secret_exists "$scope_flag" "$scope_name" "$service" ""; then
+    echo "acq: stored '$service' in the acq secret store, but sbx has a NATIVE" >&2
+    echo "     '$service' service entry in ${scope_desc} that would keep injecting to" >&2
+    echo "     sbx's own endpoint. Remove it, then re-run:" >&2
+    echo "       sbx secret rm ${service}${rm_scope:+ $rm_scope}" >&2
+    return 1
+  fi
 
   if _acq_sbx_secret_exists "$scope_flag" "$scope_name" "$service" "$env_var"; then
     echo "acq: stored '$service' in the acq secret store, but sbx already has a" >&2
@@ -1133,9 +1175,11 @@ acq_backend_secret_rm() {
   # Capture the endpoint sidecar BEFORE step 1 deletes it: a built-in name set
   # with an explicit --host (#384) was fed to sbx as a CUSTOM secret, and its
   # sidecar env is the only key that can find that placeholder in step 2.
+  # EXACT scope only — the resolve variant's sandbox->global fallback would let
+  # a global sidecar's env steer a sandbox-scoped destructive removal.
   local sidecar_env=""
-  if command -v acq_secret_meta_resolve >/dev/null 2>&1; then
-    sidecar_env=$(acq_secret_meta_resolve "$service" "$acq_sandbox" 2>/dev/null | cut -f2) || sidecar_env=""
+  if command -v acq_secret_meta_resolve_exact >/dev/null 2>&1; then
+    sidecar_env=$(acq_secret_meta_resolve_exact "$service" "$acq_sandbox" 2>/dev/null | cut -f2) || sidecar_env=""
   fi
 
   # 1) Remove from the acq store (source of truth). Idempotent.

--- a/acq.backends/secret-store.sh
+++ b/acq.backends/secret-store.sh
@@ -358,6 +358,21 @@ acq_secret_meta_resolve() {
   return 1
 }
 
+# acq_secret_meta_resolve_exact SERVICE [SANDBOX] -> "HOST<TAB>ENV" on STDOUT
+# EXACT-scope variant of acq_secret_meta_resolve: no sandbox->global fallback.
+# The sbx rm path uses it (#384 review): a GLOBAL sidecar must never steer a
+# sandbox-scoped DESTRUCTIVE placeholder removal toward an entry the sidecar
+# never described.
+acq_secret_meta_resolve_exact() {
+  local service="$1" sandbox="${2:-}" f line key
+  key=$(_acq_secret_key "$service" "$sandbox") || return 1
+  f=$(_acq_secret_meta_file_for "$key")
+  if [ -f "$f" ] && IFS= read -r line < "$f" && [ -n "$line" ]; then
+    printf '%s\n' "$line"; return 0
+  fi
+  return 1
+}
+
 # acq_secret_meta_delete SERVICE [SANDBOX] — remove the sidecar (idempotent).
 acq_secret_meta_delete() {
   local service="$1" sandbox="${2:-}" f key

--- a/test/bats/40-secret-set.bats
+++ b/test/bats/40-secret-set.bats
@@ -124,6 +124,67 @@ LS
   assert_regex "$(cat "$CALLS")" 'sbx secret rm --placeholder sbx-cs-abc123'
 }
 
+@test "#384 review: re-set with --host stops on a stale NATIVE entry with an rm hint" {
+  # A pre-fix run left a native gitlab service entry; the custom route must not
+  # proceed past it (it would keep injecting to sbx's gitlab.com endpoint).
+  printf 'SCOPE      TYPE      NAME     SECRET\n(global)   service   gitlab   (stored)\n' > "$STUBDIR/sbx_ls"
+  run bash -c 'printf "glpat-x\n" | SBX_LS_FIXTURE="$1" ACQ_BACKEND=sbx "$2" secret set -g gitlab --host gitlab.example.gov --env GITLAB_TOKEN' _ "$STUBDIR/sbx_ls" "$ACQ"
+  assert_failure
+  assert_output --partial 'sbx secret rm gitlab'
+  refute_output --partial 'set-custom'
+}
+
+@test "#384 review: hostless re-set of a built-in clears a stale --host sidecar" {
+  run bash -c 'printf "glpat-x\n" | ACQ_BACKEND=sbx "$1" secret set -g gitlab --host gitlab.example.gov --env GITLAB_TOKEN' _ "$ACQ"
+  assert [ -f "$STUBDIR/secrets/meta/acq.gitlab" ]
+  run bash -c 'printf "glpat-y\n" | ACQ_BACKEND=sbx "$1" secret set -g gitlab' _ "$ACQ"
+  assert_regex "$(cat "$CALLS")" 'sbx secret set gitlab'
+  assert [ ! -e "$STUBDIR/secrets/meta/acq.gitlab" ]
+}
+
+@test "#384 review: a scoped rm does not act on a GLOBAL sidecar's env" {
+  # Global sidecar exists; sandbox 'dev' has an UNRELATED custom secret with the
+  # same env. rm dev gitlab must not delete dev's placeholder off the global
+  # sidecar's say-so.
+  run bash -c 'printf "glpat-x\n" | ACQ_BACKEND=sbx "$1" secret set -g gitlab --host gh.agency.gov --env GITLAB_TOKEN' _ "$ACQ"
+  printf 'SCOPE      TYPE      NAME     SECRET\n\nCUSTOM SECRETS\nSCOPE      TARGETS  ENV     PLACEHOLDER  SECRET\ndev   other.example.gov  GITLAB_TOKEN  sbx-cs-devx  ****\n' > "$STUBDIR/sbx_ls"
+  run bash -c 'SBX_LS_FIXTURE="$1" ACQ_BACKEND=sbx "$2" secret rm dev gitlab' _ "$STUBDIR/sbx_ls" "$ACQ"
+  assert_success
+  refute_regex "$(cat "$CALLS")" 'sbx secret rm --placeholder sbx-cs-devx'
+}
+
+@test "#384 review: an unsafe --env name is rejected before storing" {
+  run bash -c 'printf "glpat-x\n" | ACQ_BACKEND=sbx "$1" secret set -g gitlab --host gitlab.example.gov --env GITLAB-TOKEN' _ "$ACQ"
+  assert_failure
+  assert_output --partial 'env'
+  assert [ ! -e "$STUBDIR/secrets/acq.gitlab" ]
+}
+
+@test "#384 review: --env alone on a built-in is an error, not a mis-scoped native set" {
+  # Without this, the existence pre-check searches the CUSTOM table while the
+  # native route runs, so an existing native entry's overwrite prompt would eat
+  # the piped secret value.
+  run bash -c 'printf "ghp_x\n" | ACQ_BACKEND=sbx "$1" secret set -g github --env GITHUB_TOKEN' _ "$ACQ"
+  assert_failure
+  assert_output --partial '--host'
+  refute_regex "$(cat "$CALLS")" 'sbx secret set github'
+}
+
+@test "#384 review: repeated --host flags accumulate instead of last-wins" {
+  run bash -c 'printf "glpat-x\n" | ACQ_BACKEND=sbx "$1" secret set -g gitlab --host gitlab.example.gov --host api.gitlab.example.gov --env GITLAB_TOKEN' _ "$ACQ"
+  assert_output --partial '--host gitlab.example.gov --host api.gitlab.example.gov'
+}
+
+@test "#384 review: no unguarded scope_args expansion in sbx.sh (bash 3.2 pin)" {
+  # The empty-array crash only manifests under bash 3.2 + set -u (stock macOS
+  # /bin/bash); CI runners execute acq under a newer bash, so pin the guard at
+  # the source level like the mawk interval guard in 100-kit-translate.bats.
+  # Match only the UNGUARDED form: the safe `${scope_args[@]+"${scope_args[@]}"}`
+  # guard contains the same substring but is always preceded by `+`.
+  run grep -nE '(^|[^+])"\$\{scope_args\[@\]\}"' "$REPO_ROOT/acq.backends/sbx.sh"
+  assert_failure
+}
+
 @test "mask: masked entry captures the value, shows a star per char, handles backspace/empty" {
   load_acq
   run bash -c '

--- a/test/bats/40-secret-set.bats
+++ b/test/bats/40-secret-set.bats
@@ -85,6 +85,45 @@ LS
   assert [ -f "$STUBDIR/secrets/acq.usai" ]
 }
 
+@test "#384: --host on a built-in routes to set-custom, not the native service" {
+  run bash -c 'printf "glpat-x\n" | ACQ_BACKEND=sbx "$1" secret set -g gitlab --host gitlab.example.gov --env GITLAB_TOKEN' _ "$ACQ"
+  assert_output --partial 'sbx secret set-custom --host gitlab.example.gov --env GITLAB_TOKEN'
+  refute_regex "$(cat "$CALLS")" 'sbx secret set gitlab'
+  assert [ -f "$STUBDIR/secrets/acq.gitlab" ]
+  # The endpoint mapping is persisted as a sidecar so msb (and rm) honor it too.
+  assert [ -f "$STUBDIR/secrets/meta/acq.gitlab" ]
+}
+
+@test "#384: --host on a built-in without --env is a hard error before storing" {
+  run bash -c 'printf "glpat-x\n" | ACQ_BACKEND=sbx "$1" secret set -g gitlab --host gitlab.example.gov' _ "$ACQ"
+  assert_failure
+  assert_output --partial '--env'
+  refute_regex "$(cat "$CALLS")" 'sbx secret set gitlab'
+  assert [ ! -e "$STUBDIR/secrets/acq.gitlab" ]
+}
+
+@test "#384: explicit --host wins over the compiled-in usai mapping" {
+  run bash -c 'printf "k\n" | ACQ_BACKEND=sbx "$1" secret set -g usai --host usai.alt.example.gov' _ "$ACQ"
+  assert_output --partial 'sbx secret set-custom --host usai.alt.example.gov --env USAI_API_KEY'
+  refute_output --partial 'api.gsa.usai.gov'
+}
+
+@test "#384: rm -g of a built-in does not crash (bash 3.2) and clears the native entry" {
+  mkdir -p "$STUBDIR/secrets" && printf 'x\n' > "$STUBDIR/secrets/acq.azure"
+  run env ACQ_BACKEND=sbx "$ACQ" secret rm -g azure
+  assert_success
+  assert_output --partial "removed 'azure'"
+  assert_regex "$(cat "$CALLS")" 'sbx secret rm azure -f'
+}
+
+@test "#384: rm -g of a --host-routed built-in also removes the custom placeholder" {
+  run bash -c 'printf "glpat-x\n" | ACQ_BACKEND=sbx "$1" secret set -g gitlab --host gitlab.example.gov --env GITLAB_TOKEN' _ "$ACQ"
+  printf 'SCOPE      TYPE      NAME     SECRET\n\nCUSTOM SECRETS\nSCOPE      TARGETS  ENV     PLACEHOLDER  SECRET\n(global)   gitlab.example.gov  GITLAB_TOKEN  sbx-cs-abc123  ****\n' > "$STUBDIR/sbx_ls"
+  run bash -c 'SBX_LS_FIXTURE="$1" ACQ_BACKEND=sbx "$2" secret rm -g gitlab' _ "$STUBDIR/sbx_ls" "$ACQ"
+  assert_success
+  assert_regex "$(cat "$CALLS")" 'sbx secret rm --placeholder sbx-cs-abc123'
+}
+
 @test "mask: masked entry captures the value, shows a star per char, handles backspace/empty" {
   load_acq
   run bash -c '

--- a/test/bats/71-msb-provision-secrets.bats
+++ b/test/bats/71-msb-provision-secrets.bats
@@ -117,6 +117,16 @@ _provision() { # NAME PRE_SNIPPET
   refute_regex "$log" 'SBX-REAL-VALUE|USAI-REAL-VALUE|GH-REAL-VALUE|NOMAP-VALUE'
 }
 
+@test "#384(msb): a --host sidecar overrides the compiled-in usai binding" {
+  _provision altbox '
+    export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/alt-secrets"
+    ACQ_SECRET_TEST_VALUE="USAI-ALT-VALUE" acq_secret_set_interactive usai "" "usai.alt.example.gov" "USAI_API_KEY" >/dev/null 2>&1
+  '
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" '--secret USAI_API_KEY@usai\.alt\.example\.gov'
+  refute_regex "$log" '--secret USAI_API_KEY@api\.gsa\.usai\.gov'
+}
+
 @test "progress#287: provision emits plain phase markers on stderr, no animation" {
   _provision progbox '
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/prog-secrets"


### PR DESCRIPTION
Fixes #384 — both defects, plus the gaps a code-review pass found around them.

## 1. Explicit `--host`/`--env` silently dropped for built-in service names

An explicit `--host` now forces the set-custom route for **any** service, and the user's host wins over the compiled-in service mapping — so `acq secret set -g gitlab --host gitlab.<agency>.gov --env GITLAB_TOKEN` configures the self-hosted endpoint instead of silently binding to sbx's gitlab.com service. A `--host` with no resolvable env var (no `--env` and no mapping) is a hard error **before** anything is stored. The endpoint mapping is persisted as the usual non-secret sidecar, and the msb backend resolves usai/github through the same sidecar-first binding table at provision/refeed/rm, so the explicit host is honored on both backends.

## 2. `acq secret rm -g <built-in>` crash on macOS bash 3.2

Both bare `"${scope_args[@]}"` expansions in the rm path now use the `${arr[@]+…}` empty-array guard the set path already documents for exactly this class (`set -u` + bash 3.2). Before, every global rm of a built-in crashed after deleting the acq-store entry, leaving the sbx-side secret behind. `rm` additionally clears the custom placeholder of a `--host`-routed built-in, resolving the sidecar at the **exact** scope only (no global fallback into a scoped destructive removal). A source-level guard test pins the fix, since CI runners execute `acq` under a newer bash where the crash can't reproduce.

## Hardening from review (second commit)

Stale-**native** entry (e.g. left by the pre-fix behavior) blocks a custom re-set with a precise rm hint; a hostless re-set clears a stale `--host` sidecar; env var names are validated before storing; `--env` alone on a built-in errors instead of mis-scoping the existence pre-check (whose native overwrite prompt would eat the piped value); repeated `--host` flags accumulate instead of last-wins.

## Verification

- TDD: 13 new bats tests across `40-secret-set.bats` / `71-msb-provision-secrets.bats`, each written first and watched fail. Full offline suite: **363/363** serially.
- E2E on sbx v0.39.0 / macOS system bash 3.2 with the issue's exact repro: set routes to `example.internal`, rm exits 0 (no `scope_args[@]` crash) and clears the acq store, the native entry, and the custom placeholder. Live-verified the stale-native refusal as well (rc=1, precise hint).
