### PR TITLE
ci(release): attest installer assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
@@ -29,15 +32,23 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  release-assets:
+    name: Release Assets
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
       - name: Check out release commit
-        if: ${{ steps.release.outputs.release_created == 'true' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ steps.release.outputs.tag_name }}
+          ref: ${{ needs.release-please.outputs.tag_name }}
           persist-credentials: false
 
       - name: Build release assets
-        if: ${{ steps.release.outputs.release_created == 'true' }}
         run: |
           set -eu
           release_sha="$(git rev-parse HEAD)"
@@ -47,9 +58,15 @@ jobs:
           chmod 0755 dist/install.sh
           (cd dist && sha256sum install.sh > SHA256SUMS)
 
+      - name: Attest release assets
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: |
+            dist/install.sh
+            dist/SHA256SUMS
+
       - name: Upload release assets
-        if: ${{ steps.release.outputs.release_created == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
         run: gh release upload "$RELEASE_TAG" dist/install.sh dist/SHA256SUMS --clobber

--- a/README.md
+++ b/README.md
@@ -95,22 +95,28 @@ finish, then continues on its own.
 <details>
 <summary>Prefer to look before you run it? (recommended) (click to expand)</summary>
 
-You never have to pipe a script straight into your shell. Download it, read it,
-then run it:
+You never have to pipe a script straight into your shell. If you have the GitHub
+CLI (`gh`), you can also verify the release asset attestations before running
+anything:
 
 ```bash
 ACQ_VERSION=3.0.0 # x-release-please-version
 curl -fsSLO "https://github.com/GSA-TTS/agentic-coding-quickstart/releases/download/v${ACQ_VERSION}/install.sh"
 curl -fsSLO "https://github.com/GSA-TTS/agentic-coding-quickstart/releases/download/v${ACQ_VERSION}/SHA256SUMS"
+gh attestation verify install.sh --repo GSA-TTS/agentic-coding-quickstart
+gh attestation verify SHA256SUMS --repo GSA-TTS/agentic-coding-quickstart
 shasum -a 256 -c SHA256SUMS
 less install.sh              # read it
 sh install.sh --dry-run      # show what it WOULD do, changing nothing
 sh install.sh                # actually install
 ```
 
-The release asset pins the default clone install to the release tag and verifies
-that checkout against the release commit. You can also force a specific method
-with `--method brew|npm|clone`.
+By default, the installer uses the best package manager already available on
+your host: Homebrew, then npm, then a managed git clone. Homebrew and npm rely on
+the published package/formula release path. The release asset's baked commit SHA
+is used only by the clone fallback (or `--method clone`) to verify that the clone
+landed on the release commit embedded in the installer. To pin to an independent,
+explicit commit, use `--method clone --sha <40-char-commit>`.
 
 </details>
 

--- a/docs/adr/0002-version-management-and-release-automation.md
+++ b/docs/adr/0002-version-management-and-release-automation.md
@@ -101,8 +101,11 @@ requirements while maintaining simplicity and being backed by Google's well-main
    - Configuration in `release-please-config.json` and `.release-please-manifest.json`
    - GitHub Action: `googleapis/release-please-action`
    - Release creation also uploads installer assets: `install.sh` with the release
-     commit SHA embedded as the default pin, plus `SHA256SUMS` for verifying the
-     downloaded installer asset
+     commit SHA embedded for clone-path consistency checks, plus `SHA256SUMS` for
+     verifying the downloaded installer asset
+   - Release automation publishes GitHub artifact attestations for both
+     `install.sh` and `SHA256SUMS`, tying those assets to the GitHub Actions
+     workflow identity that built them
 
 4. **CHANGELOG.md Format**
    - Follow Keep a Changelog v1.1.0 format
@@ -190,8 +193,9 @@ Initially considered but rejected because:
 6. Update `.github/workflows/release.yml` to use release-please
 7. Upload release installer assets (`install.sh` and `SHA256SUMS`) when a release
    is created
-8. Add CONTRIBUTING.md with commit message guidelines
-9. Backfill CHANGELOG for existing releases (v0.1.0, v0.2.0)
+8. Publish GitHub artifact attestations for both release assets
+9. Add CONTRIBUTING.md with commit message guidelines
+10. Backfill CHANGELOG for existing releases (v0.1.0, v0.2.0)
 
 ## Commit Message Format Reference
 

--- a/docs/adr/0026-installation-and-distribution.md
+++ b/docs/adr/0026-installation-and-distribution.md
@@ -103,12 +103,14 @@ dependency — it only defers it:
   A user who installed via tarball would hit the CLT prompt on their very first
   real `acq` command instead of during install — a *worse* experience, because
   it happens after they think setup is finished.
-- **The integrity win is available without the tarball.** Git objects are
-  content-addressed, so pinning the clone to a **full commit SHA** is itself a
-  cryptographic integrity check — the checkout cannot succeed with tampered
-  content. That gives us hash-confirmed provenance without a second archive
-  install path; release automation still publishes `SHA256SUMS` for installer
-  asset verification.
+- **The clone-path consistency check is available without the tarball.** Git
+  objects are content-addressed, so an explicit clone pin to a **full commit
+  SHA** verifies that `HEAD` equals the commit the caller requested. Release
+  assets also embed the release commit SHA so clone installs can fail closed if
+  the checkout does not land on the commit baked into the installer. This is not
+  a substitute for release-asset provenance, so release automation also
+  publishes `SHA256SUMS` and GitHub artifact attestations for installer asset
+  verification.
 
 So the CLT dependency is unavoidable for this tool; the right move is to make it
 **painless and early** rather than to engineer around it. The installer's clone
@@ -132,9 +134,10 @@ guided step.
   clone.
 - **Never touch the user's `PATH` without consent** — offer to add the line,
   and if declined, print the exact line for them to add themselves.
-- **Federal security posture** — release asset defaults pin to a release tag and
-  canonical release commit SHA, published checksums, inspect-first supported, no
-  `sudo`, install into a user-writable prefix.
+- **Federal security posture** — package-manager-first auto-selection, clone
+  installs bound to the release asset's embedded commit SHA, published checksums
+  and artifact attestations, inspect-first supported, no `sudo`, install into a
+  user-writable prefix.
 - **Preserve `acq version` introspection and easy updates** — the on-disk layout
   should keep `acq`'s git-based version reporting and support in-place updates.
 - **Minimal new surface** — reuse the existing `acq`/kit machinery and `msb`
@@ -224,18 +227,20 @@ In bounds now:
   can pin to a full 40-char commit SHA and verifies `HEAD` equals it after
   checkout, failing closed (and cleaning up) on mismatch — git objects are
   content-addressed, so a matching SHA *is* a cryptographic integrity check.
-- **Release asset commit-SHA pinning by default.** `release-please` updates the
+- **Release asset clone consistency by default.** `release-please` updates the
   installer release version marker. When a release is created, the release
   workflow checks out the release commit, writes that exact commit SHA into the
-  `install.sh` asset, generates `SHA256SUMS`, and uploads both files to the
-  GitHub release. Users who install from the release asset get a default clone
-  target of the release tag plus a default `--sha`-equivalent integrity check
-  against the release commit.
+  `install.sh` asset, generates `SHA256SUMS`, publishes GitHub artifact
+  attestations for both files, and uploads both files to the GitHub release.
+  Users who install from the release asset still get package-manager-first auto
+  selection; the embedded SHA is used only when the clone fallback is selected
+  (or when the user forces `--method clone`) to verify that checkout against the
+  release commit baked into the installer.
 - **release-please manages `package.json`'s `version`.** An `extra-files` entry in
   `release-please-config.json` bumps `$.version` on each release so the npm
-  package version tracks the release manifest (currently `2.0.0`) instead of a
-  hand-maintained placeholder. A second `extra-files` entry bumps the installer
-  release version marker so its default ref follows the package version.
+  package version tracks the release manifest instead of a hand-maintained
+  placeholder. A second `extra-files` entry bumps the installer release version
+  marker so its default ref follows the package version.
 - README streamlining + install instructions.
 
 Deferred — only the work that **must** happen outside this repository (tracked
@@ -248,17 +253,20 @@ as issues):
 
 - **No `sudo`.** Everything installs under the user's home; the `PATH` dir is
   user-writable.
-- **Pinning is the release-asset default.** The installer accepts `--ref <tag>`
-  and `--sha <full-commit>` (the latter is integrity-checked against the checked
-  out `HEAD`, failing closed on mismatch — a content-addressed check). The source
-  tree default ref is the current release tag, while release automation publishes
-  an `install.sh` asset with the canonical release commit SHA embedded as the
-  default SHA. Running `sh install.sh` from a source checkout still clones from
-  the configured repository at that default release tag; it does not install
-  unreleased files from the invoking checkout.
-- **Verifiable.** Release automation publishes `SHA256SUMS` next to the installer
-  asset. Inspect-first is supported: download `install.sh`, verify it with
-  `SHA256SUMS`, read it, and use `--dry-run` before installing.
+- **Explicit pinning is clone-only.** The installer accepts `--ref <tag>` and
+  `--sha <full-commit>`; an explicit SHA forces the clone method and verifies the
+  checked-out `HEAD` equals that full commit SHA, failing closed on mismatch. The
+  source tree default ref is the current release tag. Release automation
+  publishes an `install.sh` asset with the canonical release commit SHA embedded
+  for clone-path consistency, but that baked SHA does not override default
+  Homebrew/npm auto-selection. Running `sh install.sh` from a source checkout
+  still clones from the configured repository at that default release tag; it
+  does not install unreleased files from the invoking checkout.
+- **Verifiable release assets.** Release automation publishes `SHA256SUMS` next
+  to the installer asset and GitHub artifact attestations for both files.
+  Inspect-first is supported: download `install.sh` and `SHA256SUMS`, verify the
+  attestations, verify the checksum, read the installer, and use `--dry-run`
+  before installing.
 - **Consent-gated side effects.** `PATH` edits and `msb` installation each
   require explicit consent; declining is always a safe, documented fallback.
 - **Idempotent.** Re-running updates an existing install rather than duplicating
@@ -268,8 +276,9 @@ as issues):
   `curl -fsSL https://install.microsandbox.dev | sh`; that upstream installer is
   outside our control and is not pinned/checksummed by us. It is consent-gated
   (and, under `--yes`, authorized by the same blanket opt-in as the `PATH` edit).
-  The `acq` clone install is pinned by default when the release asset is used;
-  npm and explicit `--ref` overrides resolve the ref the user chooses.
+  The `acq` clone path verifies the baked release commit when the release asset
+  is used; Homebrew/npm installs and explicit `--ref` overrides resolve through
+  their own selected package or ref.
 
 > **Control Mapping:** CM-2 (Baseline Configuration), CM-3 (Configuration Change
 > Control), CM-6 (Configuration Settings), SA-8 (Security Engineering
@@ -283,12 +292,12 @@ as issues):
   brew and npm serve users who prefer them; `acq version` and updates keep
   working.
 - **Negative / trade-off:** `curl | bash` carries a cultural stigma in security
-  circles; we mitigate with pinning, checksums, inspect-first, no-`sudo`, and
-  consent gates, but cannot fully eliminate the pattern short of the deferred
-  signed `.pkg`.
-- **Maintenance:** release automation must keep publishing `SHA256SUMS`, and
-  (once the tap lands) the formula must track releases. The formula work remains
-  deferred because it lives outside this repository.
+  circles; we mitigate with package-manager-first auto-selection, clone-path
+  consistency checks, checksums, artifact attestations, inspect-first,
+  no-`sudo`, and consent gates, but cannot fully eliminate the pattern short of
+  the deferred signed `.pkg`.
+- **Maintenance:** release automation must keep publishing `SHA256SUMS` and
+  artifact attestations, and the formula must track releases.
 
 ## Validation
 
@@ -302,12 +311,13 @@ as issues):
   resolves its script dir through the npm symlink and runs (`acq version` reports
   the module path and backend). The npm install is not a git checkout, so
   `acq version` reports "not a git clone" for the commit line — expected.
