### PR TITLE
fix(msb): detect stale ssh-agent --vsock route after a host reboot

### DIFF
--- a/.github/workflows/bash32-compat.yml
+++ b/.github/workflows/bash32-compat.yml
@@ -91,9 +91,29 @@ jobs:
         run: |
           set -euo pipefail
           tarball="bash-${BASH32_VERSION}.tar.gz"
-          base="https://ftp.gnu.org/gnu/bash"
-          curl -fsSL --retry 3 -o "$tarball"     "${base}/${tarball}"
-          curl -fsSL --retry 3 -o "${tarball}.sig" "${base}/${tarball}.sig"
+          # Fetch the tarball + its detached signature. `ftp.gnu.org` is a single
+          # host that intermittently refuses connections and red-flags healthy
+          # PRs (curl 28 "Failed to connect"); `ftpmirror.gnu.org` redirects to a
+          # live GNU mirror, so try it FIRST and fall back to the canonical host.
+          # Integrity does not depend on the source — the OpenPGP signature below
+          # authenticates the bytes regardless of which mirror served them.
+          fetch() {
+            # $1 = output path, $2 = path under /gnu/bash
+            local _out="$1" _path="$2" _m
+            for _m in \
+              https://ftpmirror.gnu.org/gnu/bash \
+              https://ftp.gnu.org/gnu/bash ; do
+              if curl -fsSL --connect-timeout 30 --retry 3 --retry-connrefused \
+                   -o "$_out" "${_m}/${_path}"; then
+                return 0
+              fi
+              echo "warn: fetch of ${_path} from ${_m} failed; trying next mirror" >&2
+            done
+            echo "::error::could not download ${_path} from any GNU mirror" >&2
+            return 1
+          }
+          fetch "$tarball"       "$tarball"
+          fetch "${tarball}.sig" "${tarball}.sig"
 
           # Authenticate the tarball via GNU's detached OpenPGP signature.
           # Trust is anchored to Chet Ramey's release-signing key by its full

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3326,6 +3326,80 @@ _acq_msb_start_ssh_agent_bridge() {
     "mkdir -p /var/lib/acq && printf '%s' '$_sock' > /var/lib/acq/ssh-auth-sock" \
     </dev/null >/dev/null 2>&1 || true
   acq_debug "msb: ssh-agent bridge started at $_sock (vsock port $_port) in $name"
+
+  # Liveness probe (ADR-0021): the bridge + marker are now in place, but the
+  # create-time --vsock route's HOST endpoint can be STALE — most commonly after
+  # a host reboot, which restarts the host ssh-agent under a NEW socket path
+  # while the sandbox's persisted route still points at the OLD one. msb start /
+  # re-attach resume the sandbox with that persisted route; nothing re-derives
+  # it (the route is create-time only). The bridge then connects to a dead host
+  # endpoint (`socat … VSOCK-CONNECT` → "Connection reset by peer"), so the guest
+  # has SSH_AUTH_SOCK set and socat running yet `ssh-add -l` fails and signing
+  # breaks — a silent dead bridge behind a present marker. Probe once and, on
+  # failure, surface the recreate remedy instead of failing silently (repo
+  # no-silent-failure rule). Best-effort: `|| true` so a warning can NEVER abort
+  # the caller (this is the last statement of the bridge starter, which is itself
+  # the last statement of acq_backend_start, called bare under `set -euo
+  # pipefail` by the start/restart verbs — an unguarded non-zero would abort the
+  # whole verb). See ADR-0021 / docs/KNOWN_FAILURE_MODES.md §34.
+  _acq_msb_warn_if_agent_unreachable "$name" "$_sock" || true
+}
+
+# _acq_msb_warn_if_agent_unreachable NAME SOCK — probe the forwarded agent from
+# inside the guest and, if it is unreachable, print an actionable warning naming
+# the stale-route-after-reboot cause and the recreate remedy. Returns 0 when the
+# agent is reachable (or the probe cannot run), non-zero when it warned, so
+# tests can distinguish; every PRODUCTION caller MUST `|| true` this so the
+# warn-return can never abort a verb under `set -e`.
+#
+# The authoritative probe is `ssh-add -l` over the guest sock. Its exit code
+# alone is NOT enough to classify the reboot case: when the socat listener socket
+# EXISTS (the bridge is running) but its vsock backend is dead, ssh-add connects,
+# the agent protocol then fails, and ssh-add exits **1** with
+# "error fetching identities: communication with agent failed" — the SAME exit
+# code as a healthy-but-empty agent ("The agent has no identities."). Exit 2 is
+# only produced when the socket path itself cannot be opened, which is not this
+# scenario (the bridge socket is present). So we classify on the MESSAGE:
+#   - exit 0                                  -> reachable, has keys        (quiet)
+#   - "no identities" / "has no identities"   -> reachable, empty keyring   (quiet)
+#   - anything else on failure (incl. the
+#     "communication with agent failed" text
+#     and a bare exit 2)                      -> dead bridge/route          (WARN)
+# A path-compare against the create-time host_socket is deliberately NOT used:
+# the host agent socket path is platform-dependent (launchd may keep it stable;
+# a plain ssh-agent rotates it), so only a live connect is authoritative. See
+# ADR-0021.
+_acq_msb_warn_if_agent_unreachable() {
+  local name="$1" _sock="$2"
+  # Need ssh-add in the guest to probe; if it is absent, skip silently (the
+  # forward may still be fine — we simply cannot assert it here).
+  msb exec "$name" -u agent -- sh -c 'command -v ssh-add >/dev/null 2>&1' \
+    </dev/null >/dev/null 2>&1 || return 0
+  # Capture combined output AND exit status. Give the freshly-started socat a
+  # brief moment to establish its listener before probing (a fresh create can
+  # race the probe); a short bounded wait, not a fixed 1s tax on the common
+  # already-running reattach where the listener is already up.
+  local _out="" _rc=0
+  _out=$(msb exec "$name" -u agent -- sh -c \
+    "for _i in 1 2 3; do SSH_AUTH_SOCK='$_sock' ssh-add -l 2>&1 && exit 0; sleep 0.3; done; SSH_AUTH_SOCK='$_sock' ssh-add -l 2>&1" \
+    </dev/null 2>/dev/null) || _rc=$?
+  # Reachable with keys => quiet.
+  [ "$_rc" = "0" ] && return 0
+  # Reachable but empty keyring (exit 1 with the "no identities" message) => quiet.
+  case "$_out" in
+    *"no identities"*) return 0 ;;
+  esac
+  # Otherwise: cannot talk to the agent (dead bridge/route — the reboot case,
+  # whose message is "communication with agent failed", exit 1; or a bare
+  # "cannot open a connection" exit 2). Warn with the recreate remedy.
+  echo "acq(msb): warning: the forwarded host ssh-agent is UNREACHABLE from the guest" \
+       "in '$name' (the create-time --vsock route's host endpoint is stale — most" \
+       "commonly after a HOST REBOOT, which gives the host ssh-agent a new socket" \
+       "path while the sandbox keeps the old one). SSH_AUTH_SOCK is set but git" \
+       "signing will fail. The --vsock route is create-time only, so recreate the" \
+       "sandbox to refresh it: 'acq rm $name' then re-run your 'acq run …' (with" \
+       "SSH_AUTH_SOCK set). See ADR-0021 / docs/KNOWN_FAILURE_MODES.md §34." >&2
+  return 1
 }
 
 # _acq_msb_ssh_auth_sock_for NAME — echo the recorded guest ssh-agent sock path

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1807,6 +1807,51 @@ created *with* the route now re-injects `SSH_AUTH_SOCK` on every re-attach witho
 a manual export. See [ADR-0021](adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md)
 ("Re-attach to a running sandbox").
 
