### PR TITLE
ci(release): publish verified installer assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,33 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+      - id: release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          release-type: simple
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+      - name: Check out release commit
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ steps.release.outputs.tag_name }}
+          persist-credentials: false
+
+      - name: Build release assets
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        run: |
+          set -eu
+          release_sha="$(git rev-parse HEAD)"
+          mkdir -p dist
+          cp install.sh dist/install.sh
+          sed -i "s/^DEFAULT_RELEASE_SHA=.*/DEFAULT_RELEASE_SHA=\"${release_sha}\"/" dist/install.sh
+          chmod 0755 dist/install.sh
+          (cd dist && sha256sum install.sh > SHA256SUMS)
+
+      - name: Upload release assets
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+        run: gh release upload "$RELEASE_TAG" dist/install.sh dist/SHA256SUMS --clobber

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You'll type (or paste) the commands below into this window.
 Paste this one line and press Return:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/GSA-TTS/agentic-coding-quickstart/main/install.sh | sh
+curl -fsSL https://github.com/GSA-TTS/agentic-coding-quickstart/releases/download/v2.0.0/install.sh | sh # x-release-please-version
 ```
 
 That's it — you don't have to choose *how* to install. The installer:
@@ -99,13 +99,18 @@ You never have to pipe a script straight into your shell. Download it, read it,
 then run it:
 
 ```bash
