### PR TITLE
fix(secret): store macos secrets in keychain via stdin

### DIFF
--- a/acq.backends/secret-store.sh
+++ b/acq.backends/secret-store.sh
@@ -13,7 +13,7 @@
 #     `acq.<sandbox>.<service>` (sandbox-scoped), with sandbox-scope taking
 #     precedence over global — mirroring §7.5 and the Phase-1 sbx global/sandbox
 #     scope that acq already lifted into its abstraction.
-#   - Storage in the OS keychain when available (macOS `security`, Linux
+#   - Storage in the OS keychain when available (macOS `security -i`, Linux
 #     `secret-tool`), with a 0600 file fallback under
 #     $XDG_DATA_HOME/acq/secrets/ when no keychain backend exists.
 #   - Read access for adapters at provision time: each backend pulls the real
@@ -58,12 +58,20 @@ fi
 # _acq_secret_backend — which store mechanism is active: keychain-macos |
 # keychain-linux | file. Respects ACQ_SECRET_FORCE_FILE.
 # ---------------------------------------------------------------------------
+_acq_secret_security_bin() {
+  if [ -n "${ACQ_SECRET_STORE_DIR:-}" ] && [ -n "${ACQ_SECRET_SECURITY_BIN:-}" ]; then
+    printf '%s\n' "$ACQ_SECRET_SECURITY_BIN"
+    return 0
+  fi
+  printf '/usr/bin/security\n'
+}
+
 _acq_secret_backend() {
   if [ -n "${ACQ_SECRET_FORCE_FILE:-}" ]; then
     printf 'file\n'; return 0
   fi
   case "$(uname -s 2>/dev/null)" in
-    Darwin) command -v security >/dev/null 2>&1 && { printf 'keychain-macos\n'; return 0; } ;;
+    Darwin) [ -x "$(_acq_secret_security_bin)" ] && { printf 'keychain-macos\n'; return 0; } ;;
     *)      command -v secret-tool >/dev/null 2>&1 && { printf 'keychain-linux\n'; return 0; } ;;
   esac
   printf 'file\n'
@@ -74,34 +82,29 @@ _acq_secret_backend() {
 #   acq.<service>              (global)
 #   acq.<sandbox>.<service>    (sandbox-scoped)
 #
-# The key format uses '.' as the scope separator, so it is only injective when
-# the SERVICE and SANDBOX segments contain no '.' themselves. If they could, a
-# GLOBAL service literally named "foo.bar" would produce `acq.foo.bar` — the
-# SAME key a SCOPED service "bar" in sandbox "foo" produces — colliding in BOTH
-# the value store and the meta sidecar (and mis-scoping meta_list). Sandbox
-# names are always slugified dot-free upstream (common.sh slugify -> [a-z0-9-])
-# and acq's own service names are dot-free, so this collision is latent today
-# We enforce that invariant here — the single choke
-# point both the value store and the meta sidecar share — so no caller can
-# smuggle a dotted (or otherwise separator-breaking) name past the store and
-# silently alias another scope. Fail closed rather than emit an ambiguous key.
+# The key format uses '.' as the scope separator, so SERVICE and SANDBOX must be
+# simple acq slugs. Sandbox names are always slugified upstream (common.sh
+# slugify -> [a-z0-9-]) and acq's own service names are slug-like. We enforce
+# that invariant here — the single choke point both the value store and the meta
+# sidecar share — so no caller can smuggle a separator/control-character-bearing
+# name past the store and silently alias another scope or affect a keychain
+# command stream. Fail closed rather than emit an ambiguous key.
 _acq_secret_key() {
   local service="$1" sandbox="${2:-}"
-  # A '.' in either segment breaks the acq.<sandbox>.<service> separator and
-  # makes the key non-injective; an empty service has no key. Reject both. This
-  # is a defensive assertion: legitimate service/sandbox names never contain a
-  # dot (see the invariant note above), so this only fires on a would-be
-  # collision. Emit no key and return non-zero so the caller fails visibly
-  # rather than reading/writing an aliased entry.
+  # Keep both segments to the existing acq/service slug alphabet. A '.' would
+  # break the acq.<sandbox>.<service> separator; control characters could split a
+  # macOS `security -i` command stream; other punctuation is unnecessary for the
+  # supported services and sandbox slugs. Emit no key and return non-zero so the
+  # caller fails visibly rather than reading/writing an aliased or injected entry.
   case "$service" in
-    ""|*.*)
-      acq_debug "secret key: refusing ambiguous service name '$service' (empty or contains '.')"
+    ""|*[!A-Za-z0-9_-]*)
+      acq_debug "secret key: refusing unsafe service name '$service'"
       return 1
       ;;
   esac
   case "$sandbox" in
-    *.*)
-      acq_debug "secret key: refusing ambiguous sandbox name '$sandbox' (contains '.')"
+    *[!A-Za-z0-9_-]*)
+      acq_debug "secret key: refusing unsafe sandbox name '$sandbox'"
       return 1
       ;;
   esac
