### PR TITLE
fix(install): handle shallow pinned updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ This project operates under professional standards of conduct. All contributors:
 | ----------------------------------- | ---------------------------------------------------------- |
 | `acq`                               | Entry point — pluggable-backend wrapper (msb by default, or sbx) |
 | `acq.backends/`                     | Backend adapters (`common.sh`, `sbx.sh`, `msb.sh`, `kit-translate.sh`, `secret-store.sh`, `progress.sh`) |
-| `install.sh`                        | One-line `curl \| sh` installer (auto-selects brew/npm/clone) |
+| `install.sh`                        | One-line `curl \| sh` installer (auto-selects brew/npm/clone; direct `sh install.sh` still installs the default release tag from the repo, not the current checkout) |
 | `scripts/rotate-apikey`             | Rotate your USAi API key secret (`acq usai-rotate-api-key`) |
 | `scripts/test-acq-bats`             | Offline unit suite for acq (bats-core) |
 | `scripts/verify-backends`           | Live end-to-end backend verification (needs Docker or KVM) |

--- a/docs/adr/0026-installation-and-distribution.md
+++ b/docs/adr/0026-installation-and-distribution.md
@@ -259,7 +259,9 @@ as issues):
   out `HEAD`, failing closed on mismatch — a content-addressed check). The source
   tree default ref is the current release tag, while release automation publishes
   an `install.sh` asset with the canonical release commit SHA embedded as the
-  default SHA.
+  default SHA. Running `sh install.sh` from a source checkout still clones from
+  the configured repository at that default release tag; it does not install
+  unreleased files from the invoking checkout.
 - **Verifiable.** Release automation publishes `SHA256SUMS` next to the installer
   asset. Inspect-first is supported: download `install.sh`, verify it with
   `SHA256SUMS`, read it, and use `--dry-run` before installing.

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,9 @@
 #                 [--sha <full-commit>] [--no-msb] [--dry-run] [--yes]
 #                 [--help]
 #
+# Running this script from a source checkout still installs from REPO_URL at the
+# default release tag; it does not install the local working tree.
+#
 # Inspect first (recommended): download and read this file, then run it.
 
 set -eu
@@ -104,6 +107,10 @@ install.sh — install acq (agentic-coding-quickstart)
 
 It auto-selects the best method already on your host: Homebrew, then npm, then
 a git clone. Override with --method.
+
+When run directly from a source checkout, the clone method still installs from
+the configured repository at the default release tag; it does not install your
+local working tree.
 
 Options:
   --method <m>         Force install method: brew | npm | clone (default: auto).
@@ -303,6 +310,20 @@ git_is_usable() {
   command -v git >/dev/null 2>&1 && git --version >/dev/null 2>&1
 }
 
+checkout_pinned_sha() {
+  repo="$1"
+  cleanup_on_fail="$2"
+  git -C "$repo" checkout "$SHA" 2>/dev/null && return 0
+  git -C "$repo" fetch --unshallow --tags origin \
+    '+refs/heads/*:refs/remotes/origin/*' 2>/dev/null \
+    || git -C "$repo" fetch --tags origin \
+      '+refs/heads/*:refs/remotes/origin/*' 2>/dev/null \
+    || true
+  git -C "$repo" checkout "$SHA" && return 0
+  [ "$cleanup_on_fail" = "cleanup" ] && rm -rf "$repo"
+  die "pinned commit '$SHA' not found in $REPO_URL"
+}
+
 # Ensure a usable git, proactively triggering the macOS Command Line Tools
 # install and waiting for it to finish. No sudo required. On non-macOS (or if
 # the tools never appear) this fails closed with guidance.