-curl -fsSL -o install-acq.sh https://raw.githubusercontent.com/GSA-TTS/agentic-coding-quickstart/main/install.sh
-less install-acq.sh      # read it
-sh install-acq.sh --dry-run   # show what it WOULD do, changing nothing
-sh install-acq.sh             # actually install
+ACQ_VERSION=2.0.0 # x-release-please-version
+curl -fsSLO "https://github.com/GSA-TTS/agentic-coding-quickstart/releases/download/v${ACQ_VERSION}/install.sh"
+curl -fsSLO "https://github.com/GSA-TTS/agentic-coding-quickstart/releases/download/v${ACQ_VERSION}/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS
+less install.sh              # read it
+sh install.sh --dry-run      # show what it WOULD do, changing nothing
+sh install.sh                # actually install
 ```
 
-You can also force a specific method with `--method brew|npm|clone`.
+The release asset pins the default clone install to the release tag and verifies
+that checkout against the release commit. You can also force a specific method
+with `--method brew|npm|clone`.
 
 </details>
 

--- a/docs/adr/0002-version-management-and-release-automation.md
+++ b/docs/adr/0002-version-management-and-release-automation.md
@@ -100,6 +100,9 @@ requirements while maintaining simplicity and being backed by Google's well-main
    - When Release PR is merged, creates git tag and GitHub release
    - Configuration in `release-please-config.json` and `.release-please-manifest.json`
    - GitHub Action: `googleapis/release-please-action`
+   - Release creation also uploads installer assets: `install.sh` with the release
+     commit SHA embedded as the default pin, plus `SHA256SUMS` for verifying the
+     downloaded installer asset
 
 4. **CHANGELOG.md Format**
    - Follow Keep a Changelog v1.1.0 format
@@ -185,8 +188,10 @@ Initially considered but rejected because:
 4. Update AGENTS.md with commit message requirements
 5. Update CODING_PRACTICES.md with version control standards
 6. Update `.github/workflows/release.yml` to use release-please
-7. Add CONTRIBUTING.md with commit message guidelines
-8. Backfill CHANGELOG for existing releases (v0.1.0, v0.2.0)
+7. Upload release installer assets (`install.sh` and `SHA256SUMS`) when a release
+   is created
+8. Add CONTRIBUTING.md with commit message guidelines
+9. Backfill CHANGELOG for existing releases (v0.1.0, v0.2.0)
 
 ## Commit Message Format Reference
 

--- a/docs/adr/0026-installation-and-distribution.md
+++ b/docs/adr/0026-installation-and-distribution.md
@@ -106,8 +106,9 @@ dependency — it only defers it:
 - **The integrity win is available without the tarball.** Git objects are
   content-addressed, so pinning the clone to a **full commit SHA** is itself a
   cryptographic integrity check — the checkout cannot succeed with tampered
-  content. That gives us hash-confirmed provenance without a second download
-  path or a separate checksum artifact to maintain.
+  content. That gives us hash-confirmed provenance without a second archive
+  install path; release automation still publishes `SHA256SUMS` for installer
+  asset verification.
 
 So the CLT dependency is unavoidable for this tool; the right move is to make it
 **painless and early** rather than to engineer around it. The installer's clone
@@ -131,8 +132,9 @@ guided step.
   clone.
 - **Never touch the user's `PATH` without consent** — offer to add the line,
   and if declined, print the exact line for them to add themselves.
-- **Federal security posture** — pinned to a release tag, published checksums,
-  inspect-first supported, no `sudo`, install into a user-writable prefix.
+- **Federal security posture** — release asset defaults pin to a release tag and
+  canonical release commit SHA, published checksums, inspect-first supported, no
+  `sudo`, install into a user-writable prefix.
 - **Preserve `acq version` introspection and easy updates** — the on-disk layout
   should keep `acq`'s git-based version reporting and support in-place updates.
 - **Minimal new surface** — reuse the existing `acq`/kit machinery and `msb`
@@ -227,10 +229,18 @@ In bounds now:
   can pin to a full 40-char commit SHA and verifies `HEAD` equals it after
   checkout, failing closed (and cleaning up) on mismatch — git objects are
   content-addressed, so a matching SHA *is* a cryptographic integrity check.
+- **Release asset commit-SHA pinning by default.** `release-please` updates the
+  installer release version marker. When a release is created, the release
+  workflow checks out the release commit, writes that exact commit SHA into the
+  `install.sh` asset, generates `SHA256SUMS`, and uploads both files to the
+  GitHub release. Users who install from the release asset get a default clone
+  target of the release tag plus a default `--sha`-equivalent integrity check
+  against the release commit.
 - **release-please manages `package.json`'s `version`.** An `extra-files` entry in
   `release-please-config.json` bumps `$.version` on each release so the npm
   package version tracks the release manifest (currently `2.0.0`) instead of a
-  hand-maintained placeholder.
+  hand-maintained placeholder. A second `extra-files` entry bumps the installer
+  release version marker so its default ref follows the package version.
 - README streamlining + install instructions.
 
 Deferred — only the work that **must** happen outside this repository (tracked
@@ -239,44 +249,31 @@ as issues):
 - Creating the `GSA-TTS/homebrew-tap` repository and the `acq` formula, then
   un-stubbing the installer's brew branch. (External repo — cannot be done from
   this repo; tracked as an issue.)
-- Release-automation changes to attach `SHA256SUMS` to each release, then swap
-  the README install URL from `main` to a pinned release tag.
-- **Default the clone to a canonical commit SHA per release.** The `--sha`
-  mechanism is now in place (see "in bounds" above); what remains is for release
-  automation to publish the canonical SHA for each version so the installer can
-  default to it rather than a movable ref.
 
 ### Security posture
 
 - **No `sudo`.** Everything installs under the user's home; the `PATH` dir is
   user-writable.
-- **Pinning is available today, but not yet the default.** The installer accepts
-  `--ref <tag>` and `--sha <full-commit>` (the latter is integrity-checked against
-  the checked-out `HEAD`, failing closed on mismatch — a content-addressed check).
-  **Until the first release ships `install.sh`, the default `REF` is `main`** —
-  a moving target, deliberately, because there is no release tag yet that even
-  contains this installer, and the README's `curl` URL itself fetches the script
-  from `main`. This is an honest pre-release state, **not** a pinning guarantee.
-  Flipping the default to a published release tag + a shipped canonical commit SHA
-  (so the default path is content-addressed) is tracked in
-  <https://github.com/GSA-TTS/agentic-coding-quickstart/issues/408>; that release
-  automation will move the README URL and the `REF` default together.
-- **Verifiable.** `--sha` gives content-addressed integrity today; releases will
-  additionally publish `SHA256SUMS` (#408). Inspect-first is supported (download
-  and read `install.sh` before running; `--dry-run` prints actions).
+- **Pinning is the release-asset default.** The installer accepts `--ref <tag>`
+  and `--sha <full-commit>` (the latter is integrity-checked against the checked
+  out `HEAD`, failing closed on mismatch — a content-addressed check). The source
+  tree default ref is the current release tag, while release automation publishes
+  an `install.sh` asset with the canonical release commit SHA embedded as the
+  default SHA.
+- **Verifiable.** Release automation publishes `SHA256SUMS` next to the installer
+  asset. Inspect-first is supported: download `install.sh`, verify it with
+  `SHA256SUMS`, read it, and use `--dry-run` before installing.
 - **Consent-gated side effects.** `PATH` edits and `msb` installation each
   require explicit consent; declining is always a safe, documented fallback.
 - **Idempotent.** Re-running updates an existing install rather than duplicating
   it.
-- **Two unpinned legs today, both called out honestly.** (1) The default `REF`
-  is `main` until #408 lands, as described above — opt into `--ref`/`--sha` for a
-  verifiable install now. (2) The optional `msb` install, when no Homebrew is
-  present, runs the upstream `curl -fsSL https://install.microsandbox.dev | sh`;
-  that upstream installer is outside our control and is not pinned/checksummed by
-  us. Both are consent-gated (and, under `--yes`, authorized by the same blanket
-  opt-in as the `PATH` edit). The `acq` clone/npm install resolve whatever `REF`
-  resolves to — so their supply-chain guarantee is exactly as strong as the `REF`
-  the user chooses (pinned when `--ref`/`--sha` is supplied; `main` otherwise).
+- **One remaining unpinned leg, called out honestly.** The optional `msb` install,
+  when no Homebrew is present, runs the upstream
+  `curl -fsSL https://install.microsandbox.dev | sh`; that upstream installer is
+  outside our control and is not pinned/checksummed by us. It is consent-gated
+  (and, under `--yes`, authorized by the same blanket opt-in as the `PATH` edit).
+  The `acq` clone install is pinned by default when the release asset is used;
+  npm and explicit `--ref` overrides resolve the ref the user chooses.
 
 > **Control Mapping:** CM-2 (Baseline Configuration), CM-3 (Configuration Change
 > Control), CM-6 (Configuration Settings), SA-8 (Security Engineering
@@ -293,8 +290,9 @@ as issues):
   circles; we mitigate with pinning, checksums, inspect-first, no-`sudo`, and
   consent gates, but cannot fully eliminate the pattern short of the deferred
   signed `.pkg`.
