### PR TITLE
feat(install): enable homebrew tap install

### DIFF
--- a/docs/adr/0026-installation-and-distribution.md
+++ b/docs/adr/0026-installation-and-distribution.md
@@ -174,15 +174,11 @@ requires an Apple Developer ID certificate and notarization pipeline — an
 organizational hurdle out of scope for this increment. Revisit if the
 installer proves insufficient.
 
-> **Increment note:** in this PR the **npm branch is fully wired** (the
-> `package.json` `bin`/`files` fields ship an `acq` launcher, so
-> `npm install -g github:GSA-TTS/agentic-coding-quickstart` puts `acq` on
-> `PATH`). The **brew branch is stubbed** — the installer detects `brew` and
-> reports what it *would* run, but the formula lives in a separate
-> `GSA-TTS/homebrew-tap` repository that does not exist yet (deferred below). The
-> **clone fallback is fully functional**, so the front door works end-to-end
-> today regardless of which method is selected; the brew branch lights up once
-> the tap is created.
+> **Increment note:** the **brew** and **npm** branches are wired. Homebrew uses
+> `brew install GSA-TTS/tap/acq`; npm uses the `package.json` `bin`/`files`
+> fields so `npm install -g github:GSA-TTS/agentic-coding-quickstart` puts `acq`
+> on `PATH`. The **clone fallback is fully functional**, so the front door works
+> end-to-end today regardless of which method is selected.
 
 ### On-disk layout
 
@@ -222,8 +218,7 @@ In bounds now:
 
 - This ADR (`0026`, `status: accepted`).
 - `install.sh` — the hardened installer with brew → npm → clone auto-selection
-  (the **clone** and **npm** branches fully functional; the **brew branch
-  stubbed** pending the external tap repo).
+  (the **brew**, **npm**, and **clone** branches fully functional).
 - `package.json` `bin`/`files` wiring so the npm branch actually installs `acq`.
 - **Optional commit-SHA pinning** (`--sha` / `ACQ_INSTALL_SHA`). The clone method
   can pin to a full 40-char commit SHA and verifies `HEAD` equals it after
@@ -246,9 +241,8 @@ In bounds now:
 Deferred — only the work that **must** happen outside this repository (tracked
 as issues):
 
-- Creating the `GSA-TTS/homebrew-tap` repository and the `acq` formula, then
-  un-stubbing the installer's brew branch. (External repo — cannot be done from
-  this repo; tracked as an issue.)
+- Creating the `GSA-TTS/homebrew-tap` repository and the `acq` formula.
+  (External repo — cannot be done from this repo; tracked as an issue.)
 
 ### Security posture
 
@@ -347,5 +341,5 @@ as issues):
 
 ### Deferred-work tracking
 
-- Homebrew tap + formula (un-stub the brew branch):
+- Homebrew tap + formula:
   <https://github.com/GSA-TTS/agentic-coding-quickstart/issues/407>

--- a/docs/howto/acq.md
+++ b/docs/howto/acq.md
@@ -202,8 +202,8 @@ The one-line installer detects Homebrew and npm automatically. To run the direct
 command yourself:
 
 ```bash
-npm install -g github:GSA-TTS/agentic-coding-quickstart   # if you use Node/npm — works today
-brew install GSA-TTS/tap/acq                              # if you use Homebrew — coming soon (tap not published yet)
+npm install -g github:GSA-TTS/agentic-coding-quickstart   # if you use Node/npm
+brew install GSA-TTS/tap/acq                              # if you use Homebrew
 ```
 
 Package-manager installs give you `upgrade`/`uninstall` for free.

--- a/install.sh
+++ b/install.sh
@@ -14,11 +14,6 @@
 # needed). It never uses `sudo`, installs only under your home directory, and
 # never changes your PATH without asking first.
 #