-- **SHA pinning:** with `--sha <full-40-hex>` the clone method checks that commit
-  out and verifies `HEAD` equals it, failing closed (and removing the partial
-  clone) when the SHA is absent or mismatched; a malformed SHA, or `--sha` with a
-  non-clone method, is rejected at argument parse. Verified live against a local
-  checkout (matching SHA succeeds and prints "verified HEAD matches"; a
-  well-formed but absent SHA fails closed and cleans up).
+- **SHA pinning:** with `--sha <full-40-hex>` the installer forces the clone
+  method, checks that commit out, and verifies `HEAD` equals it, failing closed
+  (and removing the partial clone) when the SHA is absent or mismatched; a
+  malformed SHA, or explicit `--sha` with a forced non-clone method, is rejected
+  at argument parse. Verified live against a local checkout (matching SHA
+  succeeds and prints "verified HEAD matches"; a well-formed but absent SHA
+  fails closed and cleans up).
 - **release-please version sync:** `release-please-config.json` carries an
   `extra-files` entry (`type: json`, `jsonpath: $.version`) so the next release
   bumps `package.json`'s `version`; `npm pack --dry-run` reports the manifest
@@ -315,17 +325,19 @@ as issues):
   `install.sh`'s `DEFAULT_RELEASE_VERSION` aligned with the release version.
 - **Release assets:** on release creation, `.github/workflows/release.yml` checks
   out the release commit, copies `install.sh`, injects that exact commit into the
