### PR TITLE
fix(msb): persist kit environment[] and replay it on agent sessions

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -1491,6 +1491,20 @@ EOF
   _acq_msb_run_commands "$name" "$spec"
 }
 
+# _acq_msb_reset_kit_env NAME — remove the persisted kit-env marker so a
+# FULL-set kit application (provision, heal) rebuilds it from the current kits'
+# environment[] only. Without this, the per-kit append in _acq_msb_apply_kit_dir
+# would retain entries a kit no longer declares — removed runtime config
+# (feature toggles, host selectors) silently surviving every heal. The
+# single-kit `acq kit apply` verb deliberately does NOT reset: a mid-life add
+# is additive, and replay's last-value-wins handles its overrides. Best-effort:
+# a failed reset degrades to the previous stale-retention behavior, never
+# aborts the apply.
+_acq_msb_reset_kit_env() {
+  msb exec -u 0 "$1" -- sh -c 'rm -f /var/lib/acq/kit-env' \
+    </dev/null >/dev/null 2>&1 || true
+}
+
 # Copy a host file into the guest and VERIFY it is readable there before
 # returning. Also chown files under /home/agent to the agent user (they are
 # copied as root, but the kits' startup commands read them as the agent user;
@@ -2800,6 +2814,7 @@ EOF
   # matching acq_backend_ensure_kits_applied's best-effort heal loop.
   local kd
   acq_spin_start "Applying configuration kits"
+  _acq_msb_reset_kit_env "$name"
   for kd in "${kitdirs[@]}"; do
     acq_debug "msb provision: applying kit dir $kd ($name)"
     if _acq_msb_apply_kit_dir "$name" "$kd"; then
