### PR TITLE
ci: check only changed markdown links on PRs

### DIFF
--- a/.github/workflows/markdown-quality.yml
+++ b/.github/workflows/markdown-quality.yml
@@ -64,3 +64,5 @@ jobs:
           config-file: ".markdown-link-check.json"
           use-quiet-mode: "yes"
           folder-path: "."
+          check-modified-files-only: ${{ github.event_name == 'pull_request' && 'yes' || 'no' }}
+          base-branch: "main"


### PR DESCRIPTION
## Context

The Link Check job in \`.github/workflows/markdown-quality.yml\` scanned the entire repository on every pull request, even when a PR only touched a handful of files. This made PR runs slower than necessary.

## Change

Mirror the optimization from GSA-TTS/agentic-coding-patterns#391:

- On **pull requests**: check only Markdown files modified relative to the \`main\` base branch (\`check-modified-files-only: yes\`).
- On **push to main**: keep the full repository scan (\`check-modified-files-only: no\`).

This reduces PR link-check runtime while preserving periodic full coverage on merges to main.

## Verification

- \`git diff\` confirms the two-line addition to the Link Check step (\`check-modified-files-only\` + \`base-branch\`).
- No behavior change to the markdown-lint job.

## Rollback

Revert this commit / remove the two added keys from the \`tcort/github-action-markdown-link-check\` step.

## Security Impact

None. CI-only change; does not affect authentication, authorization, data handling, or attack surface.

AI-assisted (OpenCode).