### PR TITLE
fix(acq): propagate host git identity to guest

### DIFF
--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -1802,10 +1802,62 @@ warn_if_no_ssh_signing_key() {
   echo "      Then commit as usual. (You can still work; only committing needs it.)" >&2
 }
 
+_acq_host_git_config_value() {
+  command -v git >/dev/null 2>&1 || return 0
+  HOME="${HOME:-}" git config --global --get "$1" 2>/dev/null || true
+}
+
+_acq_git_identity_value_is_safe() {
+  local val="$1" nl tab
+  nl=$(printf '\n_'); nl=${nl%_}
+  tab=$(printf '\t')
+  case "$val" in
+    *"$nl"*|*"$tab"*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+acq_host_git_identity_env() {
+  local email
+  if [ -n "${GIT_AUTHOR_NAME:-}" ] && _acq_git_identity_value_is_safe "$GIT_AUTHOR_NAME"; then
+    printf 'GIT_AUTHOR_NAME=%s\n' "$GIT_AUTHOR_NAME"
+  fi
+  if [ -n "${GIT_AUTHOR_EMAIL:-}" ] && _acq_git_identity_value_is_safe "$GIT_AUTHOR_EMAIL"; then
+    printf 'GIT_AUTHOR_EMAIL=%s\n' "$GIT_AUTHOR_EMAIL"
+  fi
+  if [ -n "${GIT_COMMITTER_NAME:-}" ] && _acq_git_identity_value_is_safe "$GIT_COMMITTER_NAME"; then
+    printf 'GIT_COMMITTER_NAME=%s\n' "$GIT_COMMITTER_NAME"
+  fi
+  if [ -n "${GIT_COMMITTER_EMAIL:-}" ] && _acq_git_identity_value_is_safe "$GIT_COMMITTER_EMAIL"; then
+    printf 'GIT_COMMITTER_EMAIL=%s\n' "$GIT_COMMITTER_EMAIL"
+  fi
+  if [ -n "${EMAIL:-}" ] && _acq_git_identity_value_is_safe "$EMAIL"; then
+    printf 'EMAIL=%s\n' "$EMAIL"
+  else
+    email=$(_acq_host_git_config_value user.email)
+    if [ -n "$email" ] && _acq_git_identity_value_is_safe "$email"; then
+      printf 'EMAIL=%s\n' "$email"
+    fi
+  fi
+}
+
+acq_host_git_global_config_env() {
+  local name email
+  name=$(_acq_host_git_config_value user.name)
+  email=$(_acq_host_git_config_value user.email)
+  if [ -n "$name" ] && _acq_git_identity_value_is_safe "$name"; then
+    printf 'ACQ_GIT_USER_NAME=%s\n' "$name"
+  fi
+  if [ -n "$email" ] && _acq_git_identity_value_is_safe "$email"; then
+    printf 'ACQ_GIT_USER_EMAIL=%s\n' "$email"
+  fi
+}
+
 # Warn (do not block) if the mounted workspace has no usable git identity.
-# Only a repo-local identity crosses into the sandbox (the sandbox home is empty
-# and the host's global ~/.gitconfig is NOT mounted), so guidance must point at
-# repo-local config. Classifies the workspace path P into four cases:
+# A repo-local identity crosses through the mounted workspace. When present, acq
+# also forwards the host's explicit GIT_* identity env or global git identity as
+# standard git author/committer env vars for guest commands. Classifies the
+# workspace path P into four cases:
 #   (a) P is itself a git repo    -> warn if effective user.email is unset
 #   (b) P is not a repo but has    -> tell the user to set identity per sub-repo
 #       depth-1 sub-repos              (names a capped, symlink-safe list)
@@ -1817,6 +1869,20 @@ warn_if_no_git_identity() {
   local path="${1:-}"
   command -v git >/dev/null 2>&1 || return 0
   [ -n "$path" ] && [ -d "$path" ] || return 0   # (d) handled by pre-flight
+
+  local host_email
+  if [ -n "${EMAIL:-}" ] && _acq_git_identity_value_is_safe "$EMAIL"; then
+    return 0
+  fi
+  if [ -n "${GIT_AUTHOR_EMAIL:-}" ] && [ -n "${GIT_COMMITTER_EMAIL:-}" ] \
+      && _acq_git_identity_value_is_safe "$GIT_AUTHOR_EMAIL" \
+      && _acq_git_identity_value_is_safe "$GIT_COMMITTER_EMAIL"; then
+    return 0
+  fi
+  host_email=$(_acq_host_git_config_value user.email)
+  if [ -n "$host_email" ] && _acq_git_identity_value_is_safe "$host_email"; then
+    return 0
+  fi
 
   # (a) P is itself a git work tree.
   if git -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3417,6 +3417,38 @@ _acq_msb_ssh_auth_sock_for() {
     </dev/null 2>/dev/null || true; } | tr -d '[:space:]'
 }
 
+_acq_msb_git_identity_env_flags_into() {
+  local _arrn="$1" _line _flag_e _flag_val
+  eval "$_arrn=()"
+  command -v acq_host_git_identity_env >/dev/null 2>&1 || return 0
+  while IFS= read -r _line; do
+    [ -n "$_line" ] || continue
+    _flag_e="-e"
+    _flag_val="$_line"
+    eval "$_arrn+=(\"\$_flag_e\" \"\$_flag_val\")"
+  done <<EOF
+$(acq_host_git_identity_env)
+EOF
+}
+
+_acq_msb_apply_host_git_global_config() {
+  local name="$1" _flags=() _line _flag_e _flag_val
+  command -v acq_host_git_global_config_env >/dev/null 2>&1 || return 0
+  while IFS= read -r _line; do
+    [ -n "$_line" ] || continue
+    _flag_e="-e"
+    _flag_val="$_line"
+    eval "_flags+=(\"\$_flag_e\" \"\$_flag_val\")"
+  done <<EOF
+$(acq_host_git_global_config_env)
+EOF
+  [ "${#_flags[@]}" -gt 0 ] || return 0
+  msb exec -u agent -e HOME=/home/agent ${_flags[@]+"${_flags[@]}"} "$name" -- sh -c '
+    [ -n "${ACQ_GIT_USER_NAME:-}" ] && git config --global user.name "$ACQ_GIT_USER_NAME" 2>/dev/null || true
+    [ -n "${ACQ_GIT_USER_EMAIL:-}" ] && git config --global user.email "$ACQ_GIT_USER_EMAIL" 2>/dev/null || true
+  ' </dev/null >/dev/null 2>&1 || true
+}
+
 # _acq_msb_kit_env_flags_into ARRVAR NAME — build the `-e NAME=value` flag array
 # for the kit environment[] entries persisted at /var/lib/acq/kit-env by
 # _acq_msb_apply_kit_dir, so every session path (run/attach/shell) sees the env
@@ -3807,14 +3839,17 @@ acq_backend_run() {
   # Kit-declared environment[] entries persisted at provision are replayed the
   # same way, mirroring the flag order the provisioning execs use (HOME, sock,
   # then kit env — see _acq_msb_exec_flags_into).
-  local _sock _kitenv=()
+  local _sock _gitident=() _kitenv=()
   _sock=$(_acq_msb_ssh_auth_sock_for "$name")
+  _acq_msb_apply_host_git_global_config "$name"
+  _acq_msb_git_identity_env_flags_into _gitident
   _acq_msb_kit_env_flags_into _kitenv "$name"
   if [ -n "$_sock" ]; then
     msb exec -u agent -e HOME=/home/agent -e "SSH_AUTH_SOCK=$_sock" \
-      ${_kitenv[@]+"${_kitenv[@]}"} "$name" "$@"
+      ${_gitident[@]+"${_gitident[@]}"} ${_kitenv[@]+"${_kitenv[@]}"} "$name" "$@"
   else
-    msb exec -u agent -e HOME=/home/agent ${_kitenv[@]+"${_kitenv[@]}"} "$name" "$@"
+    msb exec -u agent -e HOME=/home/agent ${_gitident[@]+"${_gitident[@]}"} \
+      ${_kitenv[@]+"${_kitenv[@]}"} "$name" "$@"
   fi
 }
 
@@ -3895,9 +3930,11 @@ _acq_msb_attach() {
   _sock=$(_acq_msb_ssh_auth_sock_for "$name")
   [ -n "$_sock" ] && _sockflag=(-e "SSH_AUTH_SOCK=$_sock")
 
-  # Replay the kit environment[] persisted at provision, so agent-runtime config
-  # (OPENCODE_CONFIG-style vars, see ADR-0011) reaches the agent session.
-  local _kitenv=()
+  # Replay the host git identity and kit environment[] so git commits and
+  # agent-runtime config (OPENCODE_CONFIG-style vars, see ADR-0011) reach the session.
+  local _gitident=() _kitenv=()
+  _acq_msb_apply_host_git_global_config "$name"
+  _acq_msb_git_identity_env_flags_into _gitident
   _acq_msb_kit_env_flags_into _kitenv "$name"
 
   if [ "$agent" = "shell" ]; then
@@ -3912,7 +3949,7 @@ _acq_msb_attach() {
   fi
 
   exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} \
-    ${_kitenv[@]+"${_kitenv[@]}"} "$name" -- "$agent" "$@"
+    ${_gitident[@]+"${_gitident[@]}"} ${_kitenv[@]+"${_kitenv[@]}"} "$name" -- "$agent" "$@"
 }
 
 # _acq_msb_shell_exec NAME [WS] — exec into an interactive login shell as the
@@ -3929,12 +3966,14 @@ _acq_msb_shell_exec() {
     fi
     [ -n "$ws" ] || ws="/home/agent"
   fi
-  local _sock _sockflag=() _kitenv=()
+  local _sock _sockflag=() _gitident=() _kitenv=()
   _sock=$(_acq_msb_ssh_auth_sock_for "$name")
   [ -n "$_sock" ] && _sockflag=(-e "SSH_AUTH_SOCK=$_sock")
+  _acq_msb_apply_host_git_global_config "$name"
+  _acq_msb_git_identity_env_flags_into _gitident
   _acq_msb_kit_env_flags_into _kitenv "$name"
   exec msb exec -t -u agent -w "$ws" -e SHELL=/bin/sh ${_sockflag[@]+"${_sockflag[@]}"} \
-    ${_kitenv[@]+"${_kitenv[@]}"} "$name" -- /bin/sh -l
+    ${_gitident[@]+"${_gitident[@]}"} ${_kitenv[@]+"${_kitenv[@]}"} "$name" -- /bin/sh -l
 }
 
 # ---------------------------------------------------------------------------

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -265,6 +265,58 @@ _acq_sbx_kit_flags() {
   done
 }
 
+_acq_sbx_git_identity_kit() {
+  command -v acq_host_git_identity_env >/dev/null 2>&1 || return 0
+  command -v acq_host_git_global_config_env >/dev/null 2>&1 || return 0
+  command -v _kit_yaml_quote >/dev/null 2>&1 || return 0
+  local envrecs configrecs allrecs slug
+  envrecs=$(acq_host_git_identity_env)
+  configrecs=$(acq_host_git_global_config_env)
+  allrecs=$(printf '%s\n%s\n' "$envrecs" "$configrecs" | sed '/^$/d')
+  [ -n "$allrecs" ] || return 0
+  slug=$(printf '%s' "$allrecs" | cksum | cut -d' ' -f1)
+
+  local dir="${ACQ_SBX_KIT_CACHE}/generated/git-identity-${slug}"
+  mkdir -p "$dir"
+  {
+    printf 'schemaVersion: "2"\n'
+    printf 'kind: mixin\n'
+    printf 'name: acq-git-identity-%s\n' "$slug"
+    printf 'displayName: ACQ Git Identity\n'
+    printf 'description: Forward host git identity into the guest\n'
+    if [ -n "$envrecs" ]; then
+      printf 'environment:\n  variables:\n'
+      printf '%s\n' "$envrecs" | while IFS= read -r rec; do
+        [ -n "$rec" ] || continue
+        printf '    %s: %s\n' "${rec%%=*}" "$(_kit_yaml_quote "${rec#*=}")"
+      done
+    fi
+    if [ -n "$configrecs" ]; then
+      printf 'setup:\n  install:\n    command:\n      - sh\n      - -c\n'
+      printf '      - %s\n' "$(_kit_yaml_quote '[ -n "${ACQ_GIT_USER_NAME:-}" ] && git config --global user.name "$ACQ_GIT_USER_NAME" 2>/dev/null || true; [ -n "${ACQ_GIT_USER_EMAIL:-}" ] && git config --global user.email "$ACQ_GIT_USER_EMAIL" 2>/dev/null || true')"
+      printf '    env:\n'
+      printf '%s\n' "$configrecs" | while IFS= read -r rec; do
+        [ -n "$rec" ] || continue
+        printf '      %s: %s\n' "${rec%%=*}" "$(_kit_yaml_quote "${rec#*=}")"
+      done
+    fi
+  } >"$dir/spec.yaml"
+  printf '%s\n' "$dir"
+}
+
+_acq_sbx_apply_git_identity_kit() {
+  local name="$1" git_identity_kit _kadd_rc=0
+  git_identity_kit=$(_acq_sbx_git_identity_kit)
+  [ -n "$git_identity_kit" ] || return 0
+  _acq_sbx_kit_add "$name" "$git_identity_kit" || _kadd_rc=$?
+  case $_kadd_rc in
+    0) return 0 ;;
+    3) _acq_sbx_print_recreate_notice "$name" ;;
+    *) echo "acq: warning: 'sbx kit add' (git identity env) failed for '$name' (see error above)." >&2 ;;
+  esac
+  return 0
+}
+
 # ---------------------------------------------------------------------------
 # Wait for sbx exec to become ready in a sandbox (after create or restart).
 # ---------------------------------------------------------------------------