@@ -4335,6 +4350,7 @@ acq_backend_ensure_kits_applied() {
   fi
   local kitref kitdir i=0 ok=1
   acq_spin_start "Refreshing configuration kits"
+  _acq_msb_reset_kit_env "$name"
   for kitref in "${kits[@]}"; do
     kitdir=$(_acq_msb_fetch_kit "$kitref") || {
       echo "acq(msb): warning: could not fetch kit for healing: $kitref" >&2

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3269,8 +3269,13 @@ _acq_msb_start_ssh_agent_bridge() {
 # marker so run/attach on a name-only re-entry still find it. See ADR-0021.
 _acq_msb_ssh_auth_sock_for() {
   local name="$1"
-  msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/ssh-auth-sock 2>/dev/null' \
-    </dev/null 2>/dev/null | tr -d '[:space:]'
+  # Failure-guarded: with the marker absent (forwarding never configured), the
+  # in-guest `cat` exits 1 and — under acq's `set -euo pipefail` — the pipeline
+  # would otherwise propagate that into the caller's command substitution and
+  # kill the whole session verb (the trailing `tr` does NOT mask it: pipefail
+  # takes the failing stage's status).
+  { msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/ssh-auth-sock 2>/dev/null' \
+    </dev/null 2>/dev/null || true; } | tr -d '[:space:]'
 }
 
 # _acq_msb_kit_env_flags_into ARRVAR NAME — build the `-e NAME=value` flag array
@@ -3287,9 +3292,13 @@ _acq_msb_ssh_auth_sock_for() {
 _acq_msb_kit_env_flags_into() {
   local _arrn="$1" _name="$2"
   eval "$_arrn=()"
+  # An ABSENT marker (sandbox created before the kit-env feature, or no kit
+  # declared environment[]) makes the in-guest `cat` exit 1; acq runs under
+  # `set -euo pipefail`, so the substitution MUST be failure-guarded or every
+  # session verb against such a sandbox dies before producing any output.
   local _kvs
   _kvs=$(msb exec "$_name" -u 0 -- sh -c 'cat /var/lib/acq/kit-env 2>/dev/null' \
-    </dev/null 2>/dev/null)
+    </dev/null 2>/dev/null) || _kvs=""
   [ -n "$_kvs" ] || return 0
   local _line
   while IFS= read -r _line; do
@@ -3716,9 +3725,13 @@ _acq_msb_attach() {
   # override; otherwise read the guest path recorded at provision (it mirrors the
   # host mount path, so it can't be recomputed from NAME alone). Fall back to the
   # agent home if nothing was recorded (older sandbox).
+  # Both marker reads below are failure-guarded (`|| true` before the pipe):
+  # an absent marker makes the in-guest `cat` exit 1, and under acq's
+  # `set -euo pipefail` an unguarded pipeline would kill the attach instead of
+  # taking the documented fallback.
   local ws="${ACQ_MSB_WORKSPACE:-}"
   if [ -z "$ws" ]; then
-    ws=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' </dev/null 2>/dev/null | tr -d '\r\n')
+    ws=$({ msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' </dev/null 2>/dev/null || true; } | tr -d '\r\n')
   fi
   [ -n "$ws" ] || ws="/home/agent"
 
@@ -3728,7 +3741,7 @@ _acq_msb_attach() {
   # otherwise break the single-quoting and run as the agent user. Fall back to a
   # plain shell on anything unexpected.
   local agent
-  agent=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/agent 2>/dev/null' </dev/null 2>/dev/null | tr -d '[:space:]')
+  agent=$({ msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/agent 2>/dev/null' </dev/null 2>/dev/null || true; } | tr -d '[:space:]')
   if [ -z "$agent" ] || ! _acq_msb_safe_agent_token "$agent"; then
     agent="shell"
   fi
@@ -3775,7 +3788,9 @@ _acq_msb_shell_exec() {
   if [ -z "$ws" ]; then
     ws="${ACQ_MSB_WORKSPACE:-}"
     if [ -z "$ws" ]; then
-      ws=$(msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' </dev/null 2>/dev/null | tr -d '\r\n')
+      # Failure-guarded like the attach path: an absent marker must fall back,
+      # not kill the shell verb under `set -euo pipefail`.
+      ws=$({ msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' </dev/null 2>/dev/null || true; } | tr -d '\r\n')
     fi
     [ -n "$ws" ] || ws="/home/agent"
   fi

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -1464,7 +1464,24 @@ EOF
     fi
   done
 
-  # 2) Run commands[]. Reassemble each argv record and exec it as the given uid.
+  # 2) Persist environment[] for session replay. Threading `-e NAME=value` onto
+  #    the kit's own commands (step 3) covers provisioning only; the block exists
+  #    for agent-runtime config (see ADR-0011: OPENCODE_CONFIG-style vars), so
+  #    the validated entries are also appended to a root-owned guest marker that
+  #    run/attach/shell read back and replay as `-e` flags (same marker pattern
+  #    as /var/lib/acq/agent and /var/lib/acq/ssh-auth-sock). Entries are passed
+  #    as argv to a fixed `sh -c` body — kit bytes are never interpolated into
+  #    shell syntax (SI-10).
+  local _kit_env=()
+  _acq_msb_collect_kit_env_into _kit_env "$spec"
+  if [ "${#_kit_env[@]}" -gt 0 ]; then
+    msb exec -u 0 "$name" -- sh -c \
+      'mkdir -p /var/lib/acq && printf "%s\n" "$@" >> /var/lib/acq/kit-env' \
+      sh "${_kit_env[@]}" </dev/null >/dev/null 2>&1 || \
+      echo "acq(msb): warning: could not persist kit env for '$name'; its environment[] will not reach agent sessions" >&2
+  fi
+
+  # 3) Run commands[]. Reassemble each argv record and exec it as the given uid.
   #    install → run once (idempotent, marker-gated); initFiles/startup → every
   #    apply. msb has no create-time-only hook, so install collapses to a
   #    marker-gated exec (design §3 lifecycle table). The kit's environment[]
@@ -1582,16 +1599,8 @@ _acq_msb_run_commands() {
   # already validates each NAME (^[A-Za-z_][A-Za-z0-9_]*$) and drops unsafe ones,
   # so these are safe to pass as exec env. Values are passed as a single argv
   # element (never re-split by a shell).
-  local _kit_env=() eline ekey eval_v
-  while IFS= read -r eline; do
-    [ -n "$eline" ] || continue
-    ekey=$(printf '%s' "$eline" | cut -f1)
-    eval_v=$(printf '%s' "$eline" | cut -f2-)
-    [ -n "$ekey" ] || continue
-    _kit_env+=("${ekey}=${eval_v}")
-  done <<EOF
-$(kit_spec_env "$spec")
-EOF
+  local _kit_env=()
+  _acq_msb_collect_kit_env_into _kit_env "$spec"
 
   # Buffer the parsed command stream FIRST, then execute. The exec step calls
   # `msb exec`, which would consume this loop's stdin if we iterated the heredoc
@@ -3264,6 +3273,43 @@ _acq_msb_ssh_auth_sock_for() {
     </dev/null 2>/dev/null | tr -d '[:space:]'
 }
 
+# _acq_msb_kit_env_flags_into ARRVAR NAME — build the `-e NAME=value` flag array
+# for the kit environment[] entries persisted at /var/lib/acq/kit-env by
+# _acq_msb_apply_kit_dir, so every session path (run/attach/shell) sees the env
+# the kits declared for agent runtime (see ADR-0011). Empty array when no kit
+# declared environment[]. Array passed by name (bash 3.2 compat).
+#
+# The marker is root-owned but its content is kit-derived guest data: re-validate
+# each NAME (same ^[A-Za-z_][A-Za-z0-9_]*$ charset kit_spec_env enforces) so a
+# tampered line cannot smuggle an option-shaped or quote-bearing token, and keep
+# the LAST value for a duplicate name (kits append in application order, so a
+# later kit overrides an earlier one).
+_acq_msb_kit_env_flags_into() {
+  local _arrn="$1" _name="$2"
+  eval "$_arrn=()"
+  local _kvs
+  _kvs=$(msb exec "$_name" -u 0 -- sh -c 'cat /var/lib/acq/kit-env 2>/dev/null' \
+    </dev/null 2>/dev/null)
+  [ -n "$_kvs" ] || return 0
+  local _line
+  while IFS= read -r _line; do
+    [ -n "$_line" ] || continue
+    eval "$_arrn+=(-e \"\$_line\")"
+  done <<EOF
+$(printf '%s\n' "$_kvs" | awk '
+  {
+    i = index($0, "=")
+    if (i < 2) next
+    k = substr($0, 1, i - 1)
+    if (k !~ /^[A-Za-z_][A-Za-z0-9_]*$/) next
+    v[k] = substr($0, i + 1)
+    if (!(k in seen)) { seen[k] = 1; order[++n] = k }
+  }
+  END { for (j = 1; j <= n; j++) printf "%s=%s\n", order[j], v[order[j]] }
+')
+EOF
+}
+
 # _acq_msb_ensure_ssh_agent_forward NAME — (re)establish the host ssh-agent
 # forward on a RUNNING sandbox that acq is re-attaching to. See ADR-0021.
 #
@@ -3611,12 +3657,17 @@ acq_backend_run() {
   shift
   # If the host ssh-agent is forwarded, git/ssh in the guest must see
   # SSH_AUTH_SOCK pointing at the in-guest bridge socket. See ADR-0021.
-  local _sock
+  # Kit-declared environment[] entries persisted at provision are replayed the
+  # same way, mirroring the flag order the provisioning execs use (HOME, sock,
+  # then kit env — see _acq_msb_exec_flags_into).
+  local _sock _kitenv=()
   _sock=$(_acq_msb_ssh_auth_sock_for "$name")
+  _acq_msb_kit_env_flags_into _kitenv "$name"
   if [ -n "$_sock" ]; then
-    msb exec -u agent -e HOME=/home/agent -e "SSH_AUTH_SOCK=$_sock" "$name" "$@"
+    msb exec -u agent -e HOME=/home/agent -e "SSH_AUTH_SOCK=$_sock" \
+      ${_kitenv[@]+"${_kitenv[@]}"} "$name" "$@"
   else
-    msb exec -u agent -e HOME=/home/agent "$name" "$@"
+    msb exec -u agent -e HOME=/home/agent ${_kitenv[@]+"${_kitenv[@]}"} "$name" "$@"
   fi
 }
 
@@ -3694,6 +3745,11 @@ _acq_msb_attach() {
   _sock=$(_acq_msb_ssh_auth_sock_for "$name")
   [ -n "$_sock" ] && _sockflag=(-e "SSH_AUTH_SOCK=$_sock")
 
+  # Replay the kit environment[] persisted at provision, so agent-runtime config
+  # (OPENCODE_CONFIG-style vars, see ADR-0011) reaches the agent session.
+  local _kitenv=()
+  _acq_msb_kit_env_flags_into _kitenv "$name"
+
   if [ "$agent" = "shell" ]; then
     _acq_msb_shell_exec "$name" "$ws"
   fi
@@ -3705,7 +3761,8 @@ _acq_msb_attach() {
     _acq_msb_shell_exec "$name" "$ws"
   fi
 
-  exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} "$name" -- "$agent" "$@"
+  exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} \
+    ${_kitenv[@]+"${_kitenv[@]}"} "$name" -- "$agent" "$@"
 }
 
 # _acq_msb_shell_exec NAME [WS] — exec into an interactive login shell as the
@@ -3722,10 +3779,12 @@ _acq_msb_shell_exec() {
     fi
     [ -n "$ws" ] || ws="/home/agent"
   fi
-  local _sock _sockflag=()
+  local _sock _sockflag=() _kitenv=()
   _sock=$(_acq_msb_ssh_auth_sock_for "$name")
   [ -n "$_sock" ] && _sockflag=(-e "SSH_AUTH_SOCK=$_sock")
-  exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} "$name" -- /bin/sh -l
+  _acq_msb_kit_env_flags_into _kitenv "$name"
+  exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} \
+    ${_kitenv[@]+"${_kitenv[@]}"} "$name" -- /bin/sh -l
 }
 
 # ---------------------------------------------------------------------------

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3292,10 +3292,9 @@ _acq_msb_ssh_auth_sock_for() {
 _acq_msb_kit_env_flags_into() {
   local _arrn="$1" _name="$2"
   eval "$_arrn=()"
-  # An ABSENT marker (sandbox created before the kit-env feature, or no kit
-  # declared environment[]) makes the in-guest `cat` exit 1; acq runs under
-  # `set -euo pipefail`, so the substitution MUST be failure-guarded or every
-  # session verb against such a sandbox dies before producing any output.
+  # Failure-guarded: an absent marker (pre-kit-env sandbox, or no kit declared
+  # environment[]) must yield an empty result, not kill the session verb — see
+  # _acq_msb_ssh_auth_sock_for.
   local _kvs
   _kvs=$(msb exec "$_name" -u 0 -- sh -c 'cat /var/lib/acq/kit-env 2>/dev/null' \
     </dev/null 2>/dev/null) || _kvs=""
@@ -3725,10 +3724,9 @@ _acq_msb_attach() {
   # override; otherwise read the guest path recorded at provision (it mirrors the
   # host mount path, so it can't be recomputed from NAME alone). Fall back to the
   # agent home if nothing was recorded (older sandbox).
-  # Both marker reads below are failure-guarded (`|| true` before the pipe):
-  # an absent marker makes the in-guest `cat` exit 1, and under acq's
-  # `set -euo pipefail` an unguarded pipeline would kill the attach instead of
-  # taking the documented fallback.
+  # Both marker reads are failure-guarded so an absent marker takes the
+  # documented fallback instead of killing the attach (see
+  # _acq_msb_ssh_auth_sock_for).
   local ws="${ACQ_MSB_WORKSPACE:-}"
   if [ -z "$ws" ]; then
     ws=$({ msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' </dev/null 2>/dev/null || true; } | tr -d '\r\n')
@@ -3788,8 +3786,6 @@ _acq_msb_shell_exec() {
   if [ -z "$ws" ]; then
     ws="${ACQ_MSB_WORKSPACE:-}"
     if [ -z "$ws" ]; then
-      # Failure-guarded like the attach path: an absent marker must fall back,
-      # not kill the shell verb under `set -euo pipefail`.
       ws=$({ msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' </dev/null 2>/dev/null || true; } | tr -d '\r\n')
     fi
     [ -n "$ws" ] || ws="/home/agent"

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -371,16 +371,17 @@ strings). The translate layer:
   environment natively; no `commands` workaround.
 - **msb:** threads each `NAME=value` onto the kit's lifecycle commands as
   `msb exec -e NAME=value` (msb's native per-exec env flag, already used for
-  `HOME=/home/agent`), **and** persists the validated entries to a root-owned
-  guest marker (`/var/lib/acq/kit-env`, the same pattern as
-  `/var/lib/acq/agent` and `/var/lib/acq/ssh-auth-sock`) that every session
-  path — attach, `acq exec`, `acq shell` — reads back and replays as `-e`
-  flags. Command-only scoping was the original mapping, but it silently
-  dropped exactly the agent-runtime config (`OPENCODE_CONFIG`-style vars) this
-  vocabulary was added for; the replay closes that gap and matches sbx's
-  sandbox-level env semantics. On replay, names are re-validated (tampered
-  marker defense) and the last value wins for a duplicate name (kits append in
-  application order, so a later kit overrides an earlier one).
+  `HOME=/home/agent`), scoping the env to the kit's own commands.
+
+> **Update (2026-08-26):** The command-only scoping above dropped exactly the
+> agent-runtime config (`OPENCODE_CONFIG`-style vars) this vocabulary was
+> motivated by. The msb adapter now also persists the validated entries to a
+> root-owned guest marker (`/var/lib/acq/kit-env`, the same pattern as
+> `/var/lib/acq/agent` and `/var/lib/acq/ssh-auth-sock`) and replays them as
+> `-e` flags on every session path (attach, `acq exec`, `acq shell`), matching
+> sbx's sandbox-level env semantics. Names are re-validated on replay (tampered
+> marker defense) and the last value wins for a duplicate name (kits append in
+> application order, so a later kit overrides an earlier one).
 
 Deliberately minimal (YAGNI): **static string values only** — no interpolation,
 no references to `files[]`-staged paths (a kit needing a computed value uses a

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -371,7 +371,16 @@ strings). The translate layer:
   environment natively; no `commands` workaround.
 - **msb:** threads each `NAME=value` onto the kit's lifecycle commands as
   `msb exec -e NAME=value` (msb's native per-exec env flag, already used for
-  `HOME=/home/agent`), scoping the env to the kit's own commands.
+  `HOME=/home/agent`), **and** persists the validated entries to a root-owned
+  guest marker (`/var/lib/acq/kit-env`, the same pattern as
+  `/var/lib/acq/agent` and `/var/lib/acq/ssh-auth-sock`) that every session
+  path — attach, `acq exec`, `acq shell` — reads back and replays as `-e`
+  flags. Command-only scoping was the original mapping, but it silently
+  dropped exactly the agent-runtime config (`OPENCODE_CONFIG`-style vars) this
+  vocabulary was added for; the replay closes that gap and matches sbx's
+  sandbox-level env semantics. On replay, names are re-validated (tampered
+  marker defense) and the last value wins for a duplicate name (kits append in
+  application order, so a later kit overrides an earlier one).
 
 Deliberately minimal (YAGNI): **static string values only** — no interpolation,
 no references to `files[]`-staged paths (a kit needing a computed value uses a

--- a/scripts/test-acq-lib.sh
+++ b/scripts/test-acq-lib.sh
@@ -350,14 +350,10 @@ case "$_msb_sub" in
       *"cat /var/lib/acq/ssh-auth-sock"*)
         [ -n "${STUB_RECORDED_SSH_AUTH_SOCK+x}" ] || exit 1
         printf '%s' "$STUB_RECORDED_SSH_AUTH_SOCK" ;;
-      # The persisted kit environment[] marker read by the session paths
-      # (run/attach/shell) so kit-declared guest env survives past provisioning
-      # (see ADR-0011). STUB_RECORDED_KIT_ENV models a sandbox whose kits
-      # recorded NAME=value lines at provision time (multi-line values model
-      # multiple entries). UNSET models an ABSENT marker faithfully: a real
-      # `sh -c 'cat …'` exits 1 there, and acq runs under `set -euo pipefail`,
-      # so the reader must survive that nonzero (a sandbox created before the
-      # kit-env feature has no marker; every session verb still has to work).
+      # The persisted kit environment[] marker (see ADR-0011).
+      # STUB_RECORDED_KIT_ENV models the NAME=value lines recorded at
+      # provision (multi-line values model multiple entries); absent/empty
+      # semantics per the marker-reads comment above.
       *"cat /var/lib/acq/kit-env"*)
         [ -n "${STUB_RECORDED_KIT_ENV+x}" ] || exit 1
         printf '%s' "$STUB_RECORDED_KIT_ENV" ;;

--- a/scripts/test-acq-lib.sh
+++ b/scripts/test-acq-lib.sh
@@ -332,19 +332,35 @@ case "$_msb_sub" in
         [ "${STUB_NPM_FAIL:-0}" = "1" ] && exit 1 || exit 0 ;;
       *"test -f "*) exit 1 ;;       # markers absent
       *"test -s "*) exit 0 ;;       # copied files present
-      *"cat /var/lib/acq/agent"*) printf '%s' "${STUB_RECORDED_AGENT:-}" ;;
-      *"cat /var/lib/acq/workspace"*) printf '%s' "${STUB_RECORDED_WORKSPACE:-}" ;;
+      # The /var/lib/acq marker reads (agent, workspace, ssh-auth-sock,
+      # kit-env). An UNSET STUB_RECORDED_* models an ABSENT marker faithfully:
+      # a real `sh -c 'cat …'` exits 1 there, and acq runs under
+      # `set -euo pipefail`, so every reader must survive that nonzero (a
+      # sandbox from before a marker existed, or one whose feature was never
+      # configured, still has to serve every session verb). A SET-but-empty
+      # value models a present-but-empty marker (cat exits 0).
+      *"cat /var/lib/acq/agent"*)
+        [ -n "${STUB_RECORDED_AGENT+x}" ] || exit 1
+        printf '%s' "$STUB_RECORDED_AGENT" ;;
+      *"cat /var/lib/acq/workspace"*)
+        [ -n "${STUB_RECORDED_WORKSPACE+x}" ] || exit 1
+        printf '%s' "$STUB_RECORDED_WORKSPACE" ;;
       # ADR-0021: the persisted ssh-agent guest sock marker read by
-      # _acq_msb_ssh_auth_sock_for (and, via it, run/attach/start). Empty by
-      # default (forwarding not configured); STUB_RECORDED_SSH_AUTH_SOCK models a
-      # sandbox that recorded the bridge sock at provision time.
-      *"cat /var/lib/acq/ssh-auth-sock"*) printf '%s' "${STUB_RECORDED_SSH_AUTH_SOCK:-}" ;;
+      # _acq_msb_ssh_auth_sock_for (and, via it, run/attach/start).
+      *"cat /var/lib/acq/ssh-auth-sock"*)
+        [ -n "${STUB_RECORDED_SSH_AUTH_SOCK+x}" ] || exit 1
+        printf '%s' "$STUB_RECORDED_SSH_AUTH_SOCK" ;;
       # The persisted kit environment[] marker read by the session paths
       # (run/attach/shell) so kit-declared guest env survives past provisioning
-      # (see ADR-0011). Empty by default (no kit declared environment[]);
-      # STUB_RECORDED_KIT_ENV models a sandbox whose kits recorded NAME=value
-      # lines at provision time (multi-line values model multiple entries).
-      *"cat /var/lib/acq/kit-env"*) printf '%s' "${STUB_RECORDED_KIT_ENV:-}" ;;
+      # (see ADR-0011). STUB_RECORDED_KIT_ENV models a sandbox whose kits
+      # recorded NAME=value lines at provision time (multi-line values model
+      # multiple entries). UNSET models an ABSENT marker faithfully: a real
+      # `sh -c 'cat …'` exits 1 there, and acq runs under `set -euo pipefail`,
+      # so the reader must survive that nonzero (a sandbox created before the
+      # kit-env feature has no marker; every session verb still has to work).
+      *"cat /var/lib/acq/kit-env"*)
+        [ -n "${STUB_RECORDED_KIT_ENV+x}" ] || exit 1
+        printf '%s' "$STUB_RECORDED_KIT_ENV" ;;
       *) : ;;
     esac ;;
   ssh)

--- a/scripts/test-acq-lib.sh
+++ b/scripts/test-acq-lib.sh
@@ -339,6 +339,12 @@ case "$_msb_sub" in
       # default (forwarding not configured); STUB_RECORDED_SSH_AUTH_SOCK models a
       # sandbox that recorded the bridge sock at provision time.
       *"cat /var/lib/acq/ssh-auth-sock"*) printf '%s' "${STUB_RECORDED_SSH_AUTH_SOCK:-}" ;;
+      # The persisted kit environment[] marker read by the session paths
+      # (run/attach/shell) so kit-declared guest env survives past provisioning
+      # (see ADR-0011). Empty by default (no kit declared environment[]);
+      # STUB_RECORDED_KIT_ENV models a sandbox whose kits recorded NAME=value
+      # lines at provision time (multi-line values model multiple entries).
+      *"cat /var/lib/acq/kit-env"*) printf '%s' "${STUB_RECORDED_KIT_ENV:-}" ;;
       *) : ;;
     esac ;;
   ssh)

--- a/scripts/test-acq-lib.sh
+++ b/scripts/test-acq-lib.sh
@@ -350,13 +350,33 @@ case "$_msb_sub" in
       *"cat /var/lib/acq/ssh-auth-sock"*)
         [ -n "${STUB_RECORDED_SSH_AUTH_SOCK+x}" ] || exit 1
         printf '%s' "$STUB_RECORDED_SSH_AUTH_SOCK" ;;