+### Variant: forwarded agent unreachable after a host reboot (stale `--vsock` route)
+
+Another distinct signature, and the one that a manual
+`export SSH_AUTH_SOCK=…` does **not** fix: signing worked before, then after the
+**host machine was rebooted** (especially an unclean reboot that did not stop the
+sandbox first) a resume + re-attach leaves the guest unable to reach the agent —
+`ssh-add -l` inside the guest returns `error fetching identities: communication
+with agent failed`, and committing fails to sign — even though `SSH_AUTH_SOCK` is
+set on both the host and in the guest, the host agent holds the key, and the
+in-guest `socat` bridge is running. Probing the bridge by hand shows the tell:
+
+```
+$ socat -T2 - VSOCK-CONNECT:2:3552 </dev/null
+E connect(…, cid:2 port:3552, …): Connection reset by peer
+```
+
+`Connection reset by peer` on the vsock connect means **the host side of the
+route has no live listener**. The `--vsock HOST_PATH:3552` route is emitted
+**only at create time** and pins `HOST_PATH` to the host's `SSH_AUTH_SOCK` path
+captured then; it is persisted in the sandbox config and **never re-derived** on
+`msb start` or re-attach. A host reboot restarts the host ssh-agent under a *new*
+socket path, so the persisted route now points at a dead host endpoint. This is
+distinct from the previous variant: there the guest env var was missing; here the
+env var and bridge are present but the route's host end is dead.
+
+`acq` now **detects and reports** this instead of leaving a silent dead bridge:
+after (re)starting the bridge, `_acq_msb_start_ssh_agent_bridge` runs a liveness
+probe (`ssh-add -l` over the guest sock) and, on failure, prints an actionable
+warning naming the host-reboot cause and the remedy. Because the bridge's
+listener socket is present (only its vsock backend is dead), `ssh-add` exits **1**
+with `communication with agent failed` here — the same exit code as a healthy but
+empty agent, so the probe classifies on the message (a "no identities" reply is
+treated as healthy and stays quiet). The `--vsock` route is create-time only, so
+the fix is to **recreate the sandbox** to refresh the route:
+
+```bash
+acq rm <sandbox>
+# then re-run your original create/run WITH the host agent available:
+eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_ed25519   # if needed
+acq run <agent> <workspace…>
+```
+
+See [ADR-0021](adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md)
+("Re-attach to a running sandbox") for the full mechanism.
+
 ---
 
 ## 35. Re-attach Heal Loop Warns Every Time on sbx 0.38 — `sbx kit add` Refuses Startup-Bearing Kits

