### PR TITLE
fix(msb): session parity for exec/attach/shell (cwd, terminal identity, login shell)

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3382,16 +3382,20 @@ _acq_msb_ensure_agent_shell() {
   # guest script as a positional arg (never interpolated into the sh -c
   # string). Charset-guard the probe result before it reaches usermod/chsh.
   shell=$({ msb exec "$name" -u 0 -- sh -c 'command -v bash 2>/dev/null' </dev/null 2>/dev/null || true; } | tr -d '\r\n')
-  case "$shell" in
-    /*) : ;;
-    *)  shell="/bin/sh" ;;
-  esac
-  case "$shell" in
-    *[!A-Za-z0-9._/-]*) shell="/bin/sh" ;;
-  esac
+  shell=$(_acq_msb_safe_shell_or_sh "$shell")
   acq_debug "msb: syncing agent login shell to $shell in $name"
   # NOTE: single-quoted `sh -c` string — no single quotes inside (they would
   # close the outer quote); `echo` writes the profile lines for the same reason.
+  #
+  # The bridge exports the shell passwd ACTUALLY holds after the sync attempt
+  # (re-read into `current`), not the requested target: an image with bash but
+  # neither usermod nor chsh keeps /bin/sh in passwd, and SHELL must not lie
+  # about the shell sessions really run.
+  #
+  # The rewrite is bounded to a file acq owns outright: missing/empty, or the
+  # marker present AND still just the bridge (3 lines). Lines other tools
+  # append below the bridge (rustup et al) must survive the heal, so a
+  # marker-plus-appended file is left untouched.
   msb exec "$name" -u 0 -- sh -c '
     set -e
     target="$1"
@@ -3402,15 +3406,17 @@ _acq_msb_ensure_agent_shell() {
       elif command -v chsh >/dev/null 2>&1; then
         chsh -s "$target" agent
       fi
+      current=$({ getent passwd agent 2>/dev/null || grep "^agent:" /etc/passwd 2>/dev/null; } | head -n1 | cut -d: -f7)
     fi
+    [ -n "$current" ] || current=/bin/sh
     profile=/home/agent/.profile
     if [ -f "$profile" ]; then
       sed -i "\|^export SHELL=/bin/sh\$|d" "$profile" 2>/dev/null || true
     fi
-    if [ ! -s "$profile" ] || grep -qs acq-login-profile "$profile"; then
+    if [ ! -s "$profile" ] || { grep -qs acq-login-profile "$profile" && [ "$(wc -l < "$profile")" -le 3 ]; }; then
       {
-        echo "# acq-login-profile: written by acq (rewritten on heal; do not edit)."
-        echo "export SHELL=$target"
+        echo "# acq-login-profile: written by acq (rewritten on heal; do not edit these 3 lines)."
+        echo "export SHELL=$current"
         echo "if [ -n \"\$BASH_VERSION\" ] && [ -f \"\$HOME/.bashrc\" ]; then . \"\$HOME/.bashrc\"; fi"
       } > "$profile"
       _agrp=$(id -gn agent 2>/dev/null || echo agent)
@@ -4071,6 +4077,11 @@ EOF
 # shell come free; msb exposes only raw `msb exec`, so every session path here
 # must synthesize each piece itself or the session silently drops it.
 
+# Per-process cache for acq_backend_run's workspace resolution (see the cache
+# note there). Module scope so the first run primes it for every later run.
+_ACQ_MSB_RUN_WS_NAME=""
+_ACQ_MSB_RUN_WS=""
+
 # _acq_msb_workspace_for NAME — the guest workspace a session starts in (-w).
 # Prefer an explicit ACQ_MSB_WORKSPACE override; otherwise the guest path
 # recorded at provision (it mirrors the host mount path, so it cannot be
@@ -4112,6 +4123,14 @@ _acq_msb_term_flags_into() {
 _acq_msb_agent_passwd_shell() {
   local name="$1" shell
   shell=$({ msb exec "$name" -u 0 -- sh -c '{ getent passwd agent 2>/dev/null || grep "^agent:" /etc/passwd 2>/dev/null; } | head -n1 | cut -d: -f7' </dev/null 2>/dev/null || true; } | tr -d '\r\n')
+  _acq_msb_safe_shell_or_sh "$shell"
+}
+
+# _acq_msb_safe_shell_or_sh VALUE — echo VALUE when it is a word-safe absolute
+# path, /bin/sh otherwise. The shared guard for every shell path read from the
+# guest (passwd read, bash probe) before it reaches argv or usermod/chsh.
+_acq_msb_safe_shell_or_sh() {
+  local shell="$1"
   case "$shell" in
     /*) : ;;
     *)  shell="/bin/sh" ;;
@@ -4152,7 +4171,21 @@ acq_backend_run() {
   # Start in the primary workspace (-w), like attach/shell and like sbx's exec:
   # without it the command runs in msb's default cwd and every
   # workspace-relative invocation (direnv allow, git status) misfires.
-  ws=$(_acq_msb_workspace_for "$name")
+  # The marker read costs a guest exec, and callers drive this in probe loops
+  # (the verify/heal paths in common.sh), so cache the resolved path per NAME
+  # for the life of the process. Cached HERE, not inside the helper — the
+  # helper is always called through a command substitution, whose subshell
+  # would discard any cache write (the _ACQ_MSB_PORT_SEQ_FILE lesson). The
+  # ACQ_MSB_WORKSPACE override branch inside the helper still wins: an
+  # override never reaches the marker read, and it cannot change mid-process
+  # in a way the cache would mask (same env for every call).
+  if [ "${_ACQ_MSB_RUN_WS_NAME:-}" = "$name" ]; then
+    ws="$_ACQ_MSB_RUN_WS"
+  else
+    ws=$(_acq_msb_workspace_for "$name")
+    _ACQ_MSB_RUN_WS_NAME="$name"
+    _ACQ_MSB_RUN_WS="$ws"
+  fi
   msb exec -u agent -e HOME=/home/agent -w "$ws" ${_sockflag[@]+"${_sockflag[@]}"} \
     ${_gitident[@]+"${_gitident[@]}"} ${_kitenv[@]+"${_kitenv[@]}"} "$name" "$@"
 }

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3284,6 +3284,10 @@ _acq_msb_ensure_agent_user() {
   local name="$1"
   local marker="/var/lib/acq/agent-user-ready"
   if msb exec "$name" -u 0 -- sh -c "test -f '$marker'" >/dev/null 2>&1; then
+    # The user exists from an earlier run, but its login shell may predate the
+    # passwd-shell setup: re-sync it so an existing /bin/sh agent user
+    # is healed to bash on its next run, not left behind.
+    _acq_msb_ensure_agent_shell "$name"
     return 0
   fi
 
@@ -3328,20 +3332,6 @@ _acq_msb_ensure_agent_user() {
     su agent -s /bin/sh -c "test -w /home/agent" 2>/dev/null \
       || { echo "acq(msb): /home/agent is not writable by the agent user" >&2; exit 1; }
 
-    # Set SHELL=/bin/sh in the agent profile. The passwd shell is /bin/sh, but
-    # SHELL is not populated by `msb exec`/`su -c`, and msb interactive-exec
-    # ignores the passwd shell entirely (it drops to the base image default, a
-    # Node REPL on node:22-bookworm as an override). acq always execs an explicit
-    # shell/agent, so
-    # this is cosmetic (tools that read SHELL) but correct and cheap. Idempotent.
-    # NOTE: this whole block is a single-quoted `sh -c` string — do NOT use single
-    # quotes here (they would close the outer quote). `echo` avoids both quotes
-    # and printf %-escaping.
-    if ! grep -qs "^export SHELL=" /home/agent/.profile 2>/dev/null; then
-      echo export SHELL=/bin/sh >> /home/agent/.profile
-      chown "agent:${_agrp}" /home/agent/.profile
-    fi
-
     # Passwordless sudo for agent (base-image requirement). Only if sudo exists;
     # a base without sudo still works for our purposes (kit/agent commands that
     # need root are run by acq as -u 0 directly), so a missing sudo is non-fatal.
@@ -3366,7 +3356,71 @@ _acq_msb_ensure_agent_user() {
     echo "acq(msb):   a base with useradd/adduser. Re-run with ACQ_DEBUG=1 for details." >&2
     return 1
   }
+  _acq_msb_ensure_agent_shell "$name"
   msb exec "$name" -u 0 -- sh -c "mkdir -p /var/lib/acq && touch '$marker'" >/dev/null 2>&1 || true
+}
+
+# _acq_msb_ensure_agent_shell NAME — align the agent's login shell with what
+# the image provides. Passwd-driven, the convention sshd / `machinectl
+# shell` / toolbox follow: the account database declares the shell, the
+# session paths honor it (_acq_msb_agent_passwd_shell). Kits wire the
+# interactive environment into ~/.bashrc (rc.d drop-in loops, prompt init),
+# which dash never reads, so prefer bash when the image ships it and keep
+# /bin/sh otherwise — a stock bash-less image keeps working exactly as today.
+# Also writes a Debian-skel-style ~/.profile bridge: a LOGIN bash reads only
+# ~/.profile, so without the bridge even `bash -l` skips ~/.bashrc on images
+# whose baked home ships no ~/.profile. The bare `export SHELL=/bin/sh` line
+# earlier acq versions appended is removed wherever it appears (it stopped a
+# login bash cold); a ~/.profile with any other content is left alone (image/
+# user-owned — Debian's own skel already bridges). Idempotent and re-run on
+# every provision AND heal (even on an agent-user-ready marker hit), which is
+# what upgrades sandboxes created before this setup. Fail-soft: a sync failure
+# leaves sessions on the /bin/sh fallback, never blocks the run.
+_acq_msb_ensure_agent_shell() {
+  local name="$1" shell
+  # Probe for bash host-side so the target is decided once and threaded to the
+  # guest script as a positional arg (never interpolated into the sh -c
+  # string). Charset-guard the probe result before it reaches usermod/chsh.
+  shell=$({ msb exec "$name" -u 0 -- sh -c 'command -v bash 2>/dev/null' </dev/null 2>/dev/null || true; } | tr -d '\r\n')
+  case "$shell" in
+    /*) : ;;
+    *)  shell="/bin/sh" ;;
+  esac
+  case "$shell" in
+    *[!A-Za-z0-9._/-]*) shell="/bin/sh" ;;
+  esac
+  acq_debug "msb: syncing agent login shell to $shell in $name"
+  # NOTE: single-quoted `sh -c` string — no single quotes inside (they would
+  # close the outer quote); `echo` writes the profile lines for the same reason.
+  msb exec "$name" -u 0 -- sh -c '
+    set -e
+    target="$1"
+    current=$({ getent passwd agent 2>/dev/null || grep "^agent:" /etc/passwd 2>/dev/null; } | head -n1 | cut -d: -f7)
+    if [ "$current" != "$target" ]; then
+      if command -v usermod >/dev/null 2>&1; then
+        usermod -s "$target" agent
+      elif command -v chsh >/dev/null 2>&1; then
+        chsh -s "$target" agent
+      fi
+    fi
+    profile=/home/agent/.profile
+    if [ -f "$profile" ]; then
+      sed -i "\|^export SHELL=/bin/sh\$|d" "$profile" 2>/dev/null || true
+    fi
+    if [ ! -s "$profile" ] || grep -qs acq-login-profile "$profile"; then
+      {
+        echo "# acq-login-profile: written by acq (rewritten on heal; do not edit)."
+        echo "export SHELL=$target"
+        echo "if [ -n \"\$BASH_VERSION\" ] && [ -f \"\$HOME/.bashrc\" ]; then . \"\$HOME/.bashrc\"; fi"
+      } > "$profile"
+      _agrp=$(id -gn agent 2>/dev/null || echo agent)
+      chown "agent:${_agrp}" "$profile"
+    fi
+  ' sh "$shell" </dev/null >/dev/null 2>&1 || {
+    echo "acq(msb): warning: could not sync the agent login shell in '$name';" >&2
+    echo "acq(msb):   interactive sessions fall back to /bin/sh." >&2
+    return 0
+  }
 }
 
 # ---------------------------------------------------------------------------
@@ -4011,6 +4065,64 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# Session context shared by exec/attach/shell
+# ---------------------------------------------------------------------------
+# sbx is a full session transport, so cwd, terminal identity, and the login
+# shell come free; msb exposes only raw `msb exec`, so every session path here
+# must synthesize each piece itself or the session silently drops it.
+
+# _acq_msb_workspace_for NAME — the guest workspace a session starts in (-w).
+# Prefer an explicit ACQ_MSB_WORKSPACE override; otherwise the guest path
+# recorded at provision (it mirrors the host mount path, so it cannot be
+# recomputed from NAME alone); fall back to the agent home if nothing was
+# recorded (older sandbox). The marker read is failure-guarded so an absent
+# marker takes the documented fallback instead of killing the session verb
+# under `set -e` (see _acq_msb_ssh_auth_sock_for).
+_acq_msb_workspace_for() {
+  local name="$1" ws="${ACQ_MSB_WORKSPACE:-}"
+  if [ -z "$ws" ]; then
+    ws=$({ msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' </dev/null 2>/dev/null || true; } | tr -d '\r\n')
+  fi
+  [ -n "$ws" ] || ws="/home/agent"
+  printf '%s\n' "$ws"
+}
+
+# _acq_msb_term_flags_into ARRVAR — `-e` flags forwarding the host's terminal
+# identity (TERM, COLORTERM) into an interactive (-t) session. msb does not
+# propagate the caller's terminal env into the guest PTY, so sessions see
+# TERM=linux and no COLORTERM, and TUI agents drop to a 16-color palette (sbx
+# forwards both itself). Only values the host actually has are forwarded —
+# unset stays unset, nothing is invented — and only the interactive paths use
+# this (non-interactive exec and kit commands have no terminal to describe).
+_acq_msb_term_flags_into() {
+  local _arrn="$1"
+  eval "$_arrn=()"
+  [ -n "${TERM:-}" ] && eval "$_arrn+=(-e \"TERM=\$TERM\")"
+  [ -n "${COLORTERM:-}" ] && eval "$_arrn+=(-e \"COLORTERM=\$COLORTERM\")"
+  return 0
+}
+
+# _acq_msb_agent_passwd_shell NAME — the agent user's passwd shell, the shell
+# an interactive session execs (and exports as SHELL). Passwd-driven like
+# sshd / `machinectl shell` / toolbox: the account database declares the
+# shell (set by _acq_msb_ensure_agent_shell), the transport honors it. The
+# value comes from a guest file, so charset-guard it to a word-safe absolute
+# path; anything unexpected — including an image with no getent and no agent
+# entry — falls back to /bin/sh.
+_acq_msb_agent_passwd_shell() {
+  local name="$1" shell
+  shell=$({ msb exec "$name" -u 0 -- sh -c '{ getent passwd agent 2>/dev/null || grep "^agent:" /etc/passwd 2>/dev/null; } | head -n1 | cut -d: -f7' </dev/null 2>/dev/null || true; } | tr -d '\r\n')
+  case "$shell" in
+    /*) : ;;
+    *)  shell="/bin/sh" ;;
+  esac
+  case "$shell" in
+    *[!A-Za-z0-9._/-]*) shell="/bin/sh" ;;
+  esac
+  printf '%s\n' "$shell"
+}
+
+# ---------------------------------------------------------------------------
 # acq_backend_run — run a command inside a sandbox; return its exit status
 # ---------------------------------------------------------------------------
 # acq passes `-- CMD...`; msb exec uses the same `-- CMD...` separator.
@@ -4031,18 +4143,18 @@ acq_backend_run() {
   # Kit-declared environment[] entries persisted at provision are replayed the
   # same way, mirroring the flag order the provisioning execs use (HOME, sock,
   # then kit env — see _acq_msb_exec_flags_into).
-  local _sock _gitident=() _kitenv=()
+  local _sock _sockflag=() _gitident=() _kitenv=() ws
   _sock=$(_acq_msb_ssh_auth_sock_for "$name")
+  [ -n "$_sock" ] && _sockflag=(-e "SSH_AUTH_SOCK=$_sock")
   _acq_msb_apply_host_git_global_config "$name"
   _acq_msb_git_identity_env_flags_into _gitident
   _acq_msb_kit_env_flags_into _kitenv "$name"
-  if [ -n "$_sock" ]; then
-    msb exec -u agent -e HOME=/home/agent -e "SSH_AUTH_SOCK=$_sock" \
-      ${_gitident[@]+"${_gitident[@]}"} ${_kitenv[@]+"${_kitenv[@]}"} "$name" "$@"
-  else
-    msb exec -u agent -e HOME=/home/agent ${_gitident[@]+"${_gitident[@]}"} \
-      ${_kitenv[@]+"${_kitenv[@]}"} "$name" "$@"
-  fi
+  # Start in the primary workspace (-w), like attach/shell and like sbx's exec:
+  # without it the command runs in msb's default cwd and every
+  # workspace-relative invocation (direnv allow, git status) misfires.
+  ws=$(_acq_msb_workspace_for "$name")
+  msb exec -u agent -e HOME=/home/agent -w "$ws" ${_sockflag[@]+"${_sockflag[@]}"} \
+    ${_gitident[@]+"${_gitident[@]}"} ${_kitenv[@]+"${_kitenv[@]}"} "$name" "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -4086,18 +4198,11 @@ _acq_msb_attach() {
   local name="$1"
   shift
 
-  # Determine the workspace to cd into (-w). Prefer an explicit ACQ_MSB_WORKSPACE
-  # override; otherwise read the guest path recorded at provision (it mirrors the
-  # host mount path, so it can't be recomputed from NAME alone). Fall back to the
-  # agent home if nothing was recorded (older sandbox).
-  # Both marker reads are failure-guarded so an absent marker takes the
-  # documented fallback instead of killing the attach (see
-  # _acq_msb_ssh_auth_sock_for).
-  local ws="${ACQ_MSB_WORKSPACE:-}"
-  if [ -z "$ws" ]; then
-    ws=$({ msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' </dev/null 2>/dev/null || true; } | tr -d '\r\n')
-  fi
-  [ -n "$ws" ] || ws="/home/agent"
+  # Determine the workspace to cd into (-w); the marker reads below are
+  # failure-guarded so an absent marker takes the documented fallback instead
+  # of killing the attach (see _acq_msb_ssh_auth_sock_for).
+  local ws
+  ws=$(_acq_msb_workspace_for "$name")
 
   # Read the agent recorded at provision. Default to `shell` if unset. The value
   # comes from a guest file (/var/lib/acq/agent); charset-guard it before it
@@ -4110,8 +4215,10 @@ _acq_msb_attach() {
     agent="shell"
   fi
 
-  # Common flags for the interactive attach: PTY, agent user, workspace cwd, and
-  # a sane $SHELL (msb's default interactive shell is the base image's Node REPL).
+  # Common flags for the interactive attach: PTY, agent user, workspace cwd,
+  # the host terminal identity, and $SHELL set to the agent's passwd shell
+  # (msb's default interactive shell is the base image's Node REPL, and it
+  # exports neither the passwd shell nor the caller's TERM).
   # exec so acq hands the terminal straight to msb (no wrapper between TTY & PTY).
   #
   # When the host ssh-agent is forwarded, also point the session at the in-guest
@@ -4129,6 +4236,9 @@ _acq_msb_attach() {
   _acq_msb_git_identity_env_flags_into _gitident
   _acq_msb_kit_env_flags_into _kitenv "$name"
 
+  local _term=()
+  _acq_msb_term_flags_into _term
+
   if [ "$agent" = "shell" ]; then
     _acq_msb_shell_exec "$name" "$ws"
   fi
@@ -4140,32 +4250,35 @@ _acq_msb_attach() {
     _acq_msb_shell_exec "$name" "$ws"
   fi
 
-  exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} \
-    ${_gitident[@]+"${_gitident[@]}"} ${_kitenv[@]+"${_kitenv[@]}"} "$name" -- "$agent" "$@"
+  local shell
+  shell=$(_acq_msb_agent_passwd_shell "$name")
+  exec msb exec -t -u agent -w "$ws" ${_term[@]+"${_term[@]}"} -e "SHELL=$shell" \
+    ${_sockflag[@]+"${_sockflag[@]}"} ${_gitident[@]+"${_gitident[@]}"} \
+    ${_kitenv[@]+"${_kitenv[@]}"} "$name" -- "$agent" "$@"
 }
 
 # _acq_msb_shell_exec NAME [WS] — exec into an interactive login shell as the
-# agent user: PTY, workspace cwd, sane $SHELL, and SSH_AUTH_SOCK when the host
-# ssh-agent is forwarded (a raw `msb exec` shell gets none of that). Shared by
-# _acq_msb_attach's shell paths and the neutral `acq shell` verb. WS skips the
-# workspace lookup when the caller already resolved it.
+# agent user: PTY, workspace cwd, the agent's passwd shell with SHELL set to
+# match and login semantics (so bash reads ~/.profile → ~/.bashrc via the
+# acq-login-profile bridge), the host terminal identity, and SSH_AUTH_SOCK
+# when the host ssh-agent is forwarded (a raw `msb exec` shell gets none of
+# that). Shared by _acq_msb_attach's shell paths and the neutral `acq shell`
+# verb. WS skips the workspace lookup when the caller already resolved it.
 _acq_msb_shell_exec() {
   local name="$1" ws="${2:-}"
-  if [ -z "$ws" ]; then
-    ws="${ACQ_MSB_WORKSPACE:-}"
-    if [ -z "$ws" ]; then
-      ws=$({ msb exec "$name" -u 0 -- sh -c 'cat /var/lib/acq/workspace 2>/dev/null' </dev/null 2>/dev/null || true; } | tr -d '\r\n')
-    fi
-    [ -n "$ws" ] || ws="/home/agent"
-  fi
-  local _sock _sockflag=() _gitident=() _kitenv=()
+  [ -n "$ws" ] || ws=$(_acq_msb_workspace_for "$name")
+  local shell
+  shell=$(_acq_msb_agent_passwd_shell "$name")
+  local _sock _sockflag=() _gitident=() _kitenv=() _term=()
   _sock=$(_acq_msb_ssh_auth_sock_for "$name")
   [ -n "$_sock" ] && _sockflag=(-e "SSH_AUTH_SOCK=$_sock")
   _acq_msb_apply_host_git_global_config "$name"
   _acq_msb_git_identity_env_flags_into _gitident
   _acq_msb_kit_env_flags_into _kitenv "$name"
-  exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} \
-    ${_gitident[@]+"${_gitident[@]}"} ${_kitenv[@]+"${_kitenv[@]}"} "$name" -- /bin/sh -l
+  _acq_msb_term_flags_into _term
+  exec msb exec -t -u agent -w "$ws" ${_term[@]+"${_term[@]}"} -e "SHELL=$shell" \
+    ${_sockflag[@]+"${_sockflag[@]}"} ${_gitident[@]+"${_gitident[@]}"} \
+    ${_kitenv[@]+"${_kitenv[@]}"} "$name" -- "$shell" -l
 }
 
 # ---------------------------------------------------------------------------
@@ -4690,6 +4803,12 @@ acq_backend_ensure_kits_applied() {
   # present — the reported "have to export SSH_AUTH_SOCK by hand" symptom. Cheap
   # no-op when no host forward is requested or the sandbox has no vsock route.
   _acq_msb_ensure_ssh_agent_forward "$name"
+  # Re-run the agent-user setup. It is idempotent and marker-gated, and its
+  # login-shell sync deliberately runs even on a marker hit — that is
+  # what heals a sandbox whose agent user was created with /bin/sh before the
+  # passwd-shell setup existed. Best-effort like the rest of the heal.
+  _acq_msb_ensure_agent_user "$name" || \
+    echo "acq(msb): warning: agent-user heal failed for '$name'." >&2
   local kits=("$ZSCALER_KIT" "$USAI_KIT" "$PLAYBOOK_KIT" "$GITSSHSIGN_KIT")
   local builtin_count="${#kits[@]}"
   if [ -n "${ACQ_EXTRA_KITS:-}" ]; then

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -571,11 +571,14 @@ adds a sudoers `env_keep` for the proxy variables. It addresses the user by name
 **How attach launches the agent.** sbx's `sbx run --name` re-launches the
 baked-in agent. On msb the adapter reproduces that with `msb exec -t` — the one
 primitive that allocates a PTY (so a full-screen agent TUI renders), runs as the
-unprivileged `agent` user (`-u agent`), starts in the workspace (`-w`), and gives
-the session a sane `$SHELL`. It execs the agent recorded at provision, falling
-back to an interactive `/bin/sh -l` as `agent` — never a root shell, never msb's
-default interactive shell (the base image's Node REPL) — for a `shell` sandbox or
-if the agent binary is somehow missing.
+unprivileged `agent` user (`-u agent`), starts in the workspace (`-w`), forwards
+the host terminal identity (`TERM`/`COLORTERM`, when set), and sets `$SHELL` to
+the agent user's passwd shell (which acq sets to bash when the image ships it,
+keeping `/bin/sh` otherwise). It execs the agent recorded at provision, falling
+back to an interactive login shell in that same passwd shell as `agent` — never
+a root shell, never msb's default interactive shell (the base image's Node
+REPL) — for a `shell` sandbox or if the agent binary is somehow missing.
+`acq exec` runs its command in the workspace (`-w`) too, matching sbx.
 
 To use your own image, set `ACQ_MSB_IMAGE` to one that also provides node, git,
 curl, and ca-certificates (or use the backend-neutral `--image`/`ACQ_IMAGE`, see

--- a/scripts/test-acq-lib.sh
+++ b/scripts/test-acq-lib.sh
@@ -289,6 +289,27 @@ case "$_msb_sub" in
       # unwritable home so the block exits 1 and provision must abort.
       *"test -w /home/agent"*)
         [ "${STUB_HOME_NOT_WRITABLE:-0}" = "1" ] && exit 1 || exit 0 ;;
+      # The agent login-shell setup block: passwd-shell sync + the
+      # acq-login-profile bridge. Matched by its marker string BEFORE the
+      # generic command-v / getent arms (the block contains both).
+      *"acq-login-profile"*) exit 0 ;;
+      # The passwd-shell read the session paths (shell/attach) run. Unset
+      # STUB_AGENT_PASSWD_SHELL models an absent agent entry (exit 1, session
+      # falls back to /bin/sh), matching the marker-read convention below.
+      *"getent passwd agent"*)
+        [ -n "${STUB_AGENT_PASSWD_SHELL+x}" ] || exit 1
+        printf '%s\n' "$STUB_AGENT_PASSWD_SHELL" ;;
+      # The host-side bash probe deciding the agent's passwd shell.
+      # Default PRESENT (the default image ships bash); STUB_GUEST_BASH=0
+      # models a bash-less base. MUST precede the generic command-v arm.
+      *"command -v bash"*)
+        [ "${STUB_GUEST_BASH:-1}" = "0" ] && exit 1 || printf '/bin/bash\n' ;;
+      # The agent-user-ready marker gate. Default ABSENT (exit 1, like the
+      # generic test -f arm) so provision runs the full block;
+      # STUB_AGENT_USER_READY=1 models an already-provisioned sandbox so the
+      # heal's marker-hit shell-sync path can be exercised.
+      *"test -f '/var/lib/acq/agent-user-ready'"*)
+        [ "${STUB_AGENT_USER_READY:-0}" = "1" ] && exit 0 || exit 1 ;;
       # The OCI-engine setup is TWO msb-exec `sh -c` blocks: (1) a root (`-u 0`)
       # install/config block carrying `/usr/local/bin/docker`, and (2) a rootless
       # verify block (`-u agent`) that runs a `podman build` layer-mount self-test

--- a/test/bats/30-dispatch-routing.bats
+++ b/test/bats/30-dispatch-routing.bats
@@ -33,8 +33,8 @@ _seed_usai() {
 }
 
 @test "shell: NAME (msb) -> agent-user login shell with PTY in the workspace" {
-  run env ACQ_BACKEND=msb "$ACQ" shell mybox
-  assert_regex "$(cat "$CALLS")" 'msb exec -t -u agent -w /home/agent -e SHELL=/bin/sh mybox -- /bin/sh -l'
+  run env TERM=xterm-256color COLORTERM=truecolor ACQ_BACKEND=msb "$ACQ" shell mybox
+  assert_regex "$(cat "$CALLS")" 'msb exec -t -u agent -w /home/agent -e TERM=xterm-256color -e COLORTERM=truecolor -e SHELL=/bin/sh mybox -- /bin/sh -l'
 }
 
 @test "shell: without a name is a usage error, no backend call" {

--- a/test/bats/30-dispatch-routing.bats
+++ b/test/bats/30-dispatch-routing.bats
@@ -33,7 +33,11 @@ _seed_usai() {
 }
 
 @test "shell: NAME (msb) -> agent-user login shell with PTY in the workspace" {
-  run env TERM=xterm-256color COLORTERM=truecolor ACQ_BACKEND=msb "$ACQ" shell mybox
+  # Neutralize the host git identity (HOME/XDG config, EMAIL/GIT_* env) so the
+  # exec line is the same on a dev machine with a global identity and in CI.
+  run env -u EMAIL -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL \
+    HOME="$STUBDIR/nohome" XDG_CONFIG_HOME="$STUBDIR/noconfig" GIT_CONFIG_NOSYSTEM=1 \
+    TERM=xterm-256color COLORTERM=truecolor ACQ_BACKEND=msb "$ACQ" shell mybox
   assert_regex "$(cat "$CALLS")" 'msb exec -t -u agent -w /home/agent -e TERM=xterm-256color -e COLORTERM=truecolor -e SHELL=/bin/sh mybox -- /bin/sh -l'
 }
 

--- a/test/bats/70-msb-backend.bats
+++ b/test/bats/70-msb-backend.bats
@@ -75,7 +75,7 @@ _with_adapter() { # ADAPTER BODY
   assert_regex "$(cat "$CALLS")" 'msb remove --force mybox'
   : > "$CALLS"
   run env ACQ_BACKEND=msb "$ACQ" exec mybox -- echo hi
-  assert_regex "$(cat "$CALLS")" 'msb exec -u agent -e HOME=/home/agent mybox -- echo hi'
+  assert_regex "$(cat "$CALLS")" 'msb exec -u agent -e HOME=/home/agent -w /home/agent mybox -- echo hi'
 }
 
 @test "msb: version and backend list report the real msb version" {

--- a/test/bats/70-msb-backend.bats
+++ b/test/bats/70-msb-backend.bats
@@ -74,7 +74,11 @@ _with_adapter() { # ADAPTER BODY
   run env ACQ_BACKEND=msb "$ACQ" rm mybox
   assert_regex "$(cat "$CALLS")" 'msb remove --force mybox'
   : > "$CALLS"
-  run env ACQ_BACKEND=msb "$ACQ" exec mybox -- echo hi
+  # Neutralize the host git identity (HOME/XDG config, EMAIL/GIT_* env) so the
+  # exec line is the same on a dev machine with a global identity and in CI.
+  run env -u EMAIL -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL \
+    HOME="$STUBDIR/nohome" XDG_CONFIG_HOME="$STUBDIR/noconfig" GIT_CONFIG_NOSYSTEM=1 \
+    ACQ_BACKEND=msb "$ACQ" exec mybox -- echo hi
   assert_regex "$(cat "$CALLS")" 'msb exec -u agent -e HOME=/home/agent -w /home/agent mybox -- echo hi'
 }
 

--- a/test/bats/72-msb-agent-user.bats
+++ b/test/bats/72-msb-agent-user.bats
@@ -359,9 +359,37 @@ _attach() { # PRE_SNIPPET NAME
   _provision bridgebox shell 'export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/bridge-secrets"'
   local log; log=$(cat "$CALLS")
   assert_regex "$log" 'usermod -s'
-  assert_regex "$log" 'export SHELL='
   assert_regex "$log" 'BASH_VERSION'
   assert_regex "$log" '\.bashrc'
+  # The bridge must export the shell passwd ACTUALLY holds after the sync
+  # attempt (re-read), not the requested target: on an image with bash but no
+  # usermod/chsh the passwd shell stays /bin/sh and SHELL must not lie.
+  assert_regex "$log" 'export SHELL=\$current'
+  refute_regex "$log" 'export SHELL=\$target'
+}
+
+@test "msb #426: the heal only rewrites a .profile acq owns outright (appended lines survive)" {
+  # Tools like rustup append to ~/.profile below acq's bridge. The rewrite
+  # condition must be marker-present AND still just the bridge (line-count
+  # bound), so a marker+appended file is left alone instead of clobbered on
+  # every heal.
+  _provision profguard shell 'export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/profguard-secrets"'
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" 'acq-login-profile "\$profile"'
+  assert_regex "$log" '\-le 3'
+}
+
+@test "msb: repeated acq exec reads the workspace marker once per process (cached)" {
+  : > "$CALLS"
+  run bash -c '
+    export STUB_RECORDED_WORKSPACE=/tmp/myrepo
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_run cachebox -- git status >/dev/null 2>&1
+    acq_backend_run cachebox -- git log >/dev/null 2>&1
+  '
+  local log; log=$(cat "$CALLS")
+  assert_equal "$(grep -c 'cat /var/lib/acq/workspace' "$CALLS")" "1"
+  assert_equal "$(grep -c -- '-w /tmp/myrepo cachebox' "$CALLS")" "2"
 }
 
 @test "msb #426: heal upgrades an existing /bin/sh agent user (marker hit still syncs the shell)" {

--- a/test/bats/72-msb-agent-user.bats
+++ b/test/bats/72-msb-agent-user.bats
@@ -181,7 +181,7 @@ _attach() { # PRE_SNIPPET NAME
   local log; log=$(cat "$CALLS")
   assert_regex "$log" 'msb exec -u agent'
   assert_regex "$log" '-u agent -e HOME=/home/agent'
-  assert_regex "$log" '-e HOME=/home/agent execbox'
+  assert_regex "$log" '-w /home/agent execbox'
   assert_regex "$log" 'execbox -- sh -c ls ~/.local/bin/opencode'
   refute_regex "$log" 'msb exec execbox --'
 }
@@ -275,4 +275,136 @@ _attach() { # PRE_SNIPPET NAME
   _provision ociinjbox shell 'export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/ociinj-secrets" ACQ_MSB_PODMAN_PKGS="podman;rm -rf"'
   assert_output --partial 'unsafe characters'
   refute_regex "$(cat "$CALLS")" 'rm -rf'
+}
+
+# msb session parity: sbx is a full session transport, so
+# cwd/terminal identity/login shell come free; msb exposes only raw `msb exec`,
+# so the adapter must synthesize each piece on its session paths.
+
+@test "msb #421: acq exec passes -w with the recorded workspace" {
+  : > "$CALLS"
+  run bash -c '
+    export STUB_RECORDED_WORKSPACE=/tmp/myrepo
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_run wsbox -- git status >/dev/null 2>&1
+  '
+  assert_regex "$(cat "$CALLS")" '\-u agent -e HOME=/home/agent -w /tmp/myrepo wsbox -- git status'
+}
+
+@test "msb #421: acq exec honors ACQ_MSB_WORKSPACE and falls back to /home/agent" {
+  : > "$CALLS"
+  run bash -c '
+    export ACQ_MSB_WORKSPACE=/tmp/override STUB_RECORDED_WORKSPACE=/tmp/myrepo
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_run wsbox -- git status >/dev/null 2>&1
+  '
+  assert_regex "$(cat "$CALLS")" '\-w /tmp/override wsbox'
+  : > "$CALLS"
+  run bash -c '
+    unset ACQ_MSB_WORKSPACE STUB_RECORDED_WORKSPACE
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_run wsbox -- git status >/dev/null 2>&1
+  '
+  assert_regex "$(cat "$CALLS")" '\-w /home/agent wsbox'
+}
+
+@test "msb #425: attach and shell forward the host TERM/COLORTERM when set" {
+  _attach 'export TERM=xterm-256color COLORTERM=truecolor STUB_RECORDED_AGENT=opencode STUB_AGENT_PRESENT=1 STUB_RECORDED_WORKSPACE=/tmp/wsp' termbox
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" 'msb exec -t -u agent -w /tmp/wsp -e TERM=xterm-256color -e COLORTERM=truecolor'
+  : > "$CALLS"
+  run bash -c '
+    export TERM=xterm-256color COLORTERM=truecolor
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    ( _acq_msb_shell_exec termbox </dev/null >/dev/null 2>&1 )
+  '
+  assert_regex "$(cat "$CALLS")" '\-e TERM=xterm-256color -e COLORTERM=truecolor'
+}
+
+@test "msb #425: unset TERM/COLORTERM are not invented on interactive paths" {
+  _attach 'unset TERM COLORTERM; export STUB_RECORDED_AGENT=opencode STUB_AGENT_PRESENT=1 STUB_RECORDED_WORKSPACE=/tmp/wsp' termbox
+  local log; log=$(cat "$CALLS")
+  refute_regex "$log" '\-e TERM='
+  refute_regex "$log" '\-e COLORTERM='
+}
+
+@test "msb #425: non-interactive acq exec does not forward TERM/COLORTERM" {
+  : > "$CALLS"
+  run bash -c '
+    export TERM=xterm-256color COLORTERM=truecolor
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_run termbox -- git status >/dev/null 2>&1
+  '
+  local log; log=$(cat "$CALLS")
+  refute_regex "$log" '\-e TERM='
+  refute_regex "$log" '\-e COLORTERM='
+}
+
+@test "msb #426: provision sets the agent passwd shell to bash when the image has it" {
+  _provision bashshbox shell 'export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/bashsh-secrets"'
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" 'command -v bash'
+  assert_regex "$log" 'acq-login-profile.* sh /bin/bash'
+  refute_regex "$log" 'acq-login-profile.* sh /bin/sh$'
+}
+
+@test "msb #426: a bash-less image keeps the /bin/sh passwd shell" {
+  _provision noshbox shell 'export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/nosh-secrets" STUB_GUEST_BASH=0'
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" 'acq-login-profile.* sh /bin/sh'
+  refute_regex "$log" 'sh /bin/bash'
+}
+
+@test "msb #426: the login-profile bridge exports SHELL and sources .bashrc under bash" {
+  _provision bridgebox shell 'export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/bridge-secrets"'
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" 'usermod -s'
+  assert_regex "$log" 'export SHELL='
+  assert_regex "$log" 'BASH_VERSION'
+  assert_regex "$log" '\.bashrc'
+}
+
+@test "msb #426: heal upgrades an existing /bin/sh agent user (marker hit still syncs the shell)" {
+  : > "$CALLS"
+  printf 'healshbox\n' > "$STUBDIR/.msb_sandbox_list"
+  printf 'healshbox\n' > "$STUBDIR/.msb_running_list"
+  run bash -c '
+    export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/healsh-secrets" STUB_AGENT_USER_READY=1
+    . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    # shellcheck disable=SC2034  # consumed by the sourced acq_backend_ensure_kits_applied
+    ACQ_CLI_KITS=()
+    acq_backend_ensure_kits_applied healshbox >/dev/null 2>&1
+  '
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" "test -f '/var/lib/acq/agent-user-ready'"
+  assert_regex "$log" 'acq-login-profile.* sh /bin/bash'
+  refute_regex "$log" 'useradd'
+}
+
+@test "msb #426: shell and attach exec the agent passwd shell and set SHELL to match" {
+  : > "$CALLS"
+  run bash -c '
+    export STUB_AGENT_PASSWD_SHELL=/bin/bash
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    ( _acq_msb_shell_exec pshbox </dev/null >/dev/null 2>&1 )
+  '
+  assert_regex "$(cat "$CALLS")" '\-e SHELL=/bin/bash pshbox -- /bin/bash -l'
+  _attach 'export STUB_AGENT_PASSWD_SHELL=/bin/bash STUB_RECORDED_AGENT=opencode STUB_AGENT_PRESENT=1 STUB_RECORDED_WORKSPACE=/tmp/wsp' pshbox
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" '\-e SHELL=/bin/bash'
+  assert_regex "$log" 'pshbox -- opencode'
+}
+
+@test "msb #426: a garbage passwd shell falls back to /bin/sh" {
+  : > "$CALLS"
+  run bash -c '
+    export STUB_AGENT_PASSWD_SHELL="bad shell; rm -rf /"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    ( _acq_msb_shell_exec badshbox </dev/null >/dev/null 2>&1 )
+  '
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" '\-e SHELL=/bin/sh badshbox -- /bin/sh -l'
+  refute_regex "$log" 'rm -rf'
 }

--- a/test/bats/78-msb-kit-env.bats
+++ b/test/bats/78-msb-kit-env.bats
@@ -179,7 +179,7 @@ RUBOCOP_PARALLELISM=4"
   assert_output --partial 'RUN-SURVIVED'
   assert_output --partial 'ATTACH-SURVIVED'
   assert_output --partial 'SHELL-SURVIVED'
-  assert_regex "$(cat "$CALLS")" 'exec -u agent -e HOME=/home/agent sbox -- git status'
+  assert_regex "$(cat "$CALLS")" 'exec -u agent -e HOME=/home/agent -w /home/agent sbox -- git status'
 }
 
 @test "msb kit env: heal rebuilds the marker — a var the kit no longer declares stops reaching sessions" {


### PR DESCRIPTION
## Summary

sbx is a full session transport: shell, working directory, and terminal environment come free with every session. msb exposes only raw `msb exec`, so acq synthesizes the session itself in `acq.backends/msb.sh`. That synthesized session dropped three pieces of context that sbx provides, one per issue below. All three fixes land in the same file's session paths, so this PR closes the set as one "msb session parity" change.

## Working directory (GSA-TTS/agentic-coding-quickstart#421)

`acq_backend_run` (the `exec` verb) was the only session path that never resolved the recorded workspace, so commands ran in the guest's default cwd and workspace-relative flows (the documented devenv approval, `direnv allow`) failed. The workspace resolution the attach/shell paths already used (`ACQ_MSB_WORKSPACE` override, then the `/var/lib/acq/workspace` marker, then `/home/agent`) is now factored into `_acq_msb_workspace_for` and shared by all three paths; `acq exec` passes `-w` like the rest.

Fixes GSA-TTS/agentic-coding-quickstart#421

## Terminal identity (GSA-TTS/agentic-coding-quickstart#425)

msb does not propagate the caller's terminal env into the guest PTY, so interactive sessions saw `TERM=linux` and no `COLORTERM`, and TUI agents fell back to a 16-color palette. The interactive (`-t`) attach and shell paths now forward the host's `TERM` and `COLORTERM` as `-e` flags when set; unset values are skipped (never invented), and non-interactive `acq exec` is untouched.

Fixes GSA-TTS/agentic-coding-quickstart#425

## Login shell (GSA-TTS/agentic-coding-quickstart#426)

`acq shell` and attach exec'd a hardcoded `/bin/sh -l` (dash on Debian-family images), so everything kits wire into bash (`~/.bashrc`, rc.d drop-ins, prompt init) was silently inert; and the agent user's `~/.profile` was a bare `export SHELL=/bin/sh`, so even a manual `bash -l` skipped `~/.bashrc`. This implements the passwd-driven design from the issue:

- `_acq_msb_ensure_agent_shell` (run from `_acq_msb_ensure_agent_user`, on provision and heal, including on a marker hit) sets the agent user's passwd shell to bash when the image ships it and keeps `/bin/sh` otherwise, so a stock bash-less image keeps working exactly as today.
- The shell/attach paths exec the passwd shell with login semantics and set `SHELL` to match instead of hardcoding `/bin/sh`.
- The bare `.profile` line is replaced by a Debian-skel-style bridge that exports `SHELL` to match the passwd shell and sources `~/.bashrc` when running under bash; a `.profile` with other content is left alone.
- Every step is idempotent, and because the shell sync runs even when the `agent-user-ready` marker exists, existing sandboxes are healed to bash on their next run instead of being left behind.

Fixes GSA-TTS/agentic-coding-quickstart#426

## Tests

Extended `test/bats/72-msb-agent-user.bats` (plus the stub library) to cover: `exec` passing `-w` with the resolved workspace; `TERM`/`COLORTERM` forwarded when set on interactive paths and absent when unset or non-interactive; the passwd shell chosen per image bash availability; the `.profile` bridge content; heal upgrading an existing `/bin/sh` agent user; and a garbage passwd shell falling back to `/bin/sh`. Updated the exec/shell line-shape assertions in suites 30/70/78. `bash -n` on `acq` + all `acq.backends/*.sh`, shellcheck on the changed shell files, and the full bats suite pass.

## Review round

A medium-effort code review on the draft surfaced four findings, all applied: the heal only rewrites a `~/.profile` acq owns outright (lines appended by other tools survive), the bridge exports the passwd shell as re-read after the sync attempt (so `SHELL` cannot lie when `usermod`/`chsh` are absent), `acq exec` caches the resolved workspace per name (no extra guest round-trip per probe), and the shell validation guard is shared by one helper.

Verified live on a real msb sandbox predating the fix: `acq exec` lands in the workspace, the heal upgraded the agent user in place (bridge written, legacy line replaced, `.bashrc`/rc.d chain now loads under a login shell), and an appended `.profile` line survives a re-heal.

No behavior change for sbx.

---

AI-assisted: drafted with Claude Code (Fable 5); reviewed and directed by a human.