-      # The persisted kit environment[] marker (see ADR-0011).
-      # STUB_RECORDED_KIT_ENV models the NAME=value lines recorded at
-      # provision (multi-line values model multiple entries); absent/empty
-      # semantics per the marker-reads comment above.
+      # The persisted kit environment[] marker (see ADR-0011). The write/reset
+      # arms keep a STATEFUL model in $STUBDIR/.kit_env so the full
+      # provision→heal→replay cycle is testable (stale-entry regression);
+      # STUB_RECORDED_KIT_ENV, when set, overrides it with fixed content
+      # (multi-line values model multiple entries). Absent/empty semantics per
+      # the marker-reads comment above.
+      *">> /var/lib/acq/kit-env"*)
+        # Append the env tokens: argv shape is `… -- sh -c '<script>' sh
+        # NAME=value…` — collect everything after the argv0 `sh` that follows
+        # the script.
+        _kes_c=0 _kes_script=0 _kes_argv0=0
+        for a in "$@"; do
+          if [ "$_kes_argv0" = 1 ]; then printf '%s\n' "$a" >>"$STUBDIR/.kit_env"
+          elif [ "$_kes_script" = 1 ] && [ "$a" = "sh" ]; then _kes_argv0=1
+          elif [ "$_kes_c" = 1 ]; then _kes_script=1; _kes_c=0
+          elif [ "$a" = "-c" ]; then _kes_c=1
+          fi
+        done ;;
+      *"rm -f /var/lib/acq/kit-env"*) rm -f "$STUBDIR/.kit_env" ;;
       *"cat /var/lib/acq/kit-env"*)