-  release asset's `DEFAULT_RELEASE_SHA`, generates `SHA256SUMS`, and uploads both
-  assets to the GitHub release.
-- **Manual (bare-Mac reviewer):** on a clean macOS account, run the pinned
-  one-liner; confirm `acq` resolves on `PATH` (after accepting the offered
-  `PATH` line or adding the printed line), `acq version` reports the pinned
-  `branch@commit`, and `--dry-run` performs no writes. Decline paths (`PATH`
-  edit declined, `--no-msb`) leave a working `acq` and print correct guidance.
+  release asset's `DEFAULT_RELEASE_SHA`, generates `SHA256SUMS`, publishes GitHub
+  artifact attestations for both release assets, and uploads both assets to the
+  GitHub release.
+- **Manual (bare-Mac reviewer):** on a clean macOS account, run the one-liner;
+  confirm `acq` resolves on `PATH` (after accepting the offered `PATH` line or
+  adding the printed line), `acq version` reports the selected install's version
+  data, and `--dry-run` performs no writes. Decline paths (`PATH` edit declined,
+  `--no-msb`) leave a working `acq` and print correct guidance.
 - **Live end-to-end:** verify after the first release containing this automation
   is published by downloading the `install.sh` and `SHA256SUMS` release assets,
-  checking the checksum, and confirming `sh install.sh --dry-run --method clone`
-  reports the release tag and canonical commit SHA.
+  verifying both files' artifact attestations, checking the checksum, and
+  confirming `sh install.sh --dry-run --method clone` reports the release tag and
+  canonical commit SHA.
 
 ## Links
 

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ set -eu
 REPO_URL="${ACQ_INSTALL_REPO_URL:-https://github.com/GSA-TTS/agentic-coding-quickstart.git}"
 # release-please updates this version in release PRs. Release automation also
 # publishes an install.sh asset with DEFAULT_RELEASE_SHA replaced by the exact