-- **Maintenance:** each release must publish `SHA256SUMS`, and (once the tap
-  lands) the formula must track releases. Both are deferred follow-ups.
+- **Maintenance:** release automation must keep publishing `SHA256SUMS`, and
+  (once the tap lands) the formula must track releases. The formula work remains
+  deferred because it lives outside this repository.
 
 ## Validation
 
@@ -317,15 +315,21 @@ as issues):
 - **release-please version sync:** `release-please-config.json` carries an
   `extra-files` entry (`type: json`, `jsonpath: $.version`) so the next release
   bumps `package.json`'s `version`; `npm pack --dry-run` reports the manifest
-  version (`2.0.0`) rather than a placeholder.
+  version (`2.0.0`) rather than a placeholder. A generic extra-file marker keeps
+  `install.sh`'s `DEFAULT_RELEASE_VERSION` aligned with the release version.
+- **Release assets:** on release creation, `.github/workflows/release.yml` checks
+  out the release commit, copies `install.sh`, injects that exact commit into the
+  release asset's `DEFAULT_RELEASE_SHA`, generates `SHA256SUMS`, and uploads both
+  assets to the GitHub release.
 - **Manual (bare-Mac reviewer):** on a clean macOS account, run the pinned
   one-liner; confirm `acq` resolves on `PATH` (after accepting the offered
   `PATH` line or adding the printed line), `acq version` reports the pinned
   `branch@commit`, and `--dry-run` performs no writes. Decline paths (`PATH`
   edit declined, `--no-msb`) leave a working `acq` and print correct guidance.
-- **Live end-to-end:** deferred to the release that publishes `SHA256SUMS` and
-  hosts `install.sh` at a pinned raw URL, since the hosted-URL + checksum flow
-  cannot be exercised until those artifacts exist.
+- **Live end-to-end:** verify after the first release containing this automation
+  is published by downloading the `install.sh` and `SHA256SUMS` release assets,
+  checking the checksum, and confirming `sh install.sh --dry-run --method clone`
+  reports the release tag and canonical commit SHA.
 
 ## Links
 
@@ -343,5 +347,3 @@ as issues):
 
 - Homebrew tap + formula (un-stub the brew branch):
   <https://github.com/GSA-TTS/agentic-coding-quickstart/issues/407>
-- Release automation (`SHA256SUMS`, canonical release SHA, pin README/installer):
-  <https://github.com/GSA-TTS/agentic-coding-quickstart/issues/408>