-# NOTE: In this increment the npm and clone branches are fully functional. The
-# brew branch is a stub (the Homebrew tap repo does not exist yet) that falls
-# back to the clone install, so no path leaves the user without acq. See the
-# installation-and-distribution ADR under docs/adr/.
-#
 # Usage:
 #   curl -fsSL <release-asset-url>/install.sh | sh
 #   sh install.sh [--method brew|npm|clone] [--ref <tag-or-branch>]
@@ -44,6 +39,8 @@ DEFAULT_RELEASE_VERSION="2.0.0" # x-release-please-version
 DEFAULT_RELEASE_REF="v$DEFAULT_RELEASE_VERSION"
 DEFAULT_RELEASE_SHA=""
 REF="${ACQ_INSTALL_REF:-$DEFAULT_RELEASE_REF}"
+REF_WAS_SET=0
+[ "${ACQ_INSTALL_REF+x}" = x ] && REF_WAS_SET=1
 
 # Optional: pin to an exact 40-char commit SHA. Release assets set this to the
 # release commit by default; source checkouts leave it empty so local/dev installs
@@ -96,11 +93,6 @@ run() {
   fi
 }
 
-# Show a command that is STUBBED this increment (never executed).
-stub() {
-  printf '  [stub]    %s\n' "$*"
-}
-
 usage() {
   cat <<'EOF'
 install.sh — install acq (agentic-coding-quickstart)
@@ -141,8 +133,8 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --method) [ $# -ge 2 ] || die "--method needs a value"; METHOD="$2"; shift 2 ;;
     --method=*) METHOD="${1#--method=}"; shift ;;
-    --ref) [ $# -ge 2 ] || die "--ref needs a value"; REF="$2"; shift 2 ;;
-    --ref=*) REF="${1#--ref=}"; shift ;;
+    --ref) [ $# -ge 2 ] || die "--ref needs a value"; REF="$2"; REF_WAS_SET=1; shift 2 ;;
+    --ref=*) REF="${1#--ref=}"; REF_WAS_SET=1; shift ;;
     --sha) [ $# -ge 2 ] || die "--sha needs a value"; SHA="$2"; shift 2 ;;
     --sha=*) SHA="${1#--sha=}"; shift ;;
     --no-msb) INSTALL_MSB=0; shift ;;
@@ -229,7 +221,9 @@ command -v curl >/dev/null 2>&1 || die "curl is required but was not found."
 # ---------------------------------------------------------------------------
 
 if [ "$METHOD" = "auto" ]; then
-  if command -v brew >/dev/null 2>&1; then
+  if [ -n "$SHA" ]; then
+    METHOD="clone"
+  elif command -v brew >/dev/null 2>&1 && [ "$REF_WAS_SET" -eq 0 ]; then
     METHOD="brew"
   elif command -v npm >/dev/null 2>&1; then
     METHOD="npm"
@@ -240,24 +234,38 @@ if [ "$METHOD" = "auto" ]; then
 else
   info "  install method: $METHOD (forced)"
 fi
-info "  version:   $REF"
-[ -n "$SHA" ] && info "  pinned commit: $SHA"
+
+# Homebrew versioning is controlled by the formula in the tap. Avoid pretending a
+# caller-supplied git ref can affect `brew install GSA-TTS/tap/acq`.
+if [ "$METHOD" = "brew" ] && [ "$REF_WAS_SET" -eq 1 ]; then
+  die "--ref is not supported with --method brew; use brew update/upgrade or choose --method npm|clone"
+fi
+if [ "$METHOD" = "brew" ]; then
+  info "  version:   Homebrew formula"
+else
+  info "  version:   $REF"
+  [ -n "$SHA" ] && info "  pinned commit: $SHA"
+fi
 [ "$DRY_RUN" -eq 1 ] && warn "  (dry-run: no changes will be made)"
 
 # ---------------------------------------------------------------------------