-# release commit so the default clone path is content-addressed.
+# release commit so clone installs can verify they landed on that commit.
 DEFAULT_RELEASE_VERSION="3.0.0" # x-release-please-version
 DEFAULT_RELEASE_REF="v$DEFAULT_RELEASE_VERSION"
 DEFAULT_RELEASE_SHA=""
@@ -110,8 +110,8 @@ Options:
   --method <m>         Force install method: brew | npm | clone (default: auto).
   --ref <tag|branch>   Version to install (default: latest release tag baked
                        into this installer).
-  --sha <commit>       Pin to a full 40-char commit SHA and verify HEAD matches
-                       it after checkout (content-addressed integrity check).
+  --sha <commit>       Force clone install, pin to a full 40-char commit SHA,
+                       and verify HEAD matches it after checkout.
   --no-msb             Do not install the msb sandbox runtime.
   --dry-run            Print what would happen; make no changes.
   --yes, -y            Assume "yes" to prompts (PATH edit, msb install).
@@ -159,7 +159,7 @@ if [ "$REF_WAS_SET" -eq 1 ] && [ "$SHA_WAS_SET" -eq 0 ]; then
 fi
 
 # A pinned SHA must be a full 40-hex commit id (short SHAs and tags cannot be
-# integrity-verified the same way). Reject anything else up front.
+# verified against HEAD the same way). Reject anything else up front.
 if [ "$SHA_WAS_SET" -eq 1 ] && [ -z "$SHA" ]; then
   die "invalid --sha '$SHA' (expected a 40-char hex commit id)"
 fi