-        [ -n "${STUB_RECORDED_KIT_ENV+x}" ] || exit 1
-        printf '%s' "$STUB_RECORDED_KIT_ENV" ;;
+        if [ -n "${STUB_RECORDED_KIT_ENV+x}" ]; then
+          printf '%s' "$STUB_RECORDED_KIT_ENV"
+        elif [ -f "$STUBDIR/.kit_env" ]; then
+          cat "$STUBDIR/.kit_env"
+        else
+          exit 1
+        fi ;;
       *) : ;;
     esac ;;
   ssh)

--- a/test/bats/78-msb-kit-env.bats
+++ b/test/bats/78-msb-kit-env.bats
@@ -166,6 +166,7 @@ SPEC
     . "${REPO_ROOT}/acq.backends/secret-store.sh"
     . "${REPO_ROOT}/acq.backends/kit-translate.sh"
     . "${REPO_ROOT}/acq.backends/msb.sh"
+    # shellcheck disable=SC2034  # consumed by the sourced acq_backend_ensure_kits_applied
     ACQ_CLI_KITS=()
     _acq_msb_fetch_kit() { printf '%s\n' "$hk"; }
     acq_backend_ensure_kits_applied healbox >/dev/null 2>&1 )
@@ -184,6 +185,7 @@ SPEC
     . "${REPO_ROOT}/acq.backends/secret-store.sh"
     . "${REPO_ROOT}/acq.backends/kit-translate.sh"
     . "${REPO_ROOT}/acq.backends/msb.sh"