--- a/docs/adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md
+++ b/docs/adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md
@@ -165,6 +165,46 @@ re-drive runs the exact provision sequence (`_acq_msb_check_socat` then
 `_acq_msb_start_ssh_agent_bridge`), which restarts the bridge and writes the
 marker, so the subsequent attach injects `SSH_AUTH_SOCK`.
 
+### Stale route after a host reboot (detect-and-report)
+
+The `--vsock HOST_PATH:PORT` route pins `HOST_PATH` to the host's
+`SSH_AUTH_SOCK` path **captured at create time**; it is persisted in the sandbox
+config and is **never re-derived** on `msb start` or re-attach (the route is
+create-time only). A **host reboot** restarts the host ssh-agent under a *new*
+socket path, so the persisted route's host endpoint goes dead. Resume + re-attach
+faithfully restart the in-guest bridge and re-write the marker (the running-
+reattach fix above), but the bridge then connects to a dead host endpoint
+(`socat … VSOCK-CONNECT` → "Connection reset by peer"): the guest has
+`SSH_AUTH_SOCK` set and `socat` running, yet `ssh-add -l` fails and signing
+breaks — a silent dead bridge behind a present marker.
+
+Because the route cannot be updated on a running sandbox (create-time only), acq
+cannot transparently heal this; the honest remedy is a recreate. Rather than fail
+silently (repo no-silent-failure rule), `_acq_msb_start_ssh_agent_bridge` runs a
+**liveness probe** after (re)placing the bridge/marker
+(`_acq_msb_warn_if_agent_unreachable`): it runs `ssh-add -l` over the guest sock
+and classifies the result. Exit code alone is insufficient — because when the
+socat *listener socket exists* (the bridge is running) but its vsock backend is
+dead, `ssh-add` connects, the agent protocol then fails, and it exits **1** with
+`error fetching identities: communication with agent failed` — the **same exit
+code** as a healthy-but-empty agent (`The agent has no identities.`). Exit 2 is
+produced only when the socket path itself cannot be opened, which is *not* the
+reboot case (the bridge socket is present). The probe therefore classifies on the
+**message**: exit 0 (has keys) and exit 1 with a "no identities" message are both
+healthy and stay quiet; anything else on failure — the "communication with agent
+failed" text, or a bare exit 2 — is treated as a dead bridge/route and warns with
+the `acq rm` + re-run remedy. The warn-return is `|| true`-guarded at the call
+site so it can never abort a verb under `set -e`. A short bounded retry (3×0.3s)
+absorbs a fresh-create race without taxing the common already-running reattach.
+The probe skips silently when `ssh-add` is absent in the guest (it cannot assert
+either way). A path-compare against the create-time `host_socket` is deliberately
+not used — the host agent socket path is platform-dependent (launchd may keep it
+stable; a plain `ssh-agent` rotates it), so only a live connect is
+authoritative. Refreshing the route automatically on resume is left as future
+work pending an msb capability to update a `--vsock` route in place. See
+`docs/KNOWN_FAILURE_MODES.md` §34 ("forwarded agent unreachable after a host
+reboot").
+
 ### Version gate (MIN_MSB_VERSION stays 0.6.8)
 
 `--vsock` first appears in **msb 0.6.9**. The global `MIN_MSB_VERSION` floor stays

--- a/scripts/test-acq-lib.sh
+++ b/scripts/test-acq-lib.sh
@@ -333,6 +333,37 @@ case "$_msb_sub" in
       # VSOCK-CONNECT:2:<port>`) started by _acq_msb_start_ssh_agent_bridge.
       # Model a successful bridge start (exit 0). Match BEFORE the generic cases.
       *"socat UNIX-LISTEN"*) exit 0 ;;
