### PR TITLE
fix(msb): carry the source checkout's git identity into the --clone scratch

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -2397,10 +2397,6 @@ _acq_msb_clone_copy_identity() {
   for key in user.name user.email; do
     val=$(git -C "$src" config --get "$key" 2>/dev/null) || continue
     [ -n "$val" ] || continue
-    if command -v _acq_git_identity_value_is_safe >/dev/null 2>&1 \
-        && ! _acq_git_identity_value_is_safe "$val"; then
-      continue
-    fi
     git -C "$scratch" config "$key" "$val" >/dev/null 2>&1 \
       || echo "acq(msb): warning: --clone: could not set $key in the scratch clone." >&2
   done

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -2391,7 +2391,10 @@ _acq_msb_clone_setup() {
 # identity unknown". `git -C SRC config --get` resolves the value exactly as
 # the user's own commits do. Running git inside the scratch is safe HERE only:
 # acq just created it and it is not yet guest-exposed (see the rm-time rule in
-# _acq_msb_clone_warn_unfetched). Best-effort, always returns 0.
+# _acq_msb_clone_warn_unfetched). Unlike the global-identity forwarder in
+# common.sh there is no control-character filter: the values go through `git
+# config`, which escapes on write, never onto a command line. Best-effort,
+# always returns 0.
 _acq_msb_clone_copy_identity() {
   local src="$1" scratch="$2" key val
   for key in user.name user.email; do

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -2369,6 +2369,7 @@ _acq_msb_clone_setup() {
     rm -rf "$dir"
     return 1
   fi
+  _acq_msb_clone_copy_identity "$ws_canon" "$scratch"
   # Fetch-back remote in the host checkout (replace a stale same-name remote —
   # its scratch dir was just verified absent, so it cannot hold unfetched work).
   git -C "$ws_canon" remote remove "sandbox-${name}" >/dev/null 2>&1 || true
@@ -2379,6 +2380,33 @@ _acq_msb_clone_setup() {
   echo "acq(msb): agent runs on a disposable clone; the real checkout is untouched." >&2
   echo "acq(msb):   Recover agent branches with: git fetch sandbox-${name}" >&2
   _ACQ_MSB_CLONE_DIR=$(canonicalize_path "$scratch")
+  return 0
+}
+
+# _acq_msb_clone_copy_identity SRC SCRATCH — write the source checkout's
+# EFFECTIVE git identity (user.name/user.email) repo-locally into the scratch.
+# A clone drops .git/config, and a per-forge identity commonly lives only
+# there or in a gitdir-scoped includeIf, so without this the first in-guest
+# commit fails with "Author identity unknown"; the guest's global tier (synced
+# from the host's global config) cannot express a per-repo value. Resolved on
+# the host exactly as the user's own commits resolve it. sbx's native --clone
+# copies .git wholesale and carries identity incidentally; this is the
+# minimized form of that. Running git inside the scratch is safe HERE only:
+# acq just created it and it is not yet guest-exposed (see the rm-time rule in
+# _acq_msb_clone_warn_unfetched). Values with control characters are skipped
+# like the global-tier sync does. Best-effort, always returns 0.
+_acq_msb_clone_copy_identity() {
+  local src="$1" scratch="$2" key val
+  for key in user.name user.email; do
+    val=$(git -C "$src" config --get "$key" 2>/dev/null) || continue
+    [ -n "$val" ] || continue
+    if command -v _acq_git_identity_value_is_safe >/dev/null 2>&1 \
+        && ! _acq_git_identity_value_is_safe "$val"; then
+      continue
+    fi
+    git -C "$scratch" config "$key" "$val" >/dev/null 2>&1 \
+      || echo "acq(msb): warning: --clone: could not set $key in the scratch clone." >&2
+  done
   return 0
 }
 

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -2383,18 +2383,15 @@ _acq_msb_clone_setup() {
   return 0
 }
 
-# _acq_msb_clone_copy_identity SRC SCRATCH — write the source checkout's
-# EFFECTIVE git identity (user.name/user.email) repo-locally into the scratch.
-# A clone drops .git/config, and a per-forge identity commonly lives only
-# there or in a gitdir-scoped includeIf, so without this the first in-guest
-# commit fails with "Author identity unknown"; the guest's global tier (synced
-# from the host's global config) cannot express a per-repo value. Resolved on
-# the host exactly as the user's own commits resolve it. sbx's native --clone
-# copies .git wholesale and carries identity incidentally; this is the
-# minimized form of that. Running git inside the scratch is safe HERE only:
+# _acq_msb_clone_copy_identity SRC SCRATCH — write SRC's EFFECTIVE git
+# identity (user.name/user.email) repo-locally into the scratch. A clone drops
+# .git/config, and a per-forge identity often lives only there or behind a
+# gitdir-scoped includeIf; the guest's synced global tier cannot express a
+# per-repo value, so without this the first in-guest commit fails with "Author
+# identity unknown". `git -C SRC config --get` resolves the value exactly as
+# the user's own commits do. Running git inside the scratch is safe HERE only:
 # acq just created it and it is not yet guest-exposed (see the rm-time rule in
-# _acq_msb_clone_warn_unfetched). Values with control characters are skipped
-# like the global-tier sync does. Best-effort, always returns 0.
+# _acq_msb_clone_warn_unfetched). Best-effort, always returns 0.
 _acq_msb_clone_copy_identity() {
   local src="$1" scratch="$2" key val
   for key in user.name user.email; do

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -362,12 +362,11 @@ msb has no native clone mode, so the neutral `--clone`
 committed state only. Gitignored/untracked files (sbx copies these — the known
 host-build-state contamination trap) and uncommitted edits to tracked files do
 **not** enter the sandbox; `acq` prints a notice when the host tree is dirty.
-Commit first, or copy specific files in with `acq cp`. One thing a plain clone
-would drop is carried deliberately: the source checkout's effective git
-identity (`user.name`/`user.email`, however it resolves on the host) is written
-repo-locally into the scratch, so a per-forge identity kept in `.git/config` or
-a gitdir-scoped include still authors the sandbox's commits (sbx carries it
-incidentally by copying `.git` wholesale).
+Commit first, or copy specific files in with `acq cp`. One exception is
+deliberate: the source checkout's effective git identity
+(`user.name`/`user.email`) is written into the scratch as repo-local config, so
+a per-forge identity kept in `.git/config` or a gitdir-scoped include still
+authors the sandbox's commits. See ADR-0027 for the rationale.
 
 The scratch clone lives on host disk (unlike sbx's in-guest clone), confined to
 the acq-managed state dir — disposable by construction and never executed by

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -362,7 +362,12 @@ msb has no native clone mode, so the neutral `--clone`
 committed state only. Gitignored/untracked files (sbx copies these — the known
 host-build-state contamination trap) and uncommitted edits to tracked files do
 **not** enter the sandbox; `acq` prints a notice when the host tree is dirty.
-Commit first, or copy specific files in with `acq cp`.
+Commit first, or copy specific files in with `acq cp`. One thing a plain clone
+would drop is carried deliberately: the source checkout's effective git
+identity (`user.name`/`user.email`, however it resolves on the host) is written
+repo-locally into the scratch, so a per-forge identity kept in `.git/config` or
+a gitdir-scoped include still authors the sandbox's commits (sbx carries it
+incidentally by copying `.git` wholesale).
 
 The scratch clone lives on host disk (unlike sbx's in-guest clone), confined to
 the acq-managed state dir — disposable by construction and never executed by

--- a/docs/adr/0027-neutral-clone-option.md
+++ b/docs/adr/0027-neutral-clone-option.md
@@ -116,6 +116,17 @@ A git clone carries **committed state only**:
   dirty working tree; the msb emulation does not. Create prints a notice when
   the host tree is dirty: commit first, or `acq cp` the files in.
 
+One piece of uncommitted state is carried on purpose: the source checkout's
+**effective git identity** (`user.name`/`user.email`, resolved on the host as
+the user's own commits resolve it) is written repo-locally into the scratch.
+A clone drops `.git/config`, and per-forge identities commonly live only there
+or in a gitdir-scoped include, so without it the first in-sandbox commit fails
+with "Author identity unknown"; the guest's global tier cannot express a
+per-repo value. sbx carries identity incidentally by copying `.git` wholesale;
+propagating only the two inert `user.*` values is the minimized form of that,
+without the credential helpers, hooks, and URL rewrites that ride along with a
+wholesale copy.
+
 ### Trade-off stated openly
 
 The scratch clone lives on **host disk** (unlike sbx's in-guest clone), so

--- a/docs/adr/0027-neutral-clone-option.md
+++ b/docs/adr/0027-neutral-clone-option.md
@@ -116,14 +116,15 @@ A git clone carries **committed state only**:
   dirty working tree; the msb emulation does not. Create prints a notice when
   the host tree is dirty: commit first, or `acq cp` the files in.
 
-One piece of uncommitted state is carried on purpose: the source checkout's
-**effective git identity** (`user.name`/`user.email`, resolved on the host as
-the user's own commits resolve it) is written repo-locally into the scratch.
-A clone drops `.git/config`, and per-forge identities commonly live only there
-or in a gitdir-scoped include, so without it the first in-sandbox commit fails
-with "Author identity unknown"; the guest's global tier cannot express a
-per-repo value. sbx carries identity incidentally by copying `.git` wholesale;
-propagating only the two inert `user.*` values is the minimized form of that,
+Unlike the two divergences above, one piece of uncommitted state is carried on
+purpose: the source checkout's **effective git identity**
+(`user.name`/`user.email`), resolved on the host as the user's own commits
+resolve it, is written repo-locally into the scratch. A clone drops
+`.git/config`, and per-forge identities commonly live only there or in a
+gitdir-scoped include. Without the copy, the first in-sandbox commit fails with
+"Author identity unknown"; the guest's global tier cannot express a per-repo
+value. sbx carries identity incidentally by copying `.git` wholesale.
+Propagating only the two inert `user.*` values is the minimized form of that,
 without the credential helpers, hooks, and URL rewrites that ride along with a
 wholesale copy.
 

--- a/test/bats/116-clone-option.bats
+++ b/test/bats/116-clone-option.bats
@@ -282,13 +282,3 @@ _msb_clone_isolated() { # ARGS...
   run git config --file "$scratch/.git/config" user.email
   assert_failure
 }
-
-@test "clone(msb #438): a control-character identity value is not propagated" {
-  git -C "$CLONEPROJ" config user.name "$(printf 'Bad\tUser')"
-  git -C "$CLONEPROJ" config user.email "ok@example.gov"
-  _msb_clone_isolated create shell --clone "$CLONEPROJ"
-  local scratch="$STUBDIR/state/clones/shell-cloneproj/cloneproj"
-  run git config --file "$scratch/.git/config" user.name
-  assert_failure
-  [ "$(git config --file "$scratch/.git/config" user.email)" = "ok@example.gov" ]
-}

--- a/test/bats/116-clone-option.bats
+++ b/test/bats/116-clone-option.bats
@@ -257,3 +257,39 @@ _create_line() { printf '%s\n' "$(cat "$CALLS")" | grep "^$1 create"; }
   env ACQ_BACKEND=sbx "$ACQ" create opencode --clone "$CLONEPROJ" >/dev/null 2>&1
   assert_regex "$(_create_line sbx)" '--clone'
 }
+
+# Host git identity is neutralized for the identity tests (isolated HOME/XDG,
+# no system config) so only the source checkout's repo-local values, or their
+# absence, reach the scratch.
+_msb_clone_isolated() { # ARGS...
+  _msb_clone HOME="$STUBDIR/nohome" XDG_CONFIG_HOME="$STUBDIR/noconfig" GIT_CONFIG_NOSYSTEM=1 -- "$@"
+}
+
+@test "clone(msb #438): the scratch carries the source checkout's effective git identity, repo-locally" {
+  git -C "$CLONEPROJ" config user.name "Repo User"
+  git -C "$CLONEPROJ" config user.email "repo@example.gov"
+  _msb_clone_isolated create shell --clone "$CLONEPROJ"
+  local scratch="$STUBDIR/state/clones/shell-cloneproj/cloneproj"
+  [ "$(git config --file "$scratch/.git/config" user.name)" = "Repo User" ]
+  [ "$(git config --file "$scratch/.git/config" user.email)" = "repo@example.gov" ]
+}
+
+@test "clone(msb #438): no effective source identity writes nothing into the scratch" {
+  _msb_clone_isolated create shell --clone "$CLONEPROJ"
+  local scratch="$STUBDIR/state/clones/shell-cloneproj/cloneproj"
+  [ -d "$scratch/.git" ]
+  run git config --file "$scratch/.git/config" user.name
+  assert_failure
+  run git config --file "$scratch/.git/config" user.email
+  assert_failure
+}
+
+@test "clone(msb #438): a control-character identity value is not propagated" {
+  git -C "$CLONEPROJ" config user.name "$(printf 'Bad\tUser')"
+  git -C "$CLONEPROJ" config user.email "ok@example.gov"
+  _msb_clone_isolated create shell --clone "$CLONEPROJ"
+  local scratch="$STUBDIR/state/clones/shell-cloneproj/cloneproj"
+  run git config --file "$scratch/.git/config" user.name
+  assert_failure
+  [ "$(git config --file "$scratch/.git/config" user.email)" = "ok@example.gov" ]
+}

--- a/test/bats/116-clone-option.bats
+++ b/test/bats/116-clone-option.bats
@@ -258,9 +258,8 @@ _create_line() { printf '%s\n' "$(cat "$CALLS")" | grep "^$1 create"; }
   assert_regex "$(_create_line sbx)" '--clone'
 }
 
-# Host git identity is neutralized for the identity tests (isolated HOME/XDG,
-# no system config) so only the source checkout's repo-local values, or their
-# absence, reach the scratch.
+# Neutralize the host git identity so only the source checkout's values (or
+# their absence) can reach the scratch.
 _msb_clone_isolated() { # ARGS...
   _msb_clone HOME="$STUBDIR/nohome" XDG_CONFIG_HOME="$STUBDIR/noconfig" GIT_CONFIG_NOSYSTEM=1 -- "$@"
 }

--- a/test/bats/120-workspace-preflight.bats
+++ b/test/bats/120-workspace-preflight.bats
@@ -188,3 +188,12 @@ sandbox 4096 -> host 127.0.0.1:4096 (create-time -p)'
   _wppd "$fixture" unknown;   assert_output ''
   _wppd "" closed;            assert_output ''
 }
+
+# The identity tests above fake HOME and run real `git config --global`; git
+# routes that to $XDG_CONFIG_HOME/git/config when it exists and ~/.gitconfig
+# does not, so the harness must isolate XDG_CONFIG_HOME or a developer shell
+# exporting it gets fixture identities written into its real config. CI cannot
+# see that regression (no XDG export there), hence this guard.
+@test "harness: XDG_CONFIG_HOME is isolated so a faked HOME never reaches the developer's git config" {
+  [[ "${XDG_CONFIG_HOME:-}" == "$STUBDIR"/* ]]
+}

--- a/test/bats/helper.bash
+++ b/test/bats/helper.bash
@@ -50,7 +50,10 @@ acq_setup_stubs() {
   # not, and reads it the same way. Point it under the stub dir so a faked HOME
   # is complete (observed: fixture identities written into ~/.config/git/config
   # after every suite run). Tests that need a config dir set their own.
+  # GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM override both HOME and XDG lookups, so a
+  # runner exporting them would leak through (and receive the fixture writes).
   export XDG_CONFIG_HOME="$STUBDIR/xdg"
+  unset GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM
   load_acq
 }
 

--- a/test/bats/helper.bash
+++ b/test/bats/helper.bash
@@ -44,6 +44,13 @@ acq_setup_stubs() {
         ACQ_NETWORK_TIER_CONFIRM_OPEN ACQ_MSB_BALANCED_EGRESS ACQ_MSB_IMAGE \
         ACQ_MSB_PULL ACQ_MSB_WORKSPACE ACQ_MSB_CLONES_DIR
   make_stubs
+  # Tests that fake HOME still leak into the developer's real git config when
+  # the shell exports XDG_CONFIG_HOME: git writes --global to
+  # $XDG_CONFIG_HOME/git/config whenever that file exists and ~/.gitconfig does
+  # not, and reads it the same way. Point it under the stub dir so a faked HOME
+  # is complete (observed: fixture identities written into ~/.config/git/config
+  # after every suite run). Tests that need a config dir set their own.
+  export XDG_CONFIG_HOME="$STUBDIR/xdg"
   load_acq
 }
 


### PR DESCRIPTION
A `--clone` workspace on msb is a true `git clone`, so the source checkout's `.git/config` never reaches the scratch. Setups that keep identity repo-local (per-forge emails, or a gitdir-scoped `includeIf`) therefore hit `Author identity unknown` on the first in-sandbox commit, while the same commit works on the host. The global-tier sync from #429 cannot express a per-repo value, and sbx never had the gap because its native `--clone` copies `.git` wholesale.

**Fix.** At clone setup, read the source checkout's *effective* `user.name`/`user.email` on the host (`git -C <src> config --get`, which resolves local + includeIf + global exactly as the user's own commits do) and write them repo-locally into the scratch. Repo-local beats the guest's synced global tier, so a forge-specific identity wins as it should. Only the two `user.*` values are read, and they go through `git config`, which escapes on write, so no control-character filter is needed on this path. Running git inside the scratch is safe at this one point (acq just created it; it is not yet guest-exposed), which the code notes against the rm-time "never execute git in the scratch" rule.

Propagating only the two inert `user.*` values is the minimized form of sbx's wholesale copy, without the credential helpers, hooks, and URL rewrites that ride along with it. ADR-0027 and the backend guide now state what a clone carries.

**Tests** (`116-clone-option.bats`, host git identity isolated so only the source checkout's values can reach the scratch): identity lands repo-locally; no source identity writes nothing.

Verified live on msb: a `--clone` sandbox from a repo whose identity is repo-local only authors an in-guest commit correctly, with the host's differing global identity present in the guest's global tier.

**Harness fix (same theme, found while verifying).** The identity tests in `120-workspace-preflight.bats` run real `git config --global` with only `HOME` faked. Git routes `--global` to `$XDG_CONFIG_HOME/git/config` when that file exists and `~/.gitconfig` does not, so on a developer shell exporting `XDG_CONFIG_HOME` every suite run wrote the fixture identity into the real git config, and the read-side identity tests failed locally while CI stayed green. `acq_setup_stubs` now isolates `XDG_CONFIG_HOME` under the stub dir and unsets `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`, which git honors over both `HOME` and XDG; a one-line read-only test guards the XDG part, since CI cannot observe the regression. With it the full suite is green locally on an XDG-exporting machine.

Fixes GSA-TTS/agentic-coding-quickstart#438

---

AI-assisted: drafted with Claude Code; reviewed and directed by a human.