+    # shellcheck disable=SC2034  # consumed by the sourced acq_backend_ensure_kits_applied
     ACQ_CLI_KITS=()
     _acq_msb_fetch_kit() { printf '%s\n' "$hk"; }
     acq_backend_ensure_kits_applied healbox >/dev/null 2>&1 )

--- a/test/bats/78-msb-kit-env.bats
+++ b/test/bats/78-msb-kit-env.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+#
+# 78-msb-kit-env.bats — msb kit environment[] persistence + session replay.
+#
+# A kit's environment[] block exists for agent-runtime config (see ADR-0011:
+# OPENCODE_CONFIG-style vars). On msb the entries were only threaded onto the
+# kit's own provisioning commands and never reached the agent session or
+# `acq exec`/`acq shell` — the kit env silently no-op'd at runtime. The fix
+# persists the validated entries to a root-owned guest marker
+# (/var/lib/acq/kit-env, same pattern as /var/lib/acq/agent and
+# /var/lib/acq/ssh-auth-sock) at apply time, and every session path reads the
+# marker back and threads each entry as `msb exec -e NAME=value`.
+#
+# shellcheck shell=bats
+
+setup() { acq_setup_stubs; load_acq; }
+teardown() { acq_teardown_stubs; }
+
+load 'helper'
+
+@test "msb kit env: apply persists environment[] to /var/lib/acq/kit-env; unsafe name is dropped" {
+  : > "$CALLS"
+  run bash -c '
+    export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/kitenv-secrets"
+    . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    ek="'"$STUBDIR"'/persistkit"; mkdir -p "$ek"
+    cat >"$ek/spec.yaml" <<'"'"'SPEC'"'"'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: persist-kit
+displayName: Persist Kit
+description: environment vars persisted for session replay
+environment:
+  OPENCODE_CONFIG: /home/agent/.config/opencode/kit.jsonc
+  "1BAD": should-be-dropped
+SPEC
+    _acq_msb_apply_kit_dir envbox "$ek"
+  '
+  assert_success
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" '/var/lib/acq/kit-env'
+  assert_regex "$log" 'OPENCODE_CONFIG=/home/agent/\.config/opencode/kit\.jsonc'
+  refute_regex "$log" '1BAD'
+}
+
+@test "msb kit env: a kit with no environment[] writes no kit-env marker" {
+  : > "$CALLS"
+  run bash -c '
+    export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/noenv-secrets"
+    . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    nk="'"$STUBDIR"'/noenvkit"; mkdir -p "$nk"
+    cat >"$nk/spec.yaml" <<'"'"'SPEC'"'"'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: noenv-kit
+displayName: NoEnv Kit
+description: no environment block
+commands:
+  - phase: startup
+    user: "0"
+    command:
+      - sh
+      - -c
+      - echo CMD_NOENV
+SPEC
+    _acq_msb_apply_kit_dir envbox "$nk"
+  '
+  assert_success
+  refute_regex "$(cat "$CALLS")" '/var/lib/acq/kit-env'
+}
+
+@test "msb kit env: acq exec replays persisted entries as -e flags; none when marker empty" {
+  : > "$CALLS"
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9
+    export STUB_RECORDED_KIT_ENV="OPENCODE_CONFIG=/home/agent/oc.jsonc
+RUBOCOP_PARALLELISM=4"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_run sbox -- printenv OPENCODE_CONFIG >/dev/null 2>&1
+  '
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" '-e OPENCODE_CONFIG=/home/agent/oc\.jsonc'
+  assert_regex "$log" '-e RUBOCOP_PARALLELISM=4'
+  : > "$CALLS"
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9 STUB_RECORDED_KIT_ENV=
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_run sbox -- git status >/dev/null 2>&1
+  '
+  refute_regex "$(cat "$CALLS")" 'OPENCODE_CONFIG'
+}
+
+@test "msb kit env: attach and shell replay persisted entries as -e flags" {
+  : > "$CALLS"
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9 STUB_RECORDED_AGENT=opencode STUB_AGENT_PRESENT=1
+    export STUB_RECORDED_KIT_ENV="OPENCODE_CONFIG=/home/agent/oc.jsonc"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    ( _acq_msb_attach sbox </dev/null >/dev/null 2>&1 )
+  '
+  assert_regex "$(cat "$CALLS")" '-e OPENCODE_CONFIG=/home/agent/oc\.jsonc'
+  : > "$CALLS"
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9
+    export STUB_RECORDED_KIT_ENV="OPENCODE_CONFIG=/home/agent/oc.jsonc"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    ( _acq_msb_shell_exec sbox </dev/null >/dev/null 2>&1 )
+  '
+  assert_regex "$(cat "$CALLS")" '-e OPENCODE_CONFIG=/home/agent/oc\.jsonc'
+}
+
+@test "msb kit env: replay drops tampered names and keeps the last value for a duplicate" {
+  : > "$CALLS"
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9
+    export STUB_RECORDED_KIT_ENV="BAD-NAME=x
+GITLAB_HOST=gitlab.example.gov
+GITLAB_HOST=gitlab.override.gov"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_run sbox -- git status >/dev/null 2>&1
+  '
+  local log; log=$(cat "$CALLS")
+  refute_regex "$log" 'BAD-NAME'
+  assert_regex "$log" '-e GITLAB_HOST=gitlab\.override\.gov'
+  refute_regex "$log" 'GITLAB_HOST=gitlab\.example\.gov'
+}