--- a/install.sh
+++ b/install.sh
@@ -20,9 +20,10 @@
 # installation-and-distribution ADR under docs/adr/.
 #
 # Usage:
-#   curl -fsSL <pinned-raw-url>/install.sh | sh
+#   curl -fsSL <release-asset-url>/install.sh | sh
 #   sh install.sh [--method brew|npm|clone] [--ref <tag-or-branch>]
-#                 [--no-msb] [--dry-run] [--yes] [--help]
+#                 [--sha <full-commit>] [--no-msb] [--dry-run] [--yes]
+#                 [--help]
 #
 # Inspect first (recommended): download and read this file, then run it.
 
@@ -33,18 +34,18 @@ set -eu
 # ---------------------------------------------------------------------------
 
 REPO_URL="${ACQ_INSTALL_REPO_URL:-https://github.com/GSA-TTS/agentic-coding-quickstart.git}"
-# Default to `main` for now. This is a rolling-release default: `main` is a
-# moving target, NOT a pinned, content-addressed reference. For a verifiable
-# install, pass --ref <tag> or --sha <commit> (the latter is integrity-checked
-# after checkout). Defaulting to a published release tag + shipped SHA is
-# tracked follow-up work; see ADR-0026 and its deferred-work tracking section.
-REF="${ACQ_INSTALL_REF:-main}"
+# release-please updates this version in release PRs. Release automation also
+# publishes an install.sh asset with DEFAULT_RELEASE_SHA replaced by the exact
+# release commit so the default clone path is content-addressed.
+DEFAULT_RELEASE_VERSION="2.0.0" # x-release-please-version
+DEFAULT_RELEASE_REF="v$DEFAULT_RELEASE_VERSION"
+DEFAULT_RELEASE_SHA=""
+REF="${ACQ_INSTALL_REF:-$DEFAULT_RELEASE_REF}"
 
-# Optional: pin to an exact 40-char commit SHA. When set, the clone method
-# verifies the checked-out HEAD equals this SHA and fails closed otherwise —
-# git objects are content-addressed, so a matching SHA *is* an integrity check
-# (no separate checksum file needed). See ADR-0026.
-SHA="${ACQ_INSTALL_SHA:-}"
+# Optional: pin to an exact 40-char commit SHA. Release assets set this to the
+# release commit by default; source checkouts leave it empty so local/dev installs
+# can still target REF unless ACQ_INSTALL_SHA or --sha is supplied.
+SHA="${ACQ_INSTALL_SHA:-$DEFAULT_RELEASE_SHA}"
 
 # Where the managed clone lives (preserves `acq version` git introspection).
 DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
@@ -106,8 +107,8 @@ a git clone. Override with --method.
 
 Options:
   --method <m>         Force install method: brew | npm | clone (default: auto).
-  --ref <tag|branch>   Version to install (default: main — a moving target;
-                       pass a release tag for a stable, repeatable install).
+  --ref <tag|branch>   Version to install (default: latest release tag baked
+                       into this installer).
   --sha <commit>       Pin to a full 40-char commit SHA and verify HEAD matches
                        it after checkout (content-addressed integrity check).
   --no-msb             Do not install the msb sandbox runtime.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "acq.backends/"
   ],
   "scripts": {
-    "lint:md": "npx --prefix .github/linters markdownlint-cli2 '**/*.md' '#node_modules' '#.github/linters/node_modules' '#CHANGELOG.md' '#tmp'",
+    "lint:md": "npx --prefix .github/linters markdownlint-cli2 '**/*.md' '#node_modules' '#.github/linters/node_modules' '#CHANGELOG.md' '#tmp' '#test/vendor'",
     "lint:secrets": "gitleaks detect --source .",
     "lint": "npm run lint:md",
     "check": "pre-commit run --all-files"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,14 @@
           "type": "json",
           "path": "package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "generic",
+          "path": "install.sh"
+        },
+        {
+          "type": "generic",
+          "path": "README.md"
         }
       ]
     }

--- a/test/bats/05-install.bats
+++ b/test/bats/05-install.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+load './helper.bash'
+
+setup() {
+  acq_setup_stubs
+  export HOME="$BATS_TEST_TMPDIR/home"
+  mkdir -p "$HOME" "$STUBDIR/bin"
+  export PATH="$STUBDIR/bin:$PATH"
+  export ACQ_INSTALL_CLONE_DIR="$BATS_TEST_TMPDIR/acq-clone"
+  export ACQ_INSTALL_BIN_DIR="$BATS_TEST_TMPDIR/bin"
+}
+
+teardown() {
+  acq_teardown_stubs
+}
+
+_write_git_stub() {
+  cat >"$STUBDIR/bin/git" <<'STUB'
+#!/usr/bin/env bash
+set -eu
+log=${GIT_STUB_LOG:?}
+printf '%s\n' "$*" >>"$log"
+
+case "$1" in
+  --version)
+    printf 'git version 2.40.0\n'
+    ;;
+  clone)
+    # shellcheck disable=SC2124
+    dest=${@: -1}
+    mkdir -p "$dest/.git"
+    printf '#!/bin/sh\n' >"$dest/acq"
+    chmod +x "$dest/acq"
+    ;;
+  -C)
+    repo=$2
+    shift 2
+    case "$1" in
+      checkout)
+        mkdir -p "$repo/.git"
+        printf '%s\n' "$2" >"$repo/.git/head"
+        ;;
+      rev-parse)
+        cat "$repo/.git/head"
+        ;;
+      fetch|pull|symbolic-ref)
+        ;;
+      *)
+        printf 'unexpected git -C command: %s\n' "$*" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    printf 'unexpected git command: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$STUBDIR/bin/git"
+}
+
+@test "install: source default targets release tag without a pinned sha" {
+  export GIT_STUB_LOG="$BATS_TEST_TMPDIR/git.log"
+  _write_git_stub
+
+  run env ACQ_INSTALL_REF= ACQ_INSTALL_SHA= sh "$REPO_ROOT/install.sh" \
+    --method clone --no-msb --dry-run --yes
+
+  assert_success
+  assert_output --partial 'version:   v2.0.0'
+  refute_output --partial 'pinned commit:'
+}
+
+@test "install: release asset default sha verifies clone checkout" {
+  export GIT_STUB_LOG="$BATS_TEST_TMPDIR/git.log"
+  _write_git_stub
+  release_sha=0123456789abcdef0123456789abcdef01234567
+  release_installer="$BATS_TEST_TMPDIR/install-release.sh"
+  sed "s/^DEFAULT_RELEASE_SHA=.*/DEFAULT_RELEASE_SHA=\"$release_sha\"/" \
+    "$REPO_ROOT/install.sh" >"$release_installer"
+
+  run sh "$release_installer" --method clone --no-msb --yes
+
+  assert_success
+  assert_output --partial "version:   v2.0.0"
+  assert_output --partial "pinned commit: $release_sha"
+  assert_output --partial "verified HEAD matches pinned commit $release_sha"
+}


### PR DESCRIPTION
## Context
Implements GSA-TTS/agentic-coding-quickstart#408 by moving installer distribution from a moving raw `main` URL to release assets that can be verified and pinned.

## What changed
- Release workflow now runs release-please in manifest config mode and uploads release assets when a release is created.
- Release asset build copies `install.sh`, injects the exact release commit SHA into `DEFAULT_RELEASE_SHA`, generates `SHA256SUMS`, and uploads both files to the GitHub release.
- Installer defaults to the current release tag via release-please-managed `DEFAULT_RELEASE_VERSION`; release assets add the canonical commit SHA pin.
- README install examples now use pinned release asset URLs and document checksum verification.
- ADR-0002 and ADR-0026 document the release asset/checksum behavior.
- Added installer Bats coverage for release-tag defaults and release-asset SHA verification.
- Excluded vendored Bats submodule Markdown from `npm run lint:md`, since initialized third-party submodules should not be normalized by this repo.

## Verification
- `shellcheck --severity=warning install.sh test/bats/05-install.bats` — passed.
- `./scripts/test-acq-bats test/bats/05-install.bats` — passed, 2 tests.
- `./scripts/test-acq-bats` — passed, 394 tests.
- `npm run lint:md` — passed, 0 issues.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/release.yml")'` — passed.
- `git diff --check` — passed.
- Simulated release asset generation with SHA injection and `shasum -a 256 -c SHA256SUMS` — passed.

## Rollback
Revert this PR. The installer will return to the previous raw `main` URL/default-ref behavior and release-please will stop uploading installer assets.

## Security impact
Positive supply-chain impact: release downloads become checksum-verifiable, and release installer assets default clone installs to a release tag plus an exact release commit SHA check. No authn/authz runtime paths, secret handling paths, or sandbox permissions are broadened.

## AI assistance
AI-assisted implementation with human review required before merge.