+      # ADR-0021: the forwarded-agent liveness probe run by
+      # _acq_msb_warn_if_agent_unreachable. The probe reads BOTH ssh-add's exit
+      # code AND its message, because the reboot dead-bridge case and a healthy
+      # empty keyring BOTH exit 1 — only the text disambiguates them (real
+      # ssh-add: dead backend => exit 1 "...communication with agent failed";
+      # empty keyring => exit 1 "The agent has no identities."; missing socket =>
+      # exit 2 "Error connecting to agent..."). The guest command runs
+      # `ssh-add -l 2>&1`, folding stderr into stdout, so the message is on the
+      # msb-exec STDOUT that acq captures — model that by emitting EVERY message
+      # to STDOUT here (the stub's stdout == the outer msb-exec stdout).
+      #   default                       -> exit 0, "<key>"          (has keys; quiet)
+      #   STUB_AGENT_NO_KEYS=1          -> exit 1, "no identities"  (empty; quiet)
+      #   STUB_AGENT_UNREACHABLE=1      -> exit 1, "communication with agent failed"
+      #                                     (the reboot dead-bridge case; WARN)
+      #   STUB_AGENT_NO_SOCKET=1        -> exit 2, "Error connecting to agent"
+      #                                     (socket path gone; WARN)
+      # The probe retries up to 3x then does a final `ssh-add -l`; every attempt
+      # hits this same arm, so a stable knob yields a stable classification. This
+      # arm MUST precede the generic `command -v` catch-all so `command -v ssh-add`
+      # (probed first, present by default) is unaffected while the -l probe is
+      # controllable.
+      *"ssh-add -l"*)
+        if [ "${STUB_AGENT_UNREACHABLE:-0}" = "1" ]; then
+          printf 'error fetching identities: communication with agent failed\n'; exit 1
+        elif [ "${STUB_AGENT_NO_SOCKET:-0}" = "1" ]; then
+          printf 'Error connecting to agent: No such file or directory\n'; exit 2
+        elif [ "${STUB_AGENT_NO_KEYS:-0}" = "1" ]; then
+          printf 'The agent has no identities.\n'; exit 1
+        else
+          printf '256 SHA256:stubkey stub@host (ED25519)\n'; exit 0
+        fi ;;
       *"command -v"*) : ;;          # prereqs "present" (empty missing set)
       *"npm install"*)
         [ "${STUB_NPM_FAIL:-0}" = "1" ] && exit 1 || exit 0 ;;

--- a/test/bats/115-ssh-agent-forward.bats
+++ b/test/bats/115-ssh-agent-forward.bats
@@ -382,6 +382,111 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   assert_output --partial 'RC=1'
 }
 
