### PR TITLE
fix(msb): skip the recursive home chown when the image baked the agent user

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3358,8 +3358,8 @@ _acq_msb_ensure_agent_user() {
     # the home ownership, and a write-crawl over a dense baked home (single-user
     # Nix state is thousands of tiny files) grinds the guest disk journal for
     # minutes. The top-level chown and the writability check below still run on
-    # every path, so a wrong skip fails loudly; kits chown the subtrees they
-    # stage themselves.
+    # every path; they cover the home directory itself, not a root-owned subtree
+    # a custom image baked beneath it, which the base-image contract forbids.
     mkdir -p /home/agent
     _agrp=$(id -gn agent 2>/dev/null || echo agent)
     chown "agent:${_agrp}" /home/agent

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3024,10 +3024,13 @@ EOF
   # which is exactly how the playbook stopped fetching. Abort provision rather
   # than degrade silently.
   acq_debug "msb provision: ensuring agent user ($name)"
+  acq_spin_start "Preparing the agent user"
   if ! _acq_msb_ensure_agent_user "$name"; then
+    acq_spin_stop
     echo "acq(msb): error: agent-user setup failed for '$name'; aborting provision." >&2
     return 1
   fi
+  acq_spin_stop "Preparing the agent user"
   acq_debug "msb provision: agent user ready ($name)"
 
   # Ensure an OCI container engine (podman) so agents can run OCI images
@@ -3330,6 +3333,7 @@ _acq_msb_ensure_agent_user() {
   # silently degraded into a root-owned home and a playbook that never fetched).
   msb exec "$name" -u 0 -- sh -c '
     set -e
+    _acq_created_agent=0
     if id agent >/dev/null 2>&1; then
       :
     elif command -v useradd >/dev/null 2>&1; then
@@ -3337,20 +3341,29 @@ _acq_msb_ensure_agent_user() {
       # the tool pick a free uid. -M: do not auto-create home here; we create and
       # chown it explicitly below so ownership is unconditional.
       useradd -M -d /home/agent -s /bin/sh agent
+      _acq_created_agent=1
     elif command -v adduser >/dev/null 2>&1; then
       # Alpine/BusyBox.
       adduser -h /home/agent -s /bin/sh -D -H agent
+      _acq_created_agent=1
     else
       echo "acq(msb): no useradd/adduser in base image; cannot create agent user" >&2
       exit 1
     fi
     # Home MUST exist and be owned by agent. Not best-effort: a root-owned home
     # breaks every agent-user kit. `id -gn agent` resolves the primary group so
-    # chown works whether or not an `agent` group exists.
+    # chown works whether or not an `agent` group exists. The RECURSIVE chown is
+    # reserved for a user acq just created (a plain base can leave a half-created
+    # or root-owned home): when the image shipped the agent user it also baked
+    # the home ownership, and a write-crawl over a dense baked home (single-user
+    # Nix state is thousands of tiny files) grinds the guest disk journal for
+    # minutes. The top-level chown and the writability check below still run on
+    # every path, so a wrong skip fails loudly; kits chown the subtrees they
+    # stage themselves.
     mkdir -p /home/agent
     _agrp=$(id -gn agent 2>/dev/null || echo agent)
     chown "agent:${_agrp}" /home/agent
-    chown -R "agent:${_agrp}" /home/agent
+    if [ "$_acq_created_agent" = 1 ]; then chown -R "agent:${_agrp}" /home/agent; fi
     # Verify writability as the agent user (catches an exotic base where chown
     # "succeeds" but the mount is read-only, etc.). Fatal on failure.
     su agent -s /bin/sh -c "test -w /home/agent" 2>/dev/null \

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -572,6 +572,15 @@ no `agent`, no sudoers rule) that meets none of the first three, the msb adapter
 adds a sudoers `env_keep` for the proxy variables. It addresses the user by name
 (not the literal uid 1000), so it works even when 1000 is already taken.
 
+The recursive chown of `/home/agent` runs **only on that synthesized path**. When
+the image already ships an `agent` user, acq trusts the baked ownership (a dense
+baked home would otherwise cost minutes of chown on every first provision) and
+touches only the home directory itself. A custom image that ships `agent` but
+leaves root-owned content under `/home/agent` (a `COPY` without `--chown`)
+therefore violates the contract above and is not healed: the agent user gets
+`EACCES` on that subtree. Fix the image (`COPY --chown=agent:agent`, or a
+`chown -R agent:agent /home/agent` layer) rather than relying on acq.
+
 **How attach launches the agent.** sbx's `sbx run --name` re-launches the
 baked-in agent. On msb the adapter reproduces that with `msb exec -t` — the one
 primitive that allocates a PTY (so a full-screen agent TUI renders), runs as the

--- a/test/bats/72-msb-agent-user.bats
+++ b/test/bats/72-msb-agent-user.bats
@@ -425,6 +425,27 @@ _attach() { # PRE_SNIPPET NAME
   assert_regex "$log" 'pshbox -- opencode'
 }
 
+@test "msb #422: the recursive home chown is reserved for an acq-created agent user" {
+  _provision chownbox shell 'export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/chown-secrets"'
+  local log; log=$(cat "$CALLS")
+  # The top-level dir chown stays unconditional (single inode, asserts the
+  # contract on every path).
+  assert_regex "$log" 'chown "agent:[^ ]* /home/agent'
+  # The full write-crawl only fires when acq itself created the user; a
+  # pre-existing agent user means the image baked ownership.
+  assert_regex "$log" 'useradd -M -d /home/agent -s /bin/sh agent'
+  assert_regex "$log" '_acq_created_agent=1'
+  assert_regex "$log" 'if \[ "\$_acq_created_agent" = 1 \]; then chown -R "agent:'
+  refute_regex "$log" $'\n[[:space:]]*chown -R "agent:'
+  # The writability backstop survives the skip.
+  assert_regex "$log" 'test -w /home/agent'
+}
+
+@test "msb #422: provision wraps the agent-user step in a progress status" {
+  _provision spinusrbox shell 'export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/spinusr-secrets"'
+  assert_output --partial 'Preparing the agent user'
+}
+
 @test "msb #426: a garbage passwd shell falls back to /bin/sh" {
   : > "$CALLS"
   run bash -c '


### PR DESCRIPTION
On the msb backend, first provision runs `chown -R agent:agent /home/agent` unconditionally. On an image with a dense baked agent home (the devenv images ship single-user Nix state, thousands of tiny files) that write-crawl grinds the guest ext4 journal for minutes, with no output, right after "Waiting for the sandbox to finish booting… done". sbx never pays this: its template images bake the agent user and home ownership at image build time, so the create path has nothing to fix.

**Fix.** The guest setup script now tracks whether acq itself created the `agent` user. The recursive chown runs only on that path (a plain OCI base can leave a half-created or root-owned home, the case the FATAL rework was about). When the image shipped the user, acq trusts the baked ownership: the top-level `chown /home/agent` and the `su agent -c "test -w /home/agent"` writability backstop still run on every path, but they cover the home directory itself, not its contents. A custom image that ships `agent` yet bakes root-owned content under `/home/agent` violates the base-image contract and is no longer papered over; the backend guide's contract section now says so and how to fix the image. The default templates and the devenv image are fully agent-owned, so the common path is unaffected.

**Spinner.** The agent-user step now gets a progress status ("Preparing the agent user"), like the OCI-engine and agent-install steps, so whatever it costs no longer reads as a hang.

Fixes GSA-TTS/agentic-coding-quickstart#422

---

AI-assisted