--- a/test/bats/78-msb-kit-env.bats
+++ b/test/bats/78-msb-kit-env.bats
@@ -141,6 +141,63 @@ RUBOCOP_PARALLELISM=4"
   assert_regex "$(cat "$CALLS")" 'exec -u agent -e HOME=/home/agent sbox -- git status'
 }
 
+@test "msb kit env: heal rebuilds the marker — a var the kit no longer declares stops reaching sessions" {
+  # The heal loop (and provision) applies the FULL effective kit set, so the
+  # marker must be rebuilt from the current kits' environment[] each time. An
+  # append-only marker would retain entries a kit stopped declaring: removed
+  # runtime config (feature toggles, host selectors) would keep influencing
+  # sessions indefinitely.
+  : > "$CALLS"
+  printf 'healbox\n' > "$STUBDIR/.msb_sandbox_list"
+  printf 'healbox\n' > "$STUBDIR/.msb_running_list"
+  local hk="$STUBDIR/healkit"; mkdir -p "$hk"
+  cat > "$hk/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: heal-kit
+displayName: Heal Kit
+description: env entries across kit versions
+environment:
+  KEPT_VAR: stays
+  STALE_VAR: dropped-in-v2
+SPEC
+  ( export ACQ_SECRET_STORE_DIR="$STUBDIR/heal-secrets"
+    export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/heal-stage"
+    . "${REPO_ROOT}/acq.backends/secret-store.sh"
+    . "${REPO_ROOT}/acq.backends/kit-translate.sh"
+    . "${REPO_ROOT}/acq.backends/msb.sh"
+    ACQ_CLI_KITS=()
+    _acq_msb_fetch_kit() { printf '%s\n' "$hk"; }
+    acq_backend_ensure_kits_applied healbox >/dev/null 2>&1 )
+  # Kit v2 drops STALE_VAR; the next heal must rebuild the marker without it.
+  cat > "$hk/spec.yaml" <<'SPEC'
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: heal-kit
+displayName: Heal Kit
+description: env entries across kit versions
+environment:
+  KEPT_VAR: stays
+SPEC
+  ( export ACQ_SECRET_STORE_DIR="$STUBDIR/heal-secrets"
+    export ACQ_MSB_STARTUP_STAGE_DIR="$STUBDIR/heal-stage"
+    . "${REPO_ROOT}/acq.backends/secret-store.sh"
+    . "${REPO_ROOT}/acq.backends/kit-translate.sh"
+    . "${REPO_ROOT}/acq.backends/msb.sh"
+    ACQ_CLI_KITS=()
+    _acq_msb_fetch_kit() { printf '%s\n' "$hk"; }
+    acq_backend_ensure_kits_applied healbox >/dev/null 2>&1 )
+  : > "$CALLS"
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_run healbox -- git status >/dev/null 2>&1
+  '
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" '-e KEPT_VAR=stays'
+  refute_regex "$log" 'STALE_VAR'
+}
+
 @test "msb kit env: replay drops tampered names and keeps the last value for a duplicate" {
   : > "$CALLS"
   run bash -c '

--- a/test/bats/78-msb-kit-env.bats
+++ b/test/bats/78-msb-kit-env.bats
@@ -113,6 +113,34 @@ RUBOCOP_PARALLELISM=4"
   assert_regex "$(cat "$CALLS")" '-e OPENCODE_CONFIG=/home/agent/oc\.jsonc'
 }
 