@@ -388,7 +409,11 @@ install_via_clone() {
   if [ -e "$CLONE_DIR/.git" ]; then
     step "Updating existing install at $CLONE_DIR"
     run git -C "$CLONE_DIR" fetch --tags --prune origin
-    run git -C "$CLONE_DIR" checkout "$target"
+    if [ -n "$SHA" ] && [ "$DRY_RUN" -eq 0 ]; then
+      checkout_pinned_sha "$CLONE_DIR" keep
+    else
+      run git -C "$CLONE_DIR" checkout "$target"
+    fi
     if [ "$DRY_RUN" -eq 0 ] && [ -z "$SHA" ] \
        && git -C "$CLONE_DIR" symbolic-ref -q HEAD >/dev/null 2>&1; then
       # Only fast-forward when on a branch (a pinned SHA is detached HEAD).
@@ -413,12 +438,7 @@ install_via_clone() {
           || { rm -rf "$CLONE_DIR"; die "failed to clone $REPO_URL"; }
       fi
       if [ -n "$SHA" ]; then
-        # A shallow clone may not contain the pinned commit; deepen if needed.
-        git -C "$CLONE_DIR" checkout "$SHA" 2>/dev/null \
-          || { git -C "$CLONE_DIR" fetch --unshallow origin 2>/dev/null \
-                 || git -C "$CLONE_DIR" fetch origin 2>/dev/null || true;
-               git -C "$CLONE_DIR" checkout "$SHA" \
-                 || { rm -rf "$CLONE_DIR"; die "pinned commit '$SHA' not found in $REPO_URL"; }; }
+        checkout_pinned_sha "$CLONE_DIR" cleanup
       else
         git -C "$CLONE_DIR" checkout "$REF" \
           || { rm -rf "$CLONE_DIR"; die "requested version '$REF' not found in $REPO_URL"; }

--- a/test/bats/05-install.bats
+++ b/test/bats/05-install.bats
@@ -39,6 +39,11 @@ case "$1" in
     case "$1" in
       checkout)
         mkdir -p "$repo/.git"
+        if [ "${GIT_STUB_FAIL_FIRST_CHECKOUT_SHA:-}" = "$2" ] \
+           && [ ! -e "$repo/.git/checkout-failed-once" ]; then
+          : >"$repo/.git/checkout-failed-once"
+          exit 1
+        fi
         printf '%s\n' "$2" >"$repo/.git/head"
         ;;
       rev-parse)
@@ -87,4 +92,20 @@ STUB
   assert_output --partial "version:   v2.0.0"
   assert_output --partial "pinned commit: $release_sha"
   assert_output --partial "verified HEAD matches pinned commit $release_sha"
+}
+
+@test "install: existing shallow clone deepens before failing pinned sha" {
+  export GIT_STUB_LOG="$BATS_TEST_TMPDIR/git.log"
+  _write_git_stub
+  mkdir -p "$ACQ_INSTALL_CLONE_DIR/.git"
+  printf '#!/bin/sh\n' >"$ACQ_INSTALL_CLONE_DIR/acq"
+  chmod +x "$ACQ_INSTALL_CLONE_DIR/acq"
+  release_sha=abcdef0123456789abcdef0123456789abcdef01
+
+  run env GIT_STUB_FAIL_FIRST_CHECKOUT_SHA="$release_sha" \
+    sh "$REPO_ROOT/install.sh" --method clone --no-msb --yes --sha "$release_sha"
+
+  assert_success
+  assert_output --partial "verified HEAD matches pinned commit $release_sha"
+  assert_regex "$(cat "$GIT_STUB_LOG")" "fetch --unshallow --tags origin"
 }


### PR DESCRIPTION
## Context
Addresses the non-blocking follow-up findings from the review on GSA-TTS/agentic-coding-quickstart#419.

## What changed
- Documented that direct `sh install.sh` from a source checkout still installs from the configured repository at the default release tag, not from the invoking working tree.
- Added a shared pinned-SHA checkout helper for clone installs.
- Fixed existing shallow managed clones so `--sha` reinstalls fetch advertised heads/tags before failing a pinned commit checkout.
- Added focused Bats coverage for the existing shallow clone update path.

## Verification
- `shellcheck --severity=warning install.sh test/bats/05-install.bats` — passed.
- `./scripts/test-acq-bats test/bats/05-install.bats` — passed, 3 tests.
- `npm run lint:md` — passed, 0 issues.
- `git diff --check` — passed.
- Live scratch regression with a real shallow tag clone and a later arbitrary commit SHA — passed; installer updated the existing shallow clone to the pinned SHA.

## Rollback
Revert this PR. The installer will return to the PR 419 behavior where fresh clone SHA pinning can deepen shallow history but existing shallow managed clones do not have the same fallback.

## Security impact
Positive supply-chain correctness impact: existing shallow managed installs now honor pinned commit installs consistently with fresh installs. No authn/authz paths, secret handling, sandbox permissions, or network allowlists are broadened.

## AI assistance
AI-assisted implementation with human review required before merge.