@@ -116,6 +119,22 @@ _acq_secret_key() {
 _acq_secret_file_for() {
   local key="$1"
   printf '%s/%s\n' "$ACQ_SECRET_FILE_DIR" "$(printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_')"
+}
+
+# Quote one token for macOS `security -i`'s command stream. We terminate the
+# stream with EOF, not a literal `quit`; the latter fails on some macOS releases.
+_acq_secret_security_i_quote() {
+  local s="$1"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '"%s"' "$s"
+}
+
+_acq_secret_store_keychain_macos() {
+  local key="$1" value="$2" cmd security_bin
+  security_bin=$(_acq_secret_security_bin)
+  cmd="add-generic-password -U -s $(_acq_secret_security_i_quote "$ACQ_KEYCHAIN_LABEL") -a $(_acq_secret_security_i_quote "$key") -w $(_acq_secret_security_i_quote "$value")"
+  printf '%s\n' "$cmd" | "$security_bin" -i >/dev/null 2>&1
 }
 
 # ---------------------------------------------------------------------------
@@ -138,24 +157,20 @@ acq_secret_store() {
 
   case "$backend" in
     keychain-macos)
-      # -U updates if present; -w reads the password... but -w VALUE would put it
-      # in argv. Use -w with stdin is not supported; instead pipe via -w with a
-      # here-string is still argv. macOS `security add-generic-password` has no
-      # stdin password mode, so we fall back to the file backend when we must
-      # avoid argv. To keep the value off argv, use the file backend on macOS
-      # too UNLESS the caller accepts argv exposure. We choose safety: store to
-      # keychain via a temp file is not possible; so use `security` with the
-      # value only if ACQ_SECRET_ALLOW_ARGV=1, else file.
-      if [ -n "${ACQ_SECRET_ALLOW_ARGV:-}" ]; then
-        security add-generic-password -U \
-          -s "$ACQ_KEYCHAIN_LABEL" -a "$key" -w "$value" >/dev/null 2>&1 || {
-            echo "acq: secret store: keychain write failed for '$key'." >&2; return 1; }
+      # `security add-generic-password -w VALUE` puts VALUE on argv. Use
+      # `security -i` instead: the command stream is stdin, terminated by EOF, so
+      # the secret never appears in the process table. If that path fails, fail
+      # closed rather than silently downgrading a keychain-capable host to a
+      # plaintext file.
+      _acq_secret_store_keychain_macos "$key" "$value" || {
+        echo "acq: secret store: macOS keychain write failed for '$key'." >&2
         value=""
-        return 0
-      fi
-      # Default macOS path: 0600 file fallback (keeps the value off argv, which
-      # is the stronger guarantee; see trust hygiene rule 1).
-      _acq_secret_store_file "$key" "$value"; local rc=$?; value=""; return $rc
+        return 1
+      }
+      value=""
+      _acq_secret_delete_file "$key" || return 1
+      _acq_secret_index_add "$key"
+      return 0
       ;;
     keychain-linux)
       # secret-tool reads the secret from STDIN — never argv. Ideal.