+@test "vsock(10c19): a stale --vsock route (host reboot) warns with the recreate remedy, not silently" {
+  # After the bridge + marker are (re)placed, the forwarded-agent liveness probe
+  # runs `ssh-add -l` over the guest sock. The reboot dead-bridge signature is
+  # exit 1 with "communication with agent failed" (the socat listener socket is
+  # PRESENT, but its vsock backend is dead, so ssh-add connects then the agent
+  # protocol fails — NOT exit 2, which is only a missing socket). The starter
+  # must classify that as unreachable and SURFACE the recreate remedy.
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9 STUB_AGENT_UNREACHABLE=1
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _ACQ_MSB_SSH_AGENT_FORWARDING=1
+    _acq_msb_start_ssh_agent_bridge stalebox 2>&1
+    wait
+  '
+  assert_output --partial 'UNREACHABLE'
+  assert_output --partial 'HOST REBOOT'
+  assert_output --partial 'acq rm stalebox'
+}
+
+@test "vsock(10c19b): a missing agent socket (exit 2) also warns" {
+  # The other unreachable shape: the socket path itself cannot be opened,
+  # ssh-add exits 2 "Error connecting to agent". Must also warn.
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9 STUB_AGENT_NO_SOCKET=1
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _ACQ_MSB_SSH_AGENT_FORWARDING=1
+    _acq_msb_start_ssh_agent_bridge nosockbox 2>&1
+    wait
+  '
+  assert_output --partial 'UNREACHABLE'
+  assert_output --partial 'acq rm nosockbox'
+}
+
+@test "vsock(10c20): a reachable forwarded agent produces NO stale-route warning" {
+  # Default stub models ssh-add -l as reachable WITH keys (exit 0); the starter
+  # must stay quiet — no false stale-route warning on a healthy bridge.
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _ACQ_MSB_SSH_AGENT_FORWARDING=1
+    _acq_msb_start_ssh_agent_bridge livebox 2>&1
+    wait
+  '
+  refute_output --partial 'UNREACHABLE'
+  # Reachable but EMPTY keyring: exit 1 WITH the "no identities" message. This is
+  # a HEALTHY agent (just no keys loaded) and MUST NOT warn — the discriminator
+  # from the reboot case (also exit 1) is the message text, not the exit code.
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9 STUB_AGENT_NO_KEYS=1
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _ACQ_MSB_SSH_AGENT_FORWARDING=1
+    _acq_msb_start_ssh_agent_bridge emptybox 2>&1
+    wait
+  '
+  refute_output --partial 'UNREACHABLE'
+}
+
+@test "vsock(10c20b): the warn-return never aborts the caller under set -e" {
+  # _acq_msb_warn_if_agent_unreachable returns non-zero when it warns; every
+  # production caller must `|| true` it so a warning cannot abort a verb under
+  # `set -euo pipefail`. Assert the bridge starter (its caller) still returns 0
+  # even when the probe warns.
+  run bash -c '
+    set -euo pipefail
+    export STUB_MSB_VERSION=0.6.9 STUB_AGENT_UNREACHABLE=1
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _ACQ_MSB_SSH_AGENT_FORWARDING=1
+    _acq_msb_start_ssh_agent_bridge abortbox >/dev/null 2>&1
+    printf "RC=%s\n" "$?"
+    wait
+  '
+  assert_output --partial 'RC=0'
+}
+
+@test "vsock(10c21): the liveness probe is skipped (no warning) when ssh-add is absent in the guest" {
+  # Without ssh-add in the guest the probe cannot run; it must SKIP silently
+  # rather than warn (the forward may still be fine — we just cannot assert it).
+  local pq="$STUBDIR/pq21"; mkdir -p "$pq"
+  cat >"$pq/msb" <<'PQ'
+#!/usr/bin/env bash
+snip=""; prev=""; for a in "$@"; do [ "$prev" = "-c" ] && { snip="$a"; break; }; prev="$a"; done
+case "$1" in --version) echo "msb 0.6.9"; exit 0;; esac
+case "$snip" in
+  *"command -v ssh-add"*) exit 1 ;;   # ssh-add ABSENT
+  *) exit 0 ;;
+esac
+PQ
+  chmod +x "$pq/msb"
+  run bash -c '
+    export STUB_MSB_VERSION=0.6.9
+    export PATH="'"$pq"':$PATH"
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _acq_msb_warn_if_agent_unreachable skipbox /home/agent/.acq/ssh-agent.sock 2>&1
+    printf "RC=%s\n" "$?"
+  '
+  refute_output --partial 'UNREACHABLE'
+  assert_output --partial 'RC=0'
+}
+
 @test "msb: the base-image prereq check warns on missing tools, silent when present or skipped" {
   local pq="$STUBDIR/pq"; mkdir -p "$pq"
   cat >"$pq/msb" <<'PQ'


### PR DESCRIPTION
> AI-assisted (OpenCode). Human-owned and reviewed per repo AI-contribution policy.

Fixes GSA-TTS/agentic-coding-quickstart#413.

## Context

On the **msb** backend, after a **host reboot** (especially an unclean one that did not stop the sandbox first), resuming the sandbox and re-attaching leaves the guest **unable to reach the host ssh-agent**, so git signing fails — even though `SSH_AUTH_SOCK` is set on both host and guest, the host agent holds the key, and the in-guest `socat` bridge is running.

This is a **distinct failure from #392**. #392 fixed the *`SSH_AUTH_SOCK` env-var injection* on running-reattach (restart the bridge + write the `/var/lib/acq/ssh-auth-sock` marker) — that works. This is one layer deeper: the `--vsock HOST_PATH:3552` route is emitted **only at create time** and pins `HOST_PATH` to the host's `SSH_AUTH_SOCK` path captured *then*; it is persisted and **never re-derived** on `msb start` / re-attach. A reboot restarts the host ssh-agent under a new socket path, so the persisted route's host endpoint is dead. The bridge faithfully restarts and connects to that dead endpoint (`socat … VSOCK-CONNECT` → "Connection reset by peer"), leaving a **silent dead bridge behind a present marker**.

## Change

The `--vsock` route is **create-time only** and cannot be refreshed on a running sandbox, so acq cannot transparently heal this — the honest remedy is a recreate. Instead of failing silently (repo no-silent-failure rule), add a **liveness probe** in `_acq_msb_start_ssh_agent_bridge` (`_acq_msb_warn_if_agent_unreachable`) that runs after the bridge is (re)started and, when the forwarded agent is unreachable, prints an **actionable warning** naming the host-reboot cause and the `acq rm` + re-run remedy.

Key correctness detail (surfaced in review): the probe **classifies on the `ssh-add -l` message, not the exit code alone**. When the socat listener socket *exists* but its vsock backend is dead, `ssh-add` connects and then the agent protocol fails — it exits **1** with `communication with agent failed`, the **same exit code** as a healthy-but-empty agent (`The agent has no identities.`). Exit 2 is only a missing socket, which is not this scenario. So:

- exit 0 (has keys) → quiet
- exit 1 with "no identities" → quiet (healthy, just no keys loaded)
- anything else on failure (the "communication with agent failed" text, or a bare exit 2) → **warn**

Other robustness fixes from review:
- The warn-return is **`|| true`-guarded at the call site** so it can never abort a verb under `set -euo pipefail` (the bridge starter is the last statement of `acq_backend_start`, called bare by `start`/`restart`). Regression test 10c20b asserts this.
- A **short bounded retry (3×0.3s)** replaces a fixed `sleep 1`, absorbing a fresh-create race without taxing the common already-running reattach.
- The probe **skips silently when `ssh-add` is absent** in the guest.

No auto-refresh of the route is attempted; that is left as future work pending an msb capability to update a `--vsock` route in place (noted in the ADR).

## Files

- `acq.backends/msb.sh` — `_acq_msb_warn_if_agent_unreachable` + call site (guarded).
- `scripts/test-acq-lib.sh` — faithful ssh-add stub knobs (`STUB_AGENT_UNREACHABLE` = exit 1 + "communication…"; `STUB_AGENT_NO_SOCKET` = exit 2; `STUB_AGENT_NO_KEYS` = exit 1 + "no identities").
- `test/bats/115-ssh-agent-forward.bats` — 10c19 (reboot dead-bridge warns), 10c19b (missing socket warns), 10c20 (healthy with/without keys quiet), 10c20b (no abort under `set -e`), 10c21 (ssh-add-absent skip).
- `docs/adr/0021-msb-host-ssh-agent-forwarding-via-vsock.md` — new "Stale route after a host reboot (detect-and-report)" section.
- `docs/KNOWN_FAILURE_MODES.md` — §34 new variant with the `VSOCK-CONNECT` "Connection reset by peer" fingerprint and the recreate remedy.

## Verification

| Check | Result |
|---|---|
| `shellcheck --severity=warning acq.backends/msb.sh scripts/test-acq-lib.sh` | clean |
| markdown lint (repo files) | 0 issues |
| `scripts/test-acq-bats` | **380 passed, 0 failed** |
| `gitleaks protect --staged` | no leaks |
| adversarial code-review sub-agent | 2 blockers found (exit-code classification; `set -e` abort) — **both fixed & re-verified** |

Real ssh-add exit-code contract was confirmed live: dead-socket-backend → exit **1** "communication with agent failed"; empty keyring → exit **1** "no identities"; missing socket → exit **2**.

## Rollback

Revert the commit. The change is additive (a new helper + one guarded call site in the bridge starter); reverting restores the prior behavior (silent dead bridge after reboot). No config/data migration.

## Security impact

Touches the ssh-agent forwarding path (ADR-0021). No new external service or data-classification change. The probe is read-only (`ssh-add -l`), consent/opt-in unchanged, and never widens the forward. It cannot forward an agent into a sandbox that wasn't created for one.

## Live-verify still needed

The probe's behavior against a **real** rebooted msb guest (a genuinely stale route) has not been exercised end-to-end on a KVM/HVF host (cannot run in CI / inside a sandbox). Suggest verifying on the next sandbox-capable-host pass; the offline suite covers the classification logic against faithful ssh-add stubs.
