### PR TITLE
feat(acq): add a neutral interactive-shell verb — acq shell NAME

### DIFF
--- a/acq
+++ b/acq
@@ -90,6 +90,7 @@ Subcommands:
   restart NAME                             Stop then start a sandbox, re-running
                                            kit startup services (msb only; see 'start').
   rm NAME                                  Remove a sandbox.
+  shell NAME                               Open an interactive shell in a sandbox.
   exec NAME -- CMD...                      Run a command inside a sandbox.
   cp SRC DST                               Copy files in/out (NAME:path syntax).
   ports NAME [--publish ...]               List or publish ports.
@@ -315,6 +316,19 @@ Runs CMD as the unprivileged agent user in the workspace. On msb, when the host
 ssh-agent is forwarded, SSH_AUTH_SOCK is injected so git/ssh reach the agent.
 U
       ;;
+    shell)
+      cat >&2 <<'U'
+acq shell — open an interactive shell in a sandbox
+
+Usage:
+  acq shell NAME
+
+Opens an interactive shell in an existing sandbox as the unprivileged agent
+user (the human counterpart to 'acq run NAME', which relaunches the recorded
+agent; 'acq exec' is non-interactive). On msb, when the host ssh-agent is
+forwarded, SSH_AUTH_SOCK is injected so git/ssh reach the agent.
+U
+      ;;
     cp)
       cat >&2 <<'U'
 acq cp — copy files in or out of a sandbox
@@ -387,7 +401,7 @@ U
 _acq_verb_backend_help_kind() {
   case "${1%% *}" in
     run|ls|stop|rm|exec|cp|ports|secret|kit) printf 'shared' ;;
-    start|restart|create|version|doctor|github-scope|usai-rotate-api-key|backend) printf 'acqonly' ;;
+    start|restart|create|shell|version|doctor|github-scope|usai-rotate-api-key|backend) printf 'acqonly' ;;
     *) printf '' ;;
   esac
 }
@@ -1165,6 +1179,13 @@ case "$subcommand" in
     [ -n "$local_name" ] || { echo "acq: exec: missing sandbox name" >&2; exit 1; }
     shift
     acq_backend_run "$local_name" "$@"
+    ;;
+
+  shell)
+    shift
+    local_name="${1:-}"
+    [ -n "$local_name" ] || { echo "acq: shell: missing sandbox name" >&2; exit 1; }
+    acq_backend_shell "$local_name"
     ;;
 
   cp)

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3695,17 +3695,44 @@ _acq_msb_attach() {
   [ -n "$_sock" ] && _sockflag=(-e "SSH_AUTH_SOCK=$_sock")
 
   if [ "$agent" = "shell" ]; then
-    exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} "$name" -- /bin/sh -l
+    _acq_msb_shell_exec "$name" "$ws"
   fi
 
   # Pre-check the agent binary AS the agent user; fall back to a shell (with a
   # notice) rather than launching into a broken/blank session if it's missing.
   if ! msb exec -u agent "$name" -- sh -c "command -v '$agent'" </dev/null >/dev/null 2>&1; then
     echo "acq(msb): '$agent' not found in sandbox '$name'; opening a shell instead." >&2
-    exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} "$name" -- /bin/sh -l
+    _acq_msb_shell_exec "$name" "$ws"
   fi
 
   exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} "$name" -- "$agent" "$@"
