### PR TITLE
chore(docs): update gsa key management url

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -2,6 +2,7 @@
   "ignorePatterns": [
     { "pattern": "^https://api\\.gsa\\.usai\\.gov" },
     { "pattern": "^https://console\\.gsa\\.usai\\.gov" },
+    { "pattern": "^https://gsa\\.usai\\.gov" },
     { "pattern": "^https://workshop\\.cloud\\.gov" },
     { "pattern": "^https?://localhost" },
     { "pattern": "^https?://127\\.0\\.0\\.1" },

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ restricted filesystem and network access. Repeat Step 3 for each project.
 On first run, `acq` sets you up interactively — nothing to configure beforehand:
 
 - **USAi key** — `acq` prompts you to paste a key and validates it. Create one at
-  the [USAi key console](https://console.gsa.usai.gov/key-management) (keys expire
+  the [USAi key console](https://gsa.usai.gov/console/key-management) (keys expire
   every 7 days).
 - **GitHub token** — when your project contains GitHub repos, `acq` offers to walk
   you through creating a repo-scoped token. You can decline and add one later.

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -93,7 +93,7 @@ KIT_SOURCE_PREFIXES=("$KIT_SOURCE_PREFIX")
 
 # USAi endpoint constants
 USAI_MODELS_URL="https://api.gsa.usai.gov/api/v1/models"
-KEY_MGMT_URL="https://console.gsa.usai.gov/key-management"
+KEY_MGMT_URL="https://gsa.usai.gov/console/key-management"
 
 # Source the shared agent catalog (single source of truth for agent tokens and
 # the sandbox-template image naming convention; issue #377). Both adapters also

--- a/docs/howto/acq.md
+++ b/docs/howto/acq.md
@@ -165,7 +165,7 @@ down or re-attach a running sandbox to swap in a fresh key — run the rotation
 command from the host and the new value is stored in `acq`'s secret store, ready
 for the next request:
 
-1. Open <https://console.gsa.usai.gov/key-management>.
+1. Open <https://gsa.usai.gov/console/key-management>.
 2. Choose **Rotate** from the **Actions** menu for your key.
 3. Copy the new key using the console **copy button** (selecting the displayed
    text by hand can truncate it).


### PR DESCRIPTION
Updates README and backends/common.sh
  - new API management URL https://gsa.usai.gov/console/key-management

## Summary

Update the key management URL in readme + common.sh

#### Before
```
Your USAi API key looks invalid or expired (HTTP 401 from the models API).
USAi keys expire every 7 days.

To rotate it:
  1. Open https://console.gsa.usai.gov/key-management
  2. Choose 'Rotate' from the Actions menu for your key
  3. Copy the new key using the console copy button

Have the new key ready to paste? Rotate now? [y/N] 
Skipping. Aborting attach; re-run when your USAi key is set.
```

#### After
```
Your USAi API key looks invalid or expired (HTTP 401 from the models API).
USAi keys expire every 7 days.

To rotate it:
  1. Open https://gsa.usai.gov/console/key-management
  2. Choose 'Rotate' from the Actions menu for your key
  3. Copy the new key using the console copy button

Have the new key ready to paste? Rotate now? [y/N] 
```