@@ -171,8 +171,8 @@ if [ -n "$SHA" ]; then
 fi
 
 # Explicit SHA pinning only applies to the git-clone method (npm/brew resolve
-# their own packages). A release asset's baked SHA is used when clone is selected,
-# but does not by itself override package-manager auto-selection.
+# their own packages). A release asset's baked SHA is a clone-path consistency
+# check and does not by itself override package-manager auto-selection.
 if [ "$SHA_WAS_SET" -eq 1 ] && { [ "$METHOD" = "npm" ] || [ "$METHOD" = "brew" ]; }; then
   die "--sha is only supported with --method clone"
 fi
@@ -468,7 +468,7 @@ install_via_clone() {
     fi
   fi
 
-  # --- Integrity check: HEAD must equal the pinned SHA (content-addressed) ---
+  # --- Clone consistency check: HEAD must equal the pinned SHA. ---
   if [ -n "$SHA" ] && [ "$DRY_RUN" -eq 0 ]; then
     head_sha="$(git -C "$CLONE_DIR" rev-parse HEAD 2>/dev/null || echo '')"
     if [ "$head_sha" != "$SHA" ]; then


### PR DESCRIPTION
## Summary
Adds GitHub artifact attestations for the installer release assets and narrows the installer/docs language so baked release SHAs are described as clone-path consistency checks, not package-manager default pinning.

This is stacked on GSA-TTS/agentic-coding-quickstart#433 and should be reviewed/merged after that PR.

## Changes
- Split release asset publishing into a separate least-privilege `release-assets` job.
- Attest both release assets: `dist/install.sh` and `dist/SHA256SUMS`.
- Keep `release-please` without `id-token: write` / `attestations: write`.
- Add README verification steps using `gh attestation verify`.
- Clarify in README/ADRs/install comments that package-manager installs do not use the baked SHA, while clone installs verify the embedded release commit.

## Related PRs
- Stacked on: GSA-TTS/agentic-coding-quickstart#433

## AI Attribution
AI-assisted by OpenCode [gpt_5_5_default_v2]. Human review required before merge.

## Verification
- `pre-commit run --all-files --show-diff-on-failure --color=always` passed.
- `./test/vendor/bats-core/bin/bats test/bats/05-install.bats` passed: 11/11 on the base branch before rebase.
- `sh -n install.sh` passed on the base branch before rebase.
- `git diff --check` passed.
- `npm run lint` passed before the final rebase; markdownlint also passed inside pre-commit after the final rebase.

## Adversarial Review
- Found that granting `id-token: write` and `attestations: write` to the existing release-please job would unnecessarily broaden permissions for the release-please action. Fixed by splitting release asset build/attestation/upload into a separate job.
- Found README used `gh attestation verify` without naming the GitHub CLI prerequisite. Fixed by adding a short `gh` note.
- Searched for remaining overbroad claims such as default SHA pinning/content-addressed integrity for all install paths and narrowed the relevant language.

## Rollback
Revert commit `a4313b6` to remove artifact attestation publishing and restore the prior installer/release documentation language.

## Security Impact
Improves release asset provenance by publishing GitHub artifact attestations for both release assets. Workflow permissions are scoped so OIDC/attestation permissions are only available to the release-assets job, not the release-please job.