+}
+
+# _acq_msb_shell_exec NAME [WS] — exec into an interactive login shell as the
+# agent user: PTY, workspace cwd, sane $SHELL, and SSH_AUTH_SOCK when the host
+# ssh-agent is forwarded (a raw `msb exec` shell gets none of that). Shared by
+# _acq_msb_attach's shell paths and the neutral `acq shell` verb (#383). WS
+# skips the workspace lookup when the caller already resolved it.
+_acq_msb_shell_exec() {
+  local name="$1" ws="${2:-}"
+  if [ -z "$ws" ]; then
+    ws="${ACQ_MSB_WORKSPACE:-}"
+    if [ -z "$ws" ]; then
+      ws=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' </dev/null 2>/dev/null | tr -d '\r\n')
+    fi
+    [ -n "$ws" ] || ws="/home/agent"
+  fi
+  local _sock _sockflag=()
+  _sock=$(_acq_msb_ssh_auth_sock_for "$name")
+  [ -n "$_sock" ] && _sockflag=(-e "SSH_AUTH_SOCK=$_sock")
+  exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} "$name" -- /bin/sh -l
+}
+
+# ---------------------------------------------------------------------------
+# acq_backend_shell — interactive human shell (#383)
+# ---------------------------------------------------------------------------
+acq_backend_shell() {
+  _acq_msb_shell_exec "$1"
 }
 
 # ---------------------------------------------------------------------------

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3711,8 +3711,8 @@ _acq_msb_attach() {
 # _acq_msb_shell_exec NAME [WS] — exec into an interactive login shell as the
 # agent user: PTY, workspace cwd, sane $SHELL, and SSH_AUTH_SOCK when the host
 # ssh-agent is forwarded (a raw `msb exec` shell gets none of that). Shared by
-# _acq_msb_attach's shell paths and the neutral `acq shell` verb (#383). WS
-# skips the workspace lookup when the caller already resolved it.
+# _acq_msb_attach's shell paths and the neutral `acq shell` verb. WS skips the
+# workspace lookup when the caller already resolved it.
 _acq_msb_shell_exec() {
   local name="$1" ws="${2:-}"
   if [ -z "$ws" ]; then
@@ -3729,7 +3729,8 @@ _acq_msb_shell_exec() {
 }
 
 # ---------------------------------------------------------------------------
-# acq_backend_shell — interactive human shell (#383)
+# acq_backend_shell — interactive human shell (the neutral `acq shell` verb;
+# `acq run` relaunches the recorded agent, `acq exec` is non-interactive)
 # ---------------------------------------------------------------------------
 acq_backend_shell() {
   _acq_msb_shell_exec "$1"

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -492,6 +492,16 @@ acq_backend_run() {
 }
 
 # ---------------------------------------------------------------------------
+# acq_backend_shell — interactive human shell (#383)
+# ---------------------------------------------------------------------------
+# The one lifecycle moment the neutral surface didn't cover: `acq run NAME`
+# relaunches the recorded agent and `acq exec` is non-interactive. sbx
+# allocates the PTY itself via `exec -it`; exec hands it the terminal directly.
+acq_backend_shell() {
+  exec sbx exec -it "$1" bash
+}
+
+# ---------------------------------------------------------------------------
 # acq_backend_attach — interactive attach
 # ---------------------------------------------------------------------------
 

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -492,7 +492,7 @@ acq_backend_run() {
 }
 
 # ---------------------------------------------------------------------------
-# acq_backend_shell — interactive human shell (#383)
+# acq_backend_shell — interactive human shell
 # ---------------------------------------------------------------------------
 # The one lifecycle moment the neutral surface didn't cover: `acq run NAME`
 # relaunches the recorded agent and `acq exec` is non-interactive. sbx

--- a/docs/howto/acq.md
+++ b/docs/howto/acq.md
@@ -105,6 +105,7 @@ kits, validates your USAi key, and attaches the agent.
 | `./acq ls` | List your sandboxes |
 | `./acq stop NAME` | Stop a sandbox |
 | `./acq rm NAME` | Remove a sandbox |
+| `./acq shell NAME` | Open an interactive shell in a sandbox |
 | `./acq exec NAME -- CMD` | Run a command inside a sandbox |
 | `./acq cp SRC DST` | Copy files in/out (NAME:path syntax) |
 | `./acq version` | Show acq version + active backend |

--- a/docs/howto/msb.md
+++ b/docs/howto/msb.md
@@ -188,7 +188,7 @@ known-limitations note).
 | Resume sandbox | `acq run <name>` | `msb run <name>` |
 | Remove sandbox | `acq rm <name>` | `msb remove <name>` |
 | Run a command | `acq exec <name> -- <cmd>` | `msb exec <name> -- <cmd>` |
-| Interactive shell | `acq run <name>` (attach) | `msb exec -it <name> -- bash` |
+| Interactive shell | `acq shell <name>` | `msb exec -it <name> -- bash` |
 
 The following are genuinely msb-specific mechanics the wrapper does not
 abstract — use the raw `msb` command:

--- a/docs/howto/msb.md
+++ b/docs/howto/msb.md
@@ -168,7 +168,8 @@ acq ls                      # list sandboxes
 acq stop my-sandbox         # stop (preserves state)
 acq run my-sandbox          # resume / re-attach by name
 acq rm my-sandbox           # remove permanently
-acq run my-sandbox          # interactive attach (acq exec runs a command, not a TTY)
+acq run my-sandbox          # interactive attach (relaunches the recorded agent)
+acq shell my-sandbox        # interactive human shell (acq exec runs a command, not a TTY)
 acq exec my-sandbox -- <cmd>   # run a one-off command in the sandbox
 ```
 

--- a/docs/howto/sbx.md
+++ b/docs/howto/sbx.md
@@ -326,11 +326,10 @@ sbx rm --all
 ```
 
 > [!NOTE]
-> `acq` covers the common run/ls/stop/rm/exec operations on either backend.
-> Two forms shown here stay raw `sbx`: **`sbx rm --all`** (no `acq rm --all`
-> bulk removal exists), and the interactive **`sbx exec -it <name> bash`** shell
-> (`acq exec` runs a command via `acq exec <name> -- <cmd>` but does not attach
-> a TTY — use `acq run <name>` to attach interactively).
+> `acq` covers the common run/ls/stop/rm/shell/exec operations on either
+> backend. One form shown here stays raw `sbx`: **`sbx rm --all`** (no
+> `acq rm --all` bulk removal exists). An interactive human shell is
+> `acq shell <name>`; `acq run <name>` re-attaches the agent.
 
 ---
 
@@ -344,7 +343,7 @@ sbx rm --all
 | Resume sandbox | `acq run <name>` | `sbx run --name <name>` |
 | Remove sandbox | `acq rm <name>` | `sbx rm <name>` |
 | Run a command | `acq exec <name> -- <cmd>` | `sbx exec <name> -- <cmd>` |
-| Interactive shell | `acq run <name>` (attach) | `sbx exec -it <name> bash` |
+| Interactive shell | `acq shell <name>` | `sbx exec -it <name> bash` |
 | Copy files | `acq cp ./file.txt <name>:/path/` | `sbx cp ./file.txt <name>:/path/` |
 
 The following are genuinely sbx-specific mechanics the wrapper does not

--- a/test/bats/30-dispatch-routing.bats
+++ b/test/bats/30-dispatch-routing.bats
@@ -27,6 +27,29 @@ _seed_usai() {
   assert_regex "$(cat "$CALLS")" 'sbx ls'
 }
 
+@test "#383: shell NAME -> interactive backend shell (sbx exec -it ... bash)" {
+  run env ACQ_BACKEND=sbx "$ACQ" shell mybox
+  assert_regex "$(cat "$CALLS")" 'sbx exec -it mybox bash'
+}
+
+@test "#383: shell NAME (msb) -> agent-user login shell with PTY in the workspace" {
+  run env ACQ_BACKEND=msb "$ACQ" shell mybox
+  assert_regex "$(cat "$CALLS")" 'msb exec -t -u agent -w /home/agent -e SHELL=/bin/sh mybox -- /bin/sh -l'
+}
+
+@test "#383: shell without a name is a usage error, no backend call" {
+  run env ACQ_BACKEND=sbx "$ACQ" shell
+  assert_failure
+  assert_output --partial 'missing sandbox name'
+  refute_regex "$(cat "$CALLS")" 'sbx exec'
+}
+
+@test "#383: shell --help documents the verb (acq-owned, not a passthrough)" {
+  run env ACQ_BACKEND=sbx "$ACQ" shell --help
+  assert_output --partial 'interactive shell'
+  refute_output --partial 'passed through'
+}
+
 @test "dispatch: version reports backend and script path" {
   run env ACQ_BACKEND=sbx "$ACQ" version
   assert_output --partial 'backend:'

--- a/test/bats/30-dispatch-routing.bats
+++ b/test/bats/30-dispatch-routing.bats
@@ -27,24 +27,24 @@ _seed_usai() {
   assert_regex "$(cat "$CALLS")" 'sbx ls'
 }
 
-@test "#383: shell NAME -> interactive backend shell (sbx exec -it ... bash)" {
+@test "shell: NAME -> interactive backend shell (sbx exec -it ... bash)" {
   run env ACQ_BACKEND=sbx "$ACQ" shell mybox
   assert_regex "$(cat "$CALLS")" 'sbx exec -it mybox bash'
 }
 
-@test "#383: shell NAME (msb) -> agent-user login shell with PTY in the workspace" {
+@test "shell: NAME (msb) -> agent-user login shell with PTY in the workspace" {
   run env ACQ_BACKEND=msb "$ACQ" shell mybox
   assert_regex "$(cat "$CALLS")" 'msb exec -t -u agent -w /home/agent -e SHELL=/bin/sh mybox -- /bin/sh -l'
 }
 
-@test "#383: shell without a name is a usage error, no backend call" {
+@test "shell: without a name is a usage error, no backend call" {
   run env ACQ_BACKEND=sbx "$ACQ" shell
   assert_failure
   assert_output --partial 'missing sandbox name'
   refute_regex "$(cat "$CALLS")" 'sbx exec'
 }
 
-@test "#383: shell --help documents the verb (acq-owned, not a passthrough)" {
+@test "shell: --help documents the verb (acq-owned, not a passthrough)" {
   run env ACQ_BACKEND=sbx "$ACQ" shell --help
   assert_output --partial 'interactive shell'
   refute_output --partial 'passed through'


### PR DESCRIPTION
Fixes GSA-TTS/agentic-coding-quickstart#383.

`acq run NAME` always relaunches the recorded agent and `acq exec` is non-interactive, so an interactive human shell was the one daily-driver moment that still required the raw backend CLI (`sbx exec -it <name> bash`). This adds the neutral verb:

- **sbx**: `acq shell NAME` → `sbx exec -it NAME bash` (sbx allocates the PTY).
- **msb**: routes through a new `_acq_msb_shell_exec` helper extracted from the two identical shell launches `_acq_msb_attach` already carried — so the verb gets the agent user, PTY, workspace cwd, sane `$SHELL`, and `SSH_AUTH_SOCK` injection (when the host agent is forwarded) for free, and the attach path loses its duplication. A raw `msb exec` shell gets none of that.

Scope note: deliberately minimal per the issue — no attach-time heals on shell entry in v1 (`acq run` remains the heal point), and no `-it` on `acq exec`. Per-verb `--help` (per the repo's per-verb help convention) and the three how-to docs are updated; the sbx how-to's "stays raw" note now lists only `sbx rm --all`.

Verified: 4 new dispatch tests (red first), full offline suite green (354/354 serially), and a live E2E — a scripted PTY drove `acq shell` into a real sbx v0.39.0 sandbox and got `SHELL-E2E-42 from agent` computed guest-side.

AI-assisted (Claude Code [claude-fable-5]).