+@test "msb markers: ABSENT /var/lib/acq markers must not kill session verbs under set -e" {
+  # acq runs under `set -euo pipefail`. On a sandbox whose /var/lib/acq markers
+  # are absent (created before a marker existed, e.g. pre-kit-env sandboxes, or
+  # no ssh-agent forwarding configured), the in-guest `cat` exits 1 inside the
+  # command substitution and an unguarded assignment terminates acq before any
+  # output — every exec/shell/attach against such a sandbox dies with rc 1 and
+  # nothing on stdout/stderr (observed live for kit-env and ssh-auth-sock).
+  # All STUB_RECORDED_* stay UNSET here so the stub exits 1 like real cat.
+  : > "$CALLS"
+  run bash -c '
+    set -euo pipefail
+    export STUB_MSB_VERSION=0.6.9
+    unset STUB_RECORDED_KIT_ENV STUB_RECORDED_SSH_AUTH_SOCK STUB_RECORDED_AGENT STUB_RECORDED_WORKSPACE
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_run sbox -- git status >/dev/null 2>&1
+    echo RUN-SURVIVED
+    ( _acq_msb_attach sbox </dev/null >/dev/null 2>&1 )
+    echo ATTACH-SURVIVED
+    ( _acq_msb_shell_exec sbox </dev/null >/dev/null 2>&1 )
+    echo SHELL-SURVIVED
+  '
+  assert_success
+  assert_output --partial 'RUN-SURVIVED'
+  assert_output --partial 'ATTACH-SURVIVED'
+  assert_output --partial 'SHELL-SURVIVED'
+  assert_regex "$(cat "$CALLS")" 'exec -u agent -e HOME=/home/agent sbox -- git status'
+}
+
 @test "msb kit env: replay drops tampered names and keeps the last value for a duplicate" {
   : > "$CALLS"
   run bash -c '


### PR DESCRIPTION
Fixes GSA-TTS/agentic-coding-quickstart#400

## Problem

On the msb backend, a hybrid/v1 kit's `environment` block was applied only to the kit's own provisioning commands — it never reached the agent session or `acq exec` / `acq shell`. Any kit using `environment` for agent-runtime config (`OPENCODE_CONFIG`-style vars — the use case ADR-0011 added the vocabulary for) silently no-op'd on msb, while the same kit worked on sbx (which sets kit env at the sandbox level).

Reproduced live on msb 0.6.15: a minimal kit with `environment: {PROBE_VAR: hello}` provisioned cleanly, but `acq exec <sandbox> -- printenv PROBE_VAR` came back empty from every session path.

## Fix

Mirrors the adapter's existing marker-file pattern (`/var/lib/acq/agent`, `/var/lib/acq/ssh-auth-sock`):

- **At kit apply:** append the validated `NAME=value` entries to a root-owned guest marker, `/var/lib/acq/kit-env`. Entries are passed as argv to a fixed `sh -c` body — kit bytes are never interpolated into shell syntax (SI-10).
- **On every session path** (attach, `acq exec`, `acq shell`): read the marker back and thread each entry as `msb exec -e NAME=value`. Names are re-validated against the kit_spec_env charset (tampered-marker defense) and the last value wins for a duplicate name, so a later kit overrides an earlier one — including mid-life `acq kit apply` re-applies.
- **Absent-marker crash guard** (follow-up reported on the issue): with a `/var/lib/acq` marker file absent, the in-guest `cat` exits 1 inside the reader's command substitution and acq's `set -euo pipefail` killed the whole session verb (rc 1, no output). Verified live for the new kit-env marker (sandbox created before this feature) and the pre-existing ssh-auth-sock marker (no ssh-agent forwarding — its trailing `| tr` does not mask the failure; pipefail takes the failing stage's status). All four marker reads (kit-env, ssh-auth-sock, workspace, agent) are now failure-guarded.
- **Full-set rebuild** (review finding): the marker is removed before the provision and heal kit loops and rebuilt from the current kits' `environment[]`, so entries a kit no longer declares stop reaching sessions; mid-life single-kit `acq kit apply` stays additive.

Also amends ADR-0011's msb mapping (it documented the command-only scoping, which contradicted the block's own motivating use case) and deduplicates the env-collect loop in `_acq_msb_run_commands` into `_acq_msb_collect_kit_env_into`.

## Testing

- New `test/bats/78-msb-kit-env.bats` (7 tests, written failing-first): persist at apply, no marker without `environment[]`, replay on exec, replay on attach/shell, absent-marker crash guard under `set -euo pipefail`, heal rebuild (a var the kit no longer declares stops reaching sessions), tampered-name drop + last-wins dedupe. The stubs model absent markers faithfully (exit 1 like real `cat`) and keep a stateful kit-env marker so the full provision→heal→replay cycle is exercised.
- Full offline bats suite green; shellcheck (`--severity=warning`, repo `.shellcheckrc`) and pinned markdownlint clean.
- Live E2E on msb 0.6.15 (macOS/Apple Silicon): kit-declared var now reaches `acq exec` (previously empty); the pinned kits' entries append correctly and all arrive in sessions.