-# Method: Homebrew  (STUBBED this increment — the tap repo does not exist yet)
+# Method: Homebrew
 # ---------------------------------------------------------------------------
 
 install_via_brew() {
   step "Installing acq via Homebrew"
   info "  Homebrew gives you 'brew upgrade acq' / 'brew uninstall acq' later."
-  warn "  NOTE: the acq Homebrew tap is not published yet — this branch is a stub."
-  warn "  Falling back to the git-clone install so you still get a working acq now."
-  stub "brew install $BREW_FORMULA"
-  # The tap lives in a separate GSA-TTS/homebrew-tap repository that has to be
-  # created outside this repo; until it exists, do the real install via clone so
-  # the user is never left without acq.
-  install_via_clone
+  if [ "$DRY_RUN" -eq 0 ] && ! command -v brew >/dev/null 2>&1; then
+    die "Homebrew is required for --method brew. Install Homebrew or choose --method npm|clone."
+  fi
+  run brew install "$BREW_FORMULA"
+  if [ "$DRY_RUN" -eq 0 ] && command -v acq >/dev/null 2>&1; then
+    ok "  acq is installed via Homebrew ($(command -v acq))."
+  elif [ "$DRY_RUN" -eq 0 ]; then
+    NEED_PATH_HELP=1
+    warn "  Homebrew finished, but 'acq' is not on your PATH yet. Ensure Homebrew's"
+    warn "  bin directory is on PATH (usually /opt/homebrew/bin or /usr/local/bin)."
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -549,8 +557,10 @@ if [ "$NEED_PATH_HELP" -eq 1 ]; then
   if [ "$METHOD" = "clone" ]; then
     info "Once $BIN_DIR is on your PATH, try:  ${B}acq version${R}"
     info "Or run it directly right now:        ${B}$BIN_DIR/acq version${R}"
-  else
+  elif [ "$METHOD" = "npm" ]; then
     info "Once npm's global bin dir is on your PATH, try:  ${B}acq version${R}"
+  else
+    info "Once Homebrew's bin dir is on your PATH, try:  ${B}acq version${R}"
   fi
 else
   info "Try it now:  ${B}acq version${R}"


### PR DESCRIPTION
## Context

Implements GSA-TTS/agentic-coding-quickstart#407 after publishing the external Homebrew tap at GSA-TTS/homebrew-tap.

## Changes

- Un-stub `install.sh` Homebrew handling so it runs `brew install GSA-TTS/tap/acq`.
- Keep `--dry-run` useful even when Homebrew is absent.
- Treat Homebrew versioning as formula-controlled and reject `--ref` when forced to `--method brew`.
- Auto-select clone when `--sha` is supplied so commit pinning is honored.
- Update the install docs and ADR-0026 to remove stale tap-deferred wording.

## External Tap

- Published formula: https://github.com/GSA-TTS/homebrew-tap/blob/main/Formula/acq.rb
- Formula source: quickstart `v2.0.0`
- Formula installs `acq` + `acq.backends/` into `libexec` and symlinks `bin/acq`.
- Formula depends on `superradcompany/tap/microsandbox`.

## Verification

- `ruby -c /tmp/opencode/homebrew-tap/Formula/acq.rb` -> pass
- `sh -n install.sh` -> pass
- `shellcheck --severity=warning install.sh` -> pass
- `npm run lint:md` -> pass, 0 markdown issues
- `sh install.sh --method brew --dry-run --no-msb` -> pass, prints `brew install GSA-TTS/tap/acq`
- `sh install.sh --method brew --ref v2.0.0 --dry-run --no-msb` -> pass, rejects unsupported brew ref pinning
- `sh install.sh --sha 21fd96a152c6b38120396f503509a2d00ec0f784 --dry-run --no-msb` -> pass, auto-selects clone
- Verified remote formula content via GitHub API.

Homebrew itself is not installed in this Linux sandbox, so live `brew install` validation should be run on a Mac with Homebrew.

## Rollback

- Revert this PR to restore clone fallback behavior for the brew branch.
- Remove or deprecate the `acq` formula in GSA-TTS/homebrew-tap if needed.

## Security Impact

No authentication, authorization, or secret-handling changes. This changes the installer distribution path when Homebrew is already present. The formula is pinned to a tagged source archive and SHA256.

AI-assisted (OpenCode). Human owner: @mogul.