@@ -189,18 +204,15 @@ _acq_secret_store_file() {
 # acq_secret_get KEY  ->  value on STDOUT (empty + non-zero if absent)
 # ---------------------------------------------------------------------------
 acq_secret_get() {
-  local key="$1" backend value
+  local key="$1" backend value security_bin
   backend=$(_acq_secret_backend)
   case "$backend" in
     keychain-macos)
-      if [ -z "${ACQ_SECRET_ALLOW_ARGV:-}" ]; then
-        # Value was stored in the file fallback (see acq_secret_store note).
-        _acq_secret_get_file "$key"; return $?
-      fi
-      # ALLOW_ARGV is set: prefer the keychain, but fall back to the file backend
-      # so a value stored earlier WITHOUT the flag (→ file) is still found — the
-      # flag governs where new writes go, not where reads may look.
-      value=$(security find-generic-password -s "$ACQ_KEYCHAIN_LABEL" -a "$key" -w 2>/dev/null || true)
+      # Prefer the Keychain. Fall back to the old 0600 file location so existing
+      # macOS installs that wrote before the `security -i` path keep working until
+      # the user re-saves or removes those entries.
+      security_bin=$(_acq_secret_security_bin)
+      value=$("$security_bin" find-generic-password -s "$ACQ_KEYCHAIN_LABEL" -a "$key" -w 2>/dev/null || true)
       if [ -n "$value" ]; then printf '%s' "$value"; return 0; fi
       _acq_secret_get_file "$key"; return $?
       ;;
@@ -247,24 +259,22 @@ if [ -n "${ACQ_SECRET_STORE_DIR:-}" ]; then
   ACQ_SECRET_META_DIR="${ACQ_SECRET_STORE_DIR%/}/meta"
 fi
 
-# Enumerable KEY INDEX (keychain-linux only) — a NON-SECRET plain file listing
-# one stored `acq.*` key per line. The Linux keychain (libsecret via
-# secret-tool) can look a value up BY attribute value but cannot list every item
-# by attribute NAME, so a keychain-linux store has no way to answer "what keys do
-# I hold?" without knowing the keys in advance. We record each stored key here so
-# `acq secret ls` can enumerate the keychain store the same way the file backend
-# enumerates its directory. Like the endpoint sidecar, this holds KEYS ONLY (no
-# secret values, no hosts) and is a plain 0600 file, not the keychain. The file
-# and macOS backends do NOT use this index — their file directory is already the
-# authoritative on-disk listing — so it is maintained only on keychain-linux to
-# avoid changing macOS/file behavior.
+# Enumerable KEY INDEX (keychain-backed stores) — a NON-SECRET plain file
+# listing one stored `acq.*` key per line. OS keychains can look values up by
+# account/attribute but cannot cheaply enumerate every acq item without already
+# knowing the keys. We record each stored key here so `acq secret ls` can
+# enumerate keychain-backed stores the same way the file backend enumerates its
+# directory. Like the endpoint sidecar, this holds KEYS ONLY (no secret values,
+# no hosts) and is a plain 0600 file, not the keychain. The file backend does NOT
+# use this index — its file directory is already the authoritative on-disk
+# listing.
 ACQ_SECRET_INDEX_FILE="${ACQ_SECRET_INDEX_FILE:-${ACQ_SECRET_FILE_DIR%/secrets}/secret-index}"
 if [ -n "${ACQ_SECRET_STORE_DIR:-}" ]; then
   # Offline-test escape hatch: keep the index beside the forced file store.
   ACQ_SECRET_INDEX_FILE="${ACQ_SECRET_STORE_DIR%/}/index"
 fi
 
-# _acq_secret_index_add KEY — record KEY in the keychain-linux enumeration index
+# _acq_secret_index_add KEY — record KEY in the keychain enumeration index
 # (deduplicated, 0600). Non-secret (a key name only). Best-effort: a failure to
 # update the index never fails the store — it only degrades later enumeration.
 _acq_secret_index_add() {
@@ -281,8 +291,8 @@ _acq_secret_index_add() {
   return 0
 }
 
-# _acq_secret_index_remove KEY — drop KEY from the keychain-linux enumeration
-# index (idempotent). Best-effort: never fails delete.
+# _acq_secret_index_remove KEY — drop KEY from the keychain enumeration index
+# (idempotent). Best-effort: never fails delete.
 _acq_secret_index_remove() {
   local key="$1" tmp
   [ -f "$ACQ_SECRET_INDEX_FILE" ] || return 0
@@ -452,36 +462,30 @@ acq_secret_meta_list() {
 # Enumeration is BACKEND-AWARE, because the two store shapes are enumerated
 # differently:
 #
-#   file / keychain-macos: the file directory IS the authoritative listing. On
-#     macOS the default write path is the 0600 file fallback (keeping values off
-#     argv — see acq_secret_store), so acq-managed values live in the file dir on
-#     both backends. We glob the directory for `acq.*` filenames exactly as
-#     before. On macOS with ACQ_SECRET_ALLOW_ARGV=1, a keychain-only write lands
-#     in the keychain instead of the file dir, so it is NOT enumerated by `ls`
-#     (the glob only sees the file dir). Such an entry still resolves normally at
-#     provision time — it just does not appear in the `ls` listing.
+#   file: the file directory IS the authoritative listing. We glob the directory
+#     for `acq.*` filenames exactly as before.
 #
-#   keychain-linux: the secret VALUES live in the Linux keychain, NOT in the file
-#     dir — so the file glob above would find nothing. libsecret (secret-tool)
-#     can look a value up by attribute value but cannot list every item by
-#     attribute name, so the keychain cannot answer "what keys do I hold?" on its
-#     own. We therefore enumerate from an acq-maintained NON-SECRET key index
-#     (ACQ_SECRET_INDEX_FILE, written by acq_secret_store / acq_secret_delete),
-#     UNIONED with keys reconstructed from the endpoint sidecar (belt and
-#     suspenders, in case the index lags), and VERIFY each candidate still
-#     resolves via acq_secret_get before emitting it — so a stale index entry for
-#     a deleted secret never shows. This is best-effort and never fails `ls`.
+#   keychain-macos / keychain-linux: the secret VALUES live in the OS keychain,
+#     NOT in the file dir, and neither keychain can enumerate every item by our
+#     account/attribute without already knowing the keys. We therefore enumerate
+#     from an acq-maintained NON-SECRET key index (ACQ_SECRET_INDEX_FILE, written
+#     by acq_secret_store / acq_secret_delete), UNIONED with keys reconstructed
+#     from the endpoint sidecar (belt and suspenders, in case the index lags), and
+#     VERIFY each candidate still resolves via acq_secret_get before emitting it —
+#     so a stale index entry for a deleted secret never shows. The keychain path
+#     also scans the file fallback directory so legacy macOS plaintext entries
+#     remain visible while they are still readable. This is best-effort and never
+#     fails `ls`.
 acq_secret_list_keys() {
   local backend
   backend=$(_acq_secret_backend)
   case "$backend" in
-    keychain-linux) _acq_secret_list_keys_keychain_linux ;;
-    *)              _acq_secret_list_keys_file ;;
+    keychain-macos|keychain-linux) _acq_secret_list_keys_keychain ;;
+    *)                            _acq_secret_list_keys_file ;;
   esac
 }
 