@@ -409,6 +461,9 @@ acq_backend_provision() {
 
   local kf=()
   while IFS= read -r line; do kf+=("$line"); done < <(_acq_sbx_kit_flags)
+  local _git_identity_kit=""
+  _git_identity_kit=$(_acq_sbx_git_identity_kit)
+  [ -n "$_git_identity_kit" ] && kf+=(--kit "$_git_identity_kit")
 
   acq_debug "sbx create --name $name ${_tf[*]:-} ${kf[*]} ${_stripped[*]:-}"
   acq_spin_start "Creating sandbox '$name'"
@@ -490,6 +545,7 @@ _acq_sbx_seed_extra_kit_marker() {
 acq_backend_run() {
   local name="$1"
   shift
+  _acq_sbx_apply_git_identity_kit "$name"
   # Expect `-- CMD...` separator. No `-u agent` needed: sbx's agent templates
   # bake the unprivileged `agent` user (UID 1000, HOME=/home/agent) as the
   # default exec user, unlike a plain msb OCI base (which defaults to root).
@@ -503,6 +559,7 @@ acq_backend_run() {
 # relaunches the recorded agent and `acq exec` is non-interactive. sbx
 # allocates the PTY itself via `exec -it`; exec hands it the terminal directly.
 acq_backend_shell() {
+  _acq_sbx_apply_git_identity_kit "$1"
   exec sbx exec -it "$1" bash
 }
 
@@ -750,6 +807,8 @@ acq_backend_ensure_kits_applied() {
       *) echo "acq: warning: 'sbx kit add' (git-ssh-sign kit) failed for '$name' (see error above)." >&2; ok=0 ;;
     esac
   fi
+
+  _acq_sbx_apply_git_identity_kit "$name"
 
   # 4) Extra kits (tracked by marker file). Extra kits may be neutral or already
   #    sbx-v2; _acq_sbx_translate_kit handles both. The marker records one

--- a/test/bats/120-workspace-preflight.bats
+++ b/test/bats/120-workspace-preflight.bats
@@ -73,6 +73,76 @@ _pf_out() { # PATH
   assert_output ''
 }
 
+@test "identity: complete host env or global email suppresses repo-local warning" {
+  run bash -c '
+    export HOME="'"$WT"'/fakehome" GIT_CONFIG_NOSYSTEM=1
+    export GIT_AUTHOR_EMAIL=dev@example.gov GIT_COMMITTER_EMAIL=dev@example.gov
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    warn_if_no_git_identity "'"$WT"'/repoA" 2>&1
+  '
+  assert_output ''
+
+  mkdir -p "$WT/globalhome"
+  run bash -c '
+    export HOME="'"$WT"'/globalhome" GIT_CONFIG_NOSYSTEM=1
+    git config --global user.email global@example.gov
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    warn_if_no_git_identity "'"$WT"'/repoA" 2>&1
+  '
+  assert_output ''
+}
+
+@test "identity: incomplete explicit host env still warns" {
+  run bash -c '
+    export HOME="'"$WT"'/fakehome" GIT_CONFIG_NOSYSTEM=1 GIT_AUTHOR_EMAIL=dev@example.gov
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    warn_if_no_git_identity "'"$WT"'/repoA" 2>&1
+  '
+  assert_output --partial 'this repo has no git user.email'
+}
+
+@test "identity env: host git config yields author and committer env" {
+  mkdir -p "$WT/idenvhome"
+  run bash -c '
+    export HOME="'"$WT"'/idenvhome" GIT_CONFIG_NOSYSTEM=1
+    git config --global user.name "Global User"
+    git config --global user.email global@example.gov
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    acq_host_git_identity_env
+  '
+  assert_output --partial 'EMAIL=global@example.gov'
+}
+
+@test "identity env: partial host git config forwards configured fields" {
+  mkdir -p "$WT/partialhome"
+  run bash -c '
+    export HOME="'"$WT"'/partialhome" GIT_CONFIG_NOSYSTEM=1
+    git config --global user.email global@example.gov
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    acq_host_git_identity_env
+  '
+  assert_output --partial 'EMAIL=global@example.gov'
+  refute_output --partial 'GIT_AUTHOR_NAME='
+  refute_output --partial 'GIT_COMMITTER_NAME='
+}
+
+@test "identity env: explicit host GIT_* values override global git config" {
+  mkdir -p "$WT/overridehome"
+  run bash -c '
+    export HOME="'"$WT"'/overridehome" GIT_CONFIG_NOSYSTEM=1
+    git config --global user.name "Global User"
+    git config --global user.email global@example.gov
+    export GIT_AUTHOR_NAME="Env User" GIT_AUTHOR_EMAIL=env@example.gov
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    acq_host_git_identity_env
+  '
+  assert_output --partial 'GIT_AUTHOR_NAME=Env User'
+  assert_output --partial 'GIT_AUTHOR_EMAIL=env@example.gov'
+  assert_output --partial 'EMAIL=global@example.gov'
+  refute_output --partial 'GIT_COMMITTER_NAME='
+  refute_output --partial 'GIT_COMMITTER_EMAIL='
+}
+
 @test "identity (b): non-repo root with sub-repos, symlinked child not followed" {
   _id "$WT/wsB"
   assert_output --partial 'workspace root is not a git repo'

--- a/test/bats/78-msb-kit-env.bats
+++ b/test/bats/78-msb-kit-env.bats
@@ -113,6 +113,47 @@ RUBOCOP_PARALLELISM=4"
   assert_regex "$(cat "$CALLS")" '-e OPENCODE_CONFIG=/home/agent/oc\.jsonc'
 }
 
+@test "msb git identity: syncs global config and replays EMAIL fallback" {
+  local home="$STUBDIR/git-home"
+  mkdir -p "$home"
+  git -c "safe.directory=*" config --file "$home/.gitconfig" user.name "Global User"
+  git -c "safe.directory=*" config --file "$home/.gitconfig" user.email global@example.gov
+
+  : > "$CALLS"
+  run bash -c '
+    export HOME="'"$home"'" GIT_CONFIG_NOSYSTEM=1 STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_run sbox -- git status >/dev/null 2>&1
+  '
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" '-e ACQ_GIT_USER_NAME=Global User'
+  assert_regex "$log" '-e ACQ_GIT_USER_EMAIL=global@example\.gov'
+  assert_regex "$log" 'git config --global user.name'
+  assert_regex "$log" 'git config --global user.email'
+  assert_regex "$log" '-e EMAIL=global@example\.gov'
+  refute_regex "$log" '-e GIT_AUTHOR_NAME=Global User'
+
+  : > "$CALLS"
+  run bash -c '
+    export HOME="'"$home"'" GIT_CONFIG_NOSYSTEM=1 STUB_MSB_VERSION=0.6.9
+    export STUB_RECORDED_AGENT=opencode STUB_AGENT_PRESENT=1
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    ( _acq_msb_attach sbox </dev/null >/dev/null 2>&1 )
+  '
+  assert_regex "$(cat "$CALLS")" '-e EMAIL=global@example\.gov'
+
+  : > "$CALLS"
+  run bash -c '
+    export HOME="'"$home"'" GIT_CONFIG_NOSYSTEM=1 STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    ( _acq_msb_shell_exec sbox </dev/null >/dev/null 2>&1 )
+  '
+  assert_regex "$(cat "$CALLS")" '-e EMAIL=global@example\.gov'
+}
+
 @test "msb markers: ABSENT /var/lib/acq markers must not kill session verbs under set -e" {
   # acq runs under `set -euo pipefail`. On a sandbox whose /var/lib/acq markers
   # are absent (created before a marker existed, e.g. pre-kit-env sandboxes, or

--- a/test/bats/90-sbx-startup-kit.bats
+++ b/test/bats/90-sbx-startup-kit.bats
@@ -171,6 +171,32 @@ STUB
   refute_regex "$log" 'sbx kit add probebox'
 }
 
+@test "provision(sbx): host global git identity is emitted as a create-time env kit" {
+  local home="$STUBDIR/git-home"
+  mkdir -p "$home"
+  git -c "safe.directory=*" config --file "$home/.gitconfig" user.name "Global User"
+  git -c "safe.directory=*" config --file "$home/.gitconfig" user.email global@example.gov
+
+  run bash -c '
+    export HOME="'"$home"'" GIT_CONFIG_NOSYSTEM=1
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
+    . "'"$REPO_ROOT"'/acq.backends/sbx.sh"
+    _acq_sbx_git_identity_kit
+  '
+  assert_success
+  local kitdir="$output"
+  [ -n "$kitdir" ]
+  local spec="$kitdir/spec.yaml"
+  [ -f "$spec" ]
+  assert_regex "$(cat "$spec")" 'kind: mixin'
+  assert_regex "$(cat "$spec")" "EMAIL: '?global@example\\.gov'?"
+  assert_regex "$(cat "$spec")" 'ACQ_GIT_USER_NAME: Global User'
+  assert_regex "$(cat "$spec")" "ACQ_GIT_USER_EMAIL: '?global@example\\.gov'?"
+  assert_regex "$(cat "$spec")" 'git config --global user.name'
+  refute_regex "$(cat "$spec")" 'GIT_AUTHOR_NAME: Global User'
+}
+
 @test "provision(sbx): ACQ_EXTRA_KITS is marked into ~/.acq-extra-kits at create" {
   : > "$CALLS"
   # Subshell, NOT `bash -c`: acq_backend_provision is a sourced function, which


### PR DESCRIPTION
## Context

`acq` warned about missing repo-local git identity even when the user already had
host global `user.name` and/or `user.email` configured. That also left agents in
the guest without enough git identity context for commit/signing workflows unless
the mounted repo had local config.

## Changes

- Detect host git identity from explicit `GIT_AUTHOR_*` / `GIT_COMMITTER_*`,
  `EMAIL`, and global `git config user.name` / `user.email`.
- Forward explicit host git env vars into guest sessions.
- Forward host global `user.email` as low-precedence `EMAIL`.
- Sync host global `user.name` / `user.email` into guest global git config for
  msb and sbx so repo-local config still takes precedence.
- Suppress the missing-identity warning when a safe host email source is
  available.
- Add sbx generated git identity kit support, including `kind: mixin` and a
  content-derived kit path.
- Add tests for warning suppression, partial identity, msb replay/config sync,
  and sbx generated kit contents.

## Adversarial Review

An AI-assisted adversarial review found and this PR addresses:

- Avoiding high-precedence global-derived `GIT_AUTHOR_*` / `GIT_COMMITTER_*` that
  would override repo-local config.
- Adding missing `kind: mixin` to the generated sbx kit.
- Tightening warning suppression for incomplete explicit env.
- Reducing sbx/msb divergence for existing sessions.
- Avoiding a shared mutable sbx generated-kit cache path.

## Verification

```text
$ git submodule update --init test/vendor/bats-core test/vendor/bats-support test/vendor/bats-assert
# initialized bats submodules; corrected bats-support to the recorded commit

$ ./test/vendor/bats-core/bin/bats test/bats/120-workspace-preflight.bats test/bats/78-msb-kit-env.bats test/bats/90-sbx-startup-kit.bats
1..34
ok 1 preflight: missing path fails and gives name + mkdir hint
ok 2 preflight: a file path fails with 'must be a directory'
ok 3 preflight: existing dir and empty arg (cwd default) pass
ok 4 identity (a): repo without effective email warns; with email is silent
ok 5 identity: complete host env or global email suppresses repo-local warning
ok 6 identity: incomplete explicit host env still warns
ok 7 identity env: host git config yields author and committer env
ok 8 identity env: partial host git config forwards configured fields
ok 9 identity env: explicit host GIT_* values override global git config
ok 10 identity (b): non-repo root with sub-repos, symlinked child not followed
ok 11 identity (c): empty dir gets the new-workspace onboarding note
ok 12 identity (d): a non-directory path is silent
ok 13 ports-dead: warns, names the dead port, and cites the failure-mode doc
ok 14 ports-dead: silent when listening, indeterminate, or no published ports
ok 15 msb kit env: apply persists environment[] to /var/lib/acq/kit-env; unsafe name is dropped
ok 16 msb kit env: a kit with no environment[] writes no kit-env marker
ok 17 msb kit env: acq exec replays persisted entries as -e flags; none when marker empty
ok 18 msb kit env: attach and shell replay persisted entries as -e flags
ok 19 msb git identity: syncs global config and replays EMAIL fallback
ok 20 msb markers: ABSENT /var/lib/acq markers must not kill session verbs under set -e
ok 21 msb kit env: heal rebuilds the marker — a var the kit no longer declares stops reaching sessions
ok 22 msb kit env: replay drops tampered names and keeps the last value for a duplicate
ok 23 heal(sbx 0.38): a startup refusal yields consolidated recreate guidance, status unknown
ok 24 heal(sbx 0.38): the recreate notice prints exactly once
ok 25 heal(sbx 0.38, set -e): a refusal does not abort the heal at the first kit
ok 26 kit update(sbx 0.38): a refusal fails fast with recreate guidance, stays stale
ok 27 heal(sbx): a non-refusal kit-add failure surfaces sbx's own stderr
ok 28 heal(sbx): a reworded 0.38 refusal is still classified as recreate
ok 29 heal(sbx): the playbook stale-probe uses the AGENTS.md footprint, not .git
ok 30 provision(sbx): host global git identity is emitted as a create-time env kit
ok 31 provision(sbx): ACQ_EXTRA_KITS is marked into ~/.acq-extra-kits at create
ok 32 provision(sbx): a CLI --kit ref (ACQ_CLI_KITS) is also marked at create
ok 33 provision(sbx): a FAILED create writes no extra-kit marker
ok 34 heal(sbx): a marked extra kit is not re-applied (no refusal noise)

$ shellcheck --severity=warning acq acq.backends/common.sh acq.backends/sbx.sh acq.backends/msb.sh
# pass

$ git diff --check -- acq acq.backends/common.sh acq.backends/sbx.sh acq.backends/msb.sh test/bats/120-workspace-preflight.bats test/bats/78-msb-kit-env.bats test/bats/90-sbx-startup-kit.bats
# pass
```

## Rollback

Revert commit `598007e`.

## Security Impact

This changes guest git identity propagation only. It does not expose secrets or
modify credential handling. Host git identity values are filtered to reject
newline/tab-containing values before being forwarded or written into generated
kit specs.

AI-assisted: yes.