-# File-backend enumeration: glob the value directory for `acq.*` filenames. Used
-# by the file and macOS backends (see acq_secret_list_keys).
+# File-backend enumeration: glob the value directory for `acq.*` filenames.
 _acq_secret_list_keys_file() {
   local f base seen=" "
   [ -d "$ACQ_SECRET_FILE_DIR" ] || return 0
@@ -495,10 +499,10 @@ _acq_secret_list_keys_file() {
   done
 }
 
-# keychain-linux enumeration: union the acq-maintained key index with keys
+# Keychain-backed enumeration: union the acq-maintained key index with keys
 # reconstructed from the endpoint sidecar, verify each still resolves, emit
 # deduplicated `acq.*` keys. See acq_secret_list_keys for the rationale.
-_acq_secret_list_keys_keychain_linux() {
+_acq_secret_list_keys_keychain() {
   local key seen=" " svc
   # The resolve-check below is inlined at each emit site rather than factored into
   # a nested helper: a nested function plus `unset -f` would clobber a caller's
@@ -526,6 +530,21 @@ _acq_secret_list_keys_keychain_linux() {
   # so a sidecar without a matching value is silently skipped.
   if [ -d "$ACQ_SECRET_META_DIR" ]; then
     for svc in "$ACQ_SECRET_META_DIR"/*; do
+      [ -f "$svc" ] || continue
+      key=$(basename "$svc")
+      case "$key" in acq.*) ;; *) continue ;; esac
+      case "$seen" in *" $key "*) continue ;; esac
+      acq_secret_get "$key" >/dev/null 2>&1 || continue
+      seen="$seen$key "
+      printf '%s\n' "$key"
+    done
+  fi
+
+  # (c) Legacy macOS fallback files: before macOS wrote through `security -i`,
+  # the argv-safe default was a 0600 plaintext file. Keep those visible while the
+  # read path still honors them.
+  if [ -d "$ACQ_SECRET_FILE_DIR" ]; then
+    for svc in "$ACQ_SECRET_FILE_DIR"/*; do
       [ -f "$svc" ] || continue
       key=$(basename "$svc")
       case "$key" in acq.*) ;; *) continue ;; esac
@@ -577,15 +596,16 @@ _acq_secret_decode_key() {
 # the file fallback where relevant, since a value may have been written to the
 # file backend on macOS (see the acq_secret_store note about avoiding argv).
 acq_secret_delete() {
-  local key="$1" backend rc=0
+  local key="$1" backend rc=0 security_bin
   backend=$(_acq_secret_backend)
   acq_debug "secret delete: key=$key backend=$backend"
   case "$backend" in
     keychain-macos)
-      # New writes go to the file fallback (argv-safe); older ALLOW_ARGV writes
-      # may be in the keychain. Clear both so no copy lingers.
-      security delete-generic-password -s "$ACQ_KEYCHAIN_LABEL" -a "$key" \
+      # Clear both Keychain and legacy file fallback so no copy lingers.
+      security_bin=$(_acq_secret_security_bin)
+      "$security_bin" delete-generic-password -s "$ACQ_KEYCHAIN_LABEL" -a "$key" \
         >/dev/null 2>&1 || true
+      _acq_secret_index_remove "$key"
       _acq_secret_delete_file "$key" || rc=$?
       ;;
     keychain-linux)
@@ -706,11 +726,10 @@ _acq_read_secret_masked() {
 # provision. HOST/ENV are metadata only — never the value.
 acq_secret_set_interactive() {
   local service="$1" sandbox="${2:-}" host="${3:-}" env="${4:-}" key value
-  # _acq_secret_key fails closed on an ambiguous (dotted) service/sandbox that
-  # would alias another scope in the shared store. Refuse the
-  # set before reading a value so nothing is stored under an aliased key.
+  # _acq_secret_key fails closed on unsafe service/sandbox names before reading a
+  # value, so nothing is stored under an aliased or command-stream-breaking key.
   if ! key=$(_acq_secret_key "$service" "$sandbox"); then
-    echo "acq: secret set: refusing '$service'${sandbox:+ (sandbox '$sandbox')} — a service or sandbox name may not contain '.'" >&2
+    echo "acq: secret set: refusing '$service'${sandbox:+ (sandbox '$sandbox')} — service and sandbox names must match [A-Za-z0-9_-]+" >&2
     return 1
   fi
 

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -606,11 +606,15 @@ store at provision:
 ./acq secret set my-sandbox usai    # sandbox-scoped; overrides the global key
 ```
 
-The store lives in the host OS keychain when available (macOS `security`, Linux
-`secret-tool`) with a `0600` file fallback under `$XDG_DATA_HOME/acq/secrets/`.
-Entries are keyed `acq.<service>` (global) or `acq.<sandbox>.<service>`
-(sandbox-scoped); a sandbox-scoped key takes precedence over the global one for
-the same service (supporting USAi per-sandbox billing-code keys).
+The store lives in the host OS keychain when available (macOS `security -i`,
+Linux `secret-tool`) with a `0600` file fallback under
+`$XDG_DATA_HOME/acq/secrets/` when no keychain backend is available. macOS writes
+use `security -i` so the value travels on stdin, not process argv. Existing
+legacy macOS file-backed entries are still read as a fallback until they are
+re-saved or removed. Entries are keyed `acq.<service>` (global) or
+`acq.<sandbox>.<service>` (sandbox-scoped); a sandbox-scoped key takes precedence
+over the global one for the same service (supporting USAi per-sandbox
+billing-code keys).
 
 At `acq run`/`create`, the **msb** backend reads the value from the store,
 exports it into a transient host env var, and binds it with

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -13,6 +13,14 @@ supersedes: []
 
 # ADR-0011: Add msb (microsandbox) Backend and Neutral hybrid/v1 Kit Translation
 
+> **Update (2026-09-01):** The macOS acq secret store now uses
+> `/usr/bin/security -i` for Keychain writes. The secret value is embedded in the
+> `security -i` stdin command stream and the stream is terminated by EOF, keeping
+> the value off argv while preserving the OS Keychain storage decision below.
+> The `0600` file path remains a fallback when no keychain backend is available,
+> and existing legacy macOS file-backed entries are still read until re-saved or
+> removed.
+>
 > **Update (2026-07-31):** The default `ACQ_MSB_IMAGE` is now
 > **`docker.io/docker/sandbox-templates:shell-docker`** — the same Ubuntu-based sbx
 > agent-template image — **not** `node:22-bookworm`. The default therefore already
@@ -93,11 +101,12 @@ the neutral `hybrid/v1` kits, JSON schema, and registry) lands separately in
 - **`acq.backends/secret-store.sh`** — the acq-owned, backend-neutral secret
   store (the design's §7.5 model, as a thin bash subset). Credentials are no
   longer sbx-specific: one store keyed `acq.<service>` / `acq.<sandbox>.<service>`
-  (sandbox scope wins), stored in the OS keychain (macOS `security`, Linux
-  `secret-tool`) with a `0600` file fallback. `acq secret set` writes here; both
-  adapters read from here at provision. Trust hygiene per §7.5: the value is
-  read from TTY/stdin (never argv), never serialized into kit specs/config/logs,
-  and file entries are `0600`. Feeding each backend's runtime respects the real
+  (sandbox scope wins), stored in the OS keychain (macOS `security -i`, Linux
+  `secret-tool`) with a `0600` file fallback when no keychain backend is
+  available. `acq secret set` writes here; both adapters read from here at
+  provision. Trust hygiene per §7.5: the value is read from TTY/stdin (never
+  argv), never serialized into kit specs/config/logs, and file entries are
+  `0600`. Feeding each backend's runtime respects the real
   CLI contract: sbx built-in services take the value on **stdin**
   (`sbx secret set`), while sbx **custom endpoints** (`set-custom`) have no stdin
   and would require `--value` on argv — so acq runs `set-custom` interactively

--- a/scripts/probe-macos-keychain-stdin
+++ b/scripts/probe-macos-keychain-stdin
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# probe-macos-keychain-stdin - validate argv-safe macOS Keychain write patterns
+# for acq's backend-neutral secret store.
+#
+# This is a HOST-SIDE probe for macOS only. It writes synthetic throwaway values
+# to the user's default login keychain under a unique service name, reads them
+# back, then removes them. It never uses real acq secrets and never prints the
+# synthetic secret values.
+#
+# Usage:
+#   ./scripts/probe-macos-keychain-stdin [--prompt-form]
+#
+# Exit 0 means the `security -i` pattern is viable for acq's macOS keychain
+# store path. The direct `security ... -w` prompt-style pattern is opt-in via
+# --prompt-form because it may attach to the terminal and prompt after timeout.
+set -u
+
+PASS=0
+FAIL=0
+INFO=0
+RUN_PROMPT_FORM=""
+SERVICE="acq-keychain-stdin-probe-$$-$(date +%s)"
+ACCOUNTS=""
+
+ok() { PASS=$((PASS + 1)); printf '  ok   %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  BAD  %s\n' "$1"; [ -n "${2:-}" ] && printf '       %s\n' "$2"; }
+note() { INFO=$((INFO + 1)); printf '  info %s\n' "$1"; }
+section() { printf '\n== %s ==\n' "$1"; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+cleanup() {
+  local account
+  trap - EXIT INT TERM
+  for account in $ACCOUNTS; do
+    /usr/bin/security delete-generic-password -s "$SERVICE" -a "$account" \
+      >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT INT TERM
+
+record_account() {
+  ACCOUNTS="${ACCOUNTS:+$ACCOUNTS }$1"
+}
+
+usage() {
+  sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --prompt-form) RUN_PROMPT_FORM=1 ;;
+      -h|--help) usage; exit 0 ;;
+      *) echo "unknown arg: $1" >&2; usage >&2; exit 2 ;;
+    esac
+    shift
+  done
+}
+
+require_macos() {
+  if [ "$(uname -s 2>/dev/null)" != "Darwin" ]; then
+    bad "macOS is required" "This probe must run on the Mac host, not inside the Linux sandbox."
+    exit 2
+  fi
+  if [ ! -x /usr/bin/security ]; then
+    bad "/usr/bin/security not found" "Cannot probe the macOS Keychain CLI."
+    exit 2
+  fi
+}
+
+# Quote a single token for the `security -i` command stream. This is deliberately
+# a probe of the smallest useful grammar for acq values: one-line strings with
+# double quotes and backslashes escaped inside double quotes. If this fails for a
+# representative value, acq should not use this path without a stronger encoder.
+security_i_quote() {
+  local s="$1"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '"%s"' "$s"
+}
+
+security_i_store() {
+  local account="$1" value="$2" cmd_stream
+  cmd_stream="add-generic-password -U -s $(security_i_quote "$SERVICE") -a $(security_i_quote "$account") -w $(security_i_quote "$value")"
+  # `security -i` exits on EOF. A literal `quit` command is not portable across
+  # tested macOS versions and can make an otherwise-successful store return nonzero.
+  printf '%s\n' "$cmd_stream" | /usr/bin/security -i >/dev/null 2>&1
+}
+
+security_i_store_unquoted_basic() {
+  local account="$1" value="$2"
+  case "$SERVICE$account$value" in
+    *[!A-Za-z0-9._-]*) return 2 ;;
+  esac
+  printf 'add-generic-password -U -s %s -a %s -w %s\nquit\n' \
+    "$SERVICE" "$account" "$value" | /usr/bin/security -i >/dev/null 2>&1
+}
+
+security_i_store_stdin_no_quit_basic() {
+  local account="$1" value="$2"
+  case "$SERVICE$account$value" in
+    *[!A-Za-z0-9._-]*) return 2 ;;
+  esac
+  printf 'add-generic-password -U -s %s -a %s -w %s\n' \
+    "$SERVICE" "$account" "$value" | /usr/bin/security -i >/dev/null 2>&1
+}
+
+security_get() {
+  local account="$1"
+  /usr/bin/security find-generic-password -s "$SERVICE" -a "$account" -w 2>/dev/null
+}
+
+security_store_prompt_with_timeout() {
+  local account="$1" value="$2" timeout_s=5 pid elapsed=0
+  (
+    printf '%s\n' "$value" | /usr/bin/security add-generic-password -U \
+      -s "$SERVICE" -a "$account" -w >/dev/null 2>&1
+  ) &
+  pid=$!
+  while kill -0 "$pid" >/dev/null 2>&1; do
+    if [ "$elapsed" -ge "$timeout_s" ]; then
+      kill "$pid" >/dev/null 2>&1 || true
+      wait "$pid" >/dev/null 2>&1 || true
+      return 124
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  wait "$pid"
+}
+
+assert_store_roundtrip_i() {
+  local name="$1" account="$2" value="$3" got
+  record_account "$account"
+  if ! security_i_store "$account" "$value"; then
+    bad "$name: security -i store failed"
+    return 1
+  fi
+  got=$(security_get "$account" || true)
+  if [ "$got" = "$value" ]; then
+    ok "$name: security -i stored and retrieved the expected value"
+    return 0
+  fi
+  bad "$name: retrieved value did not match" "The command-stream quoting is not safe enough for this value shape."
+  return 1
+}
+
+test_security_i_basic() {
+  assert_store_roundtrip_i "basic" "basic" "probe-basic-value-123"
+}
+
+test_security_i_basic_variants() {
+  local value="probe-basic-value-123" got account
+
+  account="basic-unquoted"
+  record_account "$account"
+  if security_i_store_unquoted_basic "$account" "$value"; then
+    got=$(security_get "$account" || true)
+    if [ "$got" = "$value" ]; then
+      ok "basic variant: unquoted tokens with literal quit worked"
+    else
+      bad "basic variant: unquoted tokens with literal quit stored a non-matching value"
+    fi
+  else
+    note "basic variant: unquoted tokens with literal quit failed"
+  fi
+
+  account="basic-no-quit"
+  record_account "$account"
+  if security_i_store_stdin_no_quit_basic "$account" "$value"; then
+    got=$(security_get "$account" || true)
+    if [ "$got" = "$value" ]; then
+      ok "basic variant: unquoted tokens with EOF termination worked"
+    else
+      bad "basic variant: unquoted tokens with EOF termination stored a non-matching value"
+    fi
+  else
+    note "basic variant: unquoted tokens with EOF termination failed"
+  fi
+}
+
+test_security_i_special_chars() {
+  # Single-line by design: acq's current store rejects multi-line secrets. This
+  # value exercises characters likely to stress the `security -i` parser without
+  # printing them in the transcript.
+  assert_store_roundtrip_i \
+    "special chars" \
+    "special" \
+    "probe value with spaces -dash quote\" backslash\\ dollar\$ semi; single' end"
+}
+
+test_security_i_overwrite() {
+  local account="overwrite" first="probe-first-value" second="probe-second-value" got
+  record_account "$account"
+  if ! security_i_store "$account" "$first"; then
+    bad "overwrite: initial security -i store failed"
+    return 1
+  fi
+  if ! security_i_store "$account" "$second"; then
+    bad "overwrite: security -i -U update failed"
+    return 1
+  fi
+  got=$(security_get "$account" || true)
+  if [ "$got" = "$second" ]; then
+    ok "overwrite: security -i -U replaced the existing value"
+    return 0
+  fi
+  bad "overwrite: retrieved value was not the updated value"
+  return 1
+}
+
+test_prompt_form() {
+  local account="prompt-form" value="probe-prompt-value" got rc
+  record_account "$account"
+  security_store_prompt_with_timeout "$account" "$value"
+  rc=$?
+  case "$rc" in
+    0)
+      got=$(security_get "$account" || true)
+      if [ "$got" = "$value" ]; then
+        ok "prompt form: bare -w accepted a piped value"
+      else
+        note "prompt form: command exited 0, but no matching value was stored"
+      fi
+      ;;
+    124)
+      note "prompt form: timed out; likely waits on terminal input instead of stdin"
+      ;;
+    *)
+      note "prompt form: bare -w failed non-interactively (exit $rc)"
+      ;;
+  esac
+}
+
+main() {
+  parse_args "$@"
+
+  section "preflight"
+  require_macos
+  note "service: $SERVICE"
+  if ! have sw_vers; then
+    note "sw_vers not available"
+  else
+    sw_vers | sed 's/^/  info /'
+  fi
+
+  section "security -i command-stream writes"
+  test_security_i_basic
+  test_security_i_basic_variants
+  test_security_i_special_chars
+  test_security_i_overwrite
+
+  section "bare -w prompt form"
+  if [ -n "$RUN_PROMPT_FORM" ]; then
+    test_prompt_form
+  else
+    note "skipped by default; pass --prompt-form to test the terminal prompt behavior"
+  fi
+
+  section "cleanup"
+  cleanup
+  ok "removed throwaway keychain entries for $SERVICE"
+
+  section "summary"
+  printf '  passed: %s\n' "$PASS"
+  printf '  failed: %s\n' "$FAIL"
+  printf '  info:   %s\n' "$INFO"
+
+  if [ "$FAIL" -eq 0 ]; then
+    printf '\nResult: security -i is viable for an argv-safe macOS Keychain write path.\n'
+    exit 0
+  fi
+  printf '\nResult: security -i did not pass all required checks. Keep the file fallback or use a native helper.\n'
+  exit 1
+}
+
+main "$@"

--- a/test/bats/05-install.bats
+++ b/test/bats/05-install.bats
@@ -9,6 +9,12 @@ setup() {
   export PATH="$STUBDIR/bin:$PATH"
   export ACQ_INSTALL_CLONE_DIR="$BATS_TEST_TMPDIR/acq-clone"
   export ACQ_INSTALL_BIN_DIR="$BATS_TEST_TMPDIR/bin"
+  # Derive the expected default version from install.sh itself rather than
+  # hardcoding it here: release-please bumps DEFAULT_RELEASE_VERSION on every
+  # release (the x-release-please-version annotation), and a hardcoded
+  # assertion in this file would silently go stale on the next release with
+  # no test catching it -- exactly what happened (v2.0.0 -> v3.0.0).
+  DEFAULT_VERSION_TAG="v$(sed -n 's/^DEFAULT_RELEASE_VERSION="\([^"]*\)".*/\1/p' "$REPO_ROOT/install.sh")"
 }
 
 teardown() {
@@ -74,7 +80,7 @@ STUB
     --method clone --no-msb --dry-run --yes
 
   assert_success
-  assert_output --partial 'version:   v2.0.0'
+  assert_output --partial "version:   $DEFAULT_VERSION_TAG"
   refute_output --partial 'pinned commit:'
 }
 
@@ -89,7 +95,7 @@ STUB
   run sh "$release_installer" --method clone --no-msb --yes
 
   assert_success
-  assert_output --partial "version:   v2.0.0"
+  assert_output --partial "version:   $DEFAULT_VERSION_TAG"
   assert_output --partial "pinned commit: $release_sha"
   assert_output --partial "verified HEAD matches pinned commit $release_sha"
 }

--- a/test/bats/71b-msb-secret-store-backends.bats
+++ b/test/bats/71b-msb-secret-store-backends.bats
@@ -42,6 +42,77 @@ STSTUB
   chmod +x "$STUBDIR/secret-tool"
 }
 
+# A narrow macOS /usr/bin/security stub for the keychain-macos secret store path.
+# It only needs the safe subset acq uses: `security -i` with one
+# add-generic-password command, `find-generic-password -w`, and delete.
+_plant_security_stub() {
+  cat >"$STUBDIR/security" <<'SECSTUB'
+#!/usr/bin/env bash
+_dir="${STUBDIR}/security-store"
+mkdir -p "$_dir" 2>/dev/null || true
+_keyfile() { printf '%s/%s' "$_dir" "$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_')"; }
+_split_security_i_line() {
+  _line="$1"; _tok=""; _inq=0; _esc=0; _i=0
+  while [ "$_i" -lt "${#_line}" ]; do
+    _c="${_line:$_i:1}"
+    if [ "$_esc" -eq 1 ]; then
+      _tok="$_tok$_c"; _esc=0
+    elif [ "$_inq" -eq 1 ] && [ "$_c" = "\\" ]; then
+      _esc=1
+    elif [ "$_c" = '"' ]; then
+      [ "$_inq" -eq 1 ] && _inq=0 || _inq=1
+    elif [ "$_inq" -eq 0 ]; then
+      case "$_c" in
+        " "|"	") [ -n "$_tok" ] && { printf '%s\n' "$_tok"; _tok=""; } ;;
+        *) _tok="$_tok$_c" ;;
+      esac
+    else
+      _tok="$_tok$_c"
+    fi
+    _i=$((_i + 1))
+  done
+  [ -n "$_tok" ] && printf '%s\n' "$_tok"
+}
+_arg_after() {
+  _flag="$1"; shift
+  _prev=""
+  for _a in "$@"; do
+    [ "$_prev" = "$_flag" ] && { printf '%s' "$_a"; return 0; }
+    _prev="$_a"
+  done
+  return 1
+}
+case "${1:-}" in
+  -i)
+    printf 'security -i\n' >>"$CALLS"
+    IFS= read -r _line || exit 1
+    _tokens=()
+    while IFS= read -r _tok; do _tokens+=("$_tok"); done <<EOF
+$(_split_security_i_line "$_line")
+EOF
+    set -- "${_tokens[@]}"
+    [ "${1:-}" = "add-generic-password" ] || exit 1
+    _account=""; _value=""; _prev=""
+    for _a in "$@"; do
+      if [ "$_prev" = "-a" ]; then _account="$_a"; _prev=""; continue; fi
+      if [ "$_prev" = "-w" ]; then _value="$_a"; _prev=""; continue; fi
+      case "$_a" in -a|-w) _prev="$_a" ;; esac
+    done
+    [ -n "$_account" ] || exit 1
+    printf '%s' "$_value" > "$(_keyfile "$_account")"
+    exit 0 ;;
+  find-generic-password)
+    _account=$(_arg_after -a "$@") || exit 1
+    _f="$(_keyfile "$_account")"; [ -f "$_f" ] || exit 1; cat "$_f"; exit 0 ;;
+  delete-generic-password)
+    _account=$(_arg_after -a "$@") || exit 0
+    rm -f "$(_keyfile "$_account")" 2>/dev/null || true; exit 0 ;;
+  *) exit 1 ;;
+esac
+SECSTUB
+  chmod +x "$STUBDIR/security"
+}
+
 # Provision helper (as in 71): source common (chains deps) + msb, seed store,
 # stub kit fetch, provision.
 _provision() { # NAME PRE_SNIPPET WS_ARGS...
@@ -79,6 +150,53 @@ _provision() { # NAME PRE_SNIPPET WS_ARGS...
   refute_output --partial 'KL-USAI-VALUE'
   refute_output --partial 'KL-GITHUB-VALUE'
   assert_output --partial 'after-del=[acq.usai ]'
+}
+
+@test "keychain-macos: stores via security -i, lists via index, falls back to legacy file" {
+  _plant_security_stub
+  run bash -c '
+    export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/km-secrets"
+    export STUBDIR="'"$STUBDIR"'"
+    . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    unset ACQ_SECRET_FORCE_FILE
+    export ACQ_SECRET_SECURITY_BIN="'"$STUBDIR"'/security"
+    _acq_secret_backend() { printf "keychain-macos\n"; }
+    mkdir -p "$ACQ_SECRET_FILE_DIR"
+    printf "OLD-USAI" > "$ACQ_SECRET_FILE_DIR/acq.usai"
+    ACQ_SECRET_TEST_VALUE="MAC VALUE quote\" backslash\\ end" acq_secret_set_interactive usai "" >/dev/null 2>&1
+    printf "resolved=[%s]\n" "$(acq_secret_resolve usai)"
+    [ -f "$ACQ_SECRET_FILE_DIR/acq.usai" ] && printf "same-key-file=present\n" || printf "same-key-file=gone\n"
+    printf "listing=[%s]\n" "$(acq_secret_list_keys | sort | tr "\n" " ")"
+    printf "LEGACY" > "$ACQ_SECRET_FILE_DIR/acq.legacy"
+    printf "legacy=[%s]\n" "$(acq_secret_resolve legacy)"
+    printf "listing-legacy=[%s]\n" "$(acq_secret_list_keys | sort | tr "\n" " ")"
+    acq_secret_delete "$(_acq_secret_key usai)" >/dev/null 2>&1
+    acq_secret_resolve usai >/dev/null 2>&1 && printf "after=present\n" || printf "after=gone\n"
+  '
+  assert_output --partial 'resolved=[MAC VALUE quote" backslash\ end]'
+  assert_output --partial 'same-key-file=gone'
+  assert_output --partial 'listing=[acq.usai ]'
+  assert_output --partial 'legacy=[LEGACY]'
+  assert_output --partial 'listing-legacy=[acq.legacy acq.usai ]'
+  assert_output --partial 'after=gone'
+  assert_regex "$(cat "$CALLS")" '^security -i$'
+}
+
+@test "keychain-macos: unsafe service names are refused before security -i" {
+  _plant_security_stub
+  run bash -c '
+    export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/km-unsafe-secrets"
+    export STUBDIR="'"$STUBDIR"'"
+    export ACQ_SECRET_SECURITY_BIN="'"$STUBDIR"'/security"
+    . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    unset ACQ_SECRET_FORCE_FILE
+    _acq_secret_backend() { printf "keychain-macos\n"; }
+    ACQ_SECRET_TEST_VALUE="SHOULD-NOT-STORE" acq_secret_set_interactive $'"'"'bad\nservice'"'"' "" >/dev/null 2>&1 && printf "newline=stored\n" || printf "newline=refused\n"
+    ACQ_SECRET_TEST_VALUE="SHOULD-NOT-STORE" acq_secret_set_interactive "bad;service" "" >/dev/null 2>&1 && printf "punct=stored\n" || printf "punct=refused\n"
+  '
+  assert_output --partial 'newline=refused'
+  assert_output --partial 'punct=refused'
+  refute_regex "$(cat "$CALLS")" '^security -i$'
 }
 
 @test "file ls: a stored secret lists (no value); an empty store lists nothing" {


### PR DESCRIPTION
## Context

`acq secret` was falling back to host plaintext `0600` files on macOS to avoid putting secret values on argv with `security add-generic-password -w VALUE`. A host-side probe confirmed that `/usr/bin/security -i` can write generic-password items from stdin when the command stream is terminated by EOF.

This PR also includes `679f4472856b08b507ba2d92236a7cc47bb5bae5` (`fix(test): derive expected install.sh version instead of hardcoding it`) so the full offline suite reflects the current release tag.

AI-assisted: yes.

## Plan

- Add a macOS Keychain write path using `/usr/bin/security -i` with stdin command-stream input.
- Keep secret values off argv and avoid `security` PATH hijacking by using `/usr/bin/security` in production.
- Preserve compatibility with legacy macOS file-backed secrets by reading them as a fallback.
- Remove same-key legacy file fallback entries after successful Keychain re-save.
- Use the non-secret key index so `acq secret ls` can list macOS Keychain-backed entries.
- Add a host-side macOS probe script and stubbed offline tests for the Keychain path.
- Update docs and ADR-0011 to describe the new macOS behavior.

## Verification

- `bash -n acq.backends/secret-store.sh scripts/probe-macos-keychain-stdin test/bats/71b-msb-secret-store-backends.bats`
  - PASS
- `git diff --check -- acq.backends/secret-store.sh scripts/probe-macos-keychain-stdin test/bats/71b-msb-secret-store-backends.bats docs/BACKEND_GUIDE.md docs/adr/0011-msb-backend-and-neutral-kits.md`
  - PASS
- `./scripts/test-acq-bats test/bats/71b-msb-secret-store-backends.bats`
  - PASS, 9/9
- `./scripts/test-acq-bats test/bats/40-secret-set.bats test/bats/45-secret-store-unit.bats test/bats/71b-msb-secret-store-backends.bats`
  - PASS, 45/45
- `./scripts/test-acq-bats`
  - PASS, 404/404
- `./scripts/probe-macos-keychain-stdin`
  - BLOCKED in this Linux sandbox as expected: fails closed with "macOS is required"
  - Live host probe was run manually on macOS 26.6.2 and passed: basic, special-character, and overwrite `security -i` cases succeeded; bare `-w` prompt form was skipped by default.

## Rollback

Revert this PR. macOS will return to the previous argv-safe `0600` file fallback behavior for new writes. Existing Keychain entries can be removed with `acq secret rm` or left unused if the old file fallback path is restored.

## Security Impact

- Improves macOS secret storage by using the OS Keychain instead of plaintext file fallback when `/usr/bin/security` is available.
- Keeps secret values off argv by using `security -i` over stdin.
- Avoids command hijacking by invoking `/usr/bin/security` directly in production.
- Rejects unsafe service/sandbox names before constructing a Keychain command stream.
- Removes same-key legacy plaintext fallback files after successful Keychain re-save.
