### PR TITLE
fix(msb): follow the host resolvers and disable DNS rebind protection in the guest

### DIFF
--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -2279,11 +2279,12 @@ _report_usai_unreachable() {
 # resolver, while other public hosts (GitHub, npm) resolve and connect fine.
 #
 # The usual cause on GFE is split-horizon DNS — the USAi host resolves to an
-# INTERNAL address that only exists in the corporate/tunnel zone, which the
-# guest's default public resolver (ACQ_MSB_DNS_NAMESERVER, 1.1.1.1) cannot see.
-# A key rotation cannot fix this, and neither can a msb data wipe; the remedy is
-# a resolver that can reach the internal USAi zone. State the signal and point
-# at the docs rather than guessing the user's network fix.
+# INTERNAL address that only exists in the corporate/tunnel zone. The guest
+# follows the host's resolvers by default with msb's rebind protection off, so
+# this now points at a forced public resolver (ACQ_MSB_DNS_NAMESERVER) or
+# rebind protection re-enabled (ACQ_MSB_DNS_REBIND_PROTECTION=1), which drops
+# the private-range answer. A key rotation cannot fix this, and neither can a
+# msb data wipe. State the signal and point at the docs.
 _report_usai_unresolved() {
   echo >&2
   echo "acq: the USAi API host in $USAI_MODELS_URL did not RESOLVE from the sandbox" >&2
@@ -2291,9 +2292,9 @@ _report_usai_unresolved() {
   echo "      invalid or expired key, so rotating the key will not help." >&2
   echo "      If other public hosts (GitHub, npm) work from the sandbox but only" >&2
   echo "      USAi fails to resolve, USAi is likely a split-horizon name whose" >&2
-  echo "      address lives in an internal/tunnel-only zone the guest's default" >&2
-  echo "      resolver cannot see. Point the guest at a resolver that can reach the" >&2
-  echo "      internal USAi zone via ACQ_MSB_DNS_NAMESERVER." >&2
+  echo "      address lives in an internal/tunnel-only zone. Check that the guest" >&2
+  echo "      follows the host's resolvers (ACQ_MSB_DNS_NAMESERVER unset) and that" >&2
+  echo "      msb's rebind protection is off (ACQ_MSB_DNS_REBIND_PROTECTION unset)." >&2
   echo "      See docs/KNOWN_FAILURE_MODES.md §30 (USAi-only NXDOMAIN)." >&2
   echo >&2
 }

--- a/acq.backends/common.sh
+++ b/acq.backends/common.sh
@@ -2280,11 +2280,13 @@ _report_usai_unreachable() {
 #
 # The usual cause on GFE is split-horizon DNS — the USAi host resolves to an
 # INTERNAL address that only exists in the corporate/tunnel zone. The guest
-# follows the host's resolvers by default with msb's rebind protection off, so
-# this now points at a forced public resolver (ACQ_MSB_DNS_NAMESERVER) or
-# rebind protection re-enabled (ACQ_MSB_DNS_REBIND_PROTECTION=1), which drops
-# the private-range answer. A key rotation cannot fix this, and neither can a
-# msb data wipe. State the signal and point at the docs.
+# follows the host's resolvers by default, with msb's rebind protection off on
+# a ZPA host, so this now points at a forced public resolver
+# (ACQ_MSB_DNS_NAMESERVER), rebind protection forced on
+# (ACQ_MSB_DNS_REBIND_PROTECTION=1), or a sandbox created while the tunnel was
+# down (detection missed; recreate with ACQ_MSB_DNS_REBIND_PROTECTION=0). A key
+# rotation cannot fix this, and neither can a msb data wipe. State the signal
+# and point at the docs.
 _report_usai_unresolved() {
   echo >&2
   echo "acq: the USAi API host in $USAI_MODELS_URL did not RESOLVE from the sandbox" >&2
@@ -2294,7 +2296,8 @@ _report_usai_unresolved() {
   echo "      USAi fails to resolve, USAi is likely a split-horizon name whose" >&2
   echo "      address lives in an internal/tunnel-only zone. Check that the guest" >&2
   echo "      follows the host's resolvers (ACQ_MSB_DNS_NAMESERVER unset) and that" >&2
-  echo "      msb's rebind protection is off (ACQ_MSB_DNS_REBIND_PROTECTION unset)." >&2
+  echo "      msb's rebind protection is not forced on (ACQ_MSB_DNS_REBIND_PROTECTION" >&2
+  echo "      unset, or 0 if the sandbox was created while the tunnel was down)." >&2
   echo "      See docs/KNOWN_FAILURE_MODES.md §30 (USAi-only NXDOMAIN)." >&2
   echo >&2
 }

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -309,29 +309,30 @@ ACQ_MSB_DNS_NAMESERVER="${ACQ_MSB_DNS_NAMESERVER:-}"
 # detection misses, e.g. the tunnel was down at create time).
 ACQ_MSB_DNS_REBIND_PROTECTION="${ACQ_MSB_DNS_REBIND_PROTECTION:-}"
 case "$(printf '%s' "$ACQ_MSB_DNS_REBIND_PROTECTION" | tr '[:upper:]' '[:lower:]')" in
+  "")             ;;
   1|true|yes|on)  ACQ_MSB_DNS_REBIND_PROTECTION="1" ;;
   0|false|no|off) ACQ_MSB_DNS_REBIND_PROTECTION="0" ;;
-  *)              ACQ_MSB_DNS_REBIND_PROTECTION="" ;;
+  *)
+    printf 'acq(msb): WARNING: invalid ACQ_MSB_DNS_REBIND_PROTECTION=%s (expected 1|0|empty); using auto\n' "$ACQ_MSB_DNS_REBIND_PROTECTION" >&2
+    ACQ_MSB_DNS_REBIND_PROTECTION=""
+    ;;
 esac
 
-# _acq_msb_host_resolver_lines — the raw resolver listing msb's host-side stack
-# will use: `scutil --dns` on Darwin, /etc/resolv.conf elsewhere. Tests
-# override this to feed a fixture.
+# _acq_msb_host_resolver_lines — the resolver listing msb's host-side stack
+# will use. /etc/resolv.conf on every platform: on macOS configd writes it from
+# the global DNS state (State:/Network/Global/DNS), the one source msb reads,
+# whereas `scutil --dns` also lists domain-scoped supplemental resolvers msb
+# never consults. Tests override this to feed a fixture.
 _acq_msb_host_resolver_lines() {
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    scutil --dns 2>/dev/null
-  else
-    cat /etc/resolv.conf 2>/dev/null
-  fi
+  cat /etc/resolv.conf 2>/dev/null
   return 0
 }
 
 # _acq_msb_host_resolvers_in_cgnat — true when any host resolver sits in
-# 100.64.0.0/10 (second octet 64-127), the ZPA signature. Both listing formats
-# put the address last on a line whose first field starts with "nameserver".
+# 100.64.0.0/10 (second octet 64-127), the ZPA signature.
 _acq_msb_host_resolvers_in_cgnat() {
   local ip o2
-  for ip in $(_acq_msb_host_resolver_lines | awk '$1 ~ /^nameserver/ { print $NF }'); do
+  for ip in $(_acq_msb_host_resolver_lines | awk '$1 == "nameserver" { print $2 }'); do
     case "$ip" in 100.*.*.*) ;; *) continue ;; esac
     o2=${ip#100.}; o2=${o2%%.*}
     case "$o2" in ""|*[!0-9]*) continue ;; esac

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -292,21 +292,53 @@ ACQ_MSB_DNS_NAMESERVER="${ACQ_MSB_DNS_NAMESERVER:-}"
 
 # msb's DNS rebind protection drops answers that point at private ranges,
 # which is exactly what split-horizon/ZPA names resolve to (100.64.x), so the
-# name silently resolves to nothing. acq turns it off by default. What the
-# protection guards: msb maps a kit's allow@host rule onto the resolved IP, and
-# without it an allowed domain whose DNS an attacker influences could steer the
-# guest at private space (other tunnel app segments, the msb gateway) under
-# that rule. Mitigations that remain: only named kit hosts are allowed under
+# name silently resolves to nothing. acq turns it off only where that applies:
+# when the host's own resolvers sit in 100.64.0.0/10, the CGNAT range ZPA uses
+# for both its resolvers and its synthetic app addresses (see
+# _acq_msb_host_resolvers_in_cgnat). A host without such resolvers gains
+# nothing from the relaxation and keeps msb's default. What the protection
+# guards: msb maps a kit's allow@host rule onto the resolved IP, and without it
+# an allowed domain whose DNS an attacker influences could steer the guest at
+# private space (other tunnel app segments, the msb gateway) under that rule.
+# Mitigations that remain: only named kit hosts are allowed under
 # strict/balanced, answers come from the host's corporate resolver over the
 # tunnel, IP-group rules (allow@public) never admit private addresses, and
 # injected secrets are bound to the upstream TLS identity so a rebound endpoint
-# cannot receive them. Set to 1/true/on to keep the protection at the cost of
-# every tunnel-only host. Normalized like the other toggles.
+# cannot receive them. Three values: empty = auto (above); 1/true/on = always
+# keep the protection; 0/false/off = always disable it (the escape hatch when
+# detection misses, e.g. the tunnel was down at create time).
 ACQ_MSB_DNS_REBIND_PROTECTION="${ACQ_MSB_DNS_REBIND_PROTECTION:-}"
 case "$(printf '%s' "$ACQ_MSB_DNS_REBIND_PROTECTION" | tr '[:upper:]' '[:lower:]')" in
-  1|true|yes|on) ACQ_MSB_DNS_REBIND_PROTECTION="1" ;;
-  *)             ACQ_MSB_DNS_REBIND_PROTECTION="" ;;
+  1|true|yes|on)  ACQ_MSB_DNS_REBIND_PROTECTION="1" ;;
+  0|false|no|off) ACQ_MSB_DNS_REBIND_PROTECTION="0" ;;
+  *)              ACQ_MSB_DNS_REBIND_PROTECTION="" ;;
 esac
+
+# _acq_msb_host_resolver_lines — the raw resolver listing msb's host-side stack
+# will use: `scutil --dns` on Darwin, /etc/resolv.conf elsewhere. Tests
+# override this to feed a fixture.
+_acq_msb_host_resolver_lines() {
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    scutil --dns 2>/dev/null
+  else
+    cat /etc/resolv.conf 2>/dev/null
+  fi
+  return 0
+}
+
+# _acq_msb_host_resolvers_in_cgnat — true when any host resolver sits in
+# 100.64.0.0/10 (second octet 64-127), the ZPA signature. Both listing formats
+# put the address last on a line whose first field starts with "nameserver".
+_acq_msb_host_resolvers_in_cgnat() {
+  local ip o2
+  for ip in $(_acq_msb_host_resolver_lines | awk '$1 ~ /^nameserver/ { print $NF }'); do
+    case "$ip" in 100.*.*.*) ;; *) continue ;; esac
+    o2=${ip#100.}; o2=${o2%%.*}
+    case "$o2" in ""|*[!0-9]*) continue ;; esac
+    if [ "$o2" -ge 64 ] && [ "$o2" -le 127 ]; then return 0; fi
+  done
+  return 1
+}
 
 # ---------------------------------------------------------------------------
 # TLS-interception UPSTREAM trust (corporate MITM proxy, e.g. Zscaler)
@@ -2757,12 +2789,21 @@ EOF
     [ "${#_upstream_ca[@]}" -gt 0 ] && create_flags+=("${_upstream_ca[@]}")
   fi
 
-  # Guest DNS: host resolvers unless overridden, rebind protection off unless
-  # kept. See the ACQ_MSB_DNS_NAMESERVER / ACQ_MSB_DNS_REBIND_PROTECTION notes.
+  # Guest DNS: host resolvers unless overridden; rebind protection off on ZPA
+  # hosts (auto), or as forced. Create-time only: an existing sandbox keeps its
+  # DNS config until recreated. See the ACQ_MSB_DNS_* notes.
   if [ -n "$ACQ_MSB_DNS_NAMESERVER" ]; then
     create_flags+=(--dns-nameserver "$ACQ_MSB_DNS_NAMESERVER")
   fi
-  [ -n "$ACQ_MSB_DNS_REBIND_PROTECTION" ] || create_flags+=(--no-dns-rebind-protection)
+  case "$ACQ_MSB_DNS_REBIND_PROTECTION" in
+    1) ;;
+    0) create_flags+=(--no-dns-rebind-protection) ;;
+    *)
+      if _acq_msb_host_resolvers_in_cgnat; then
+        echo "acq(msb): host resolvers are in 100.64/10 (ZPA); disabling guest DNS rebind protection so split-horizon names resolve" >&2
+        create_flags+=(--no-dns-rebind-protection)
+      fi ;;
+  esac
 
   # Guest RAM / vCPU. msb defaults to 512 MiB / 1 vCPU — too small for a Node.js
   # agent TUI (opencode), which the guest OOM-kills on launch (prints "Killed";

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -278,17 +278,35 @@ _acq_msb_service_binding() {
 ACQ_MSB_MEMORY="${ACQ_MSB_MEMORY-4G}"
 ACQ_MSB_CPUS="${ACQ_MSB_CPUS-2}"
 
-# DNS nameserver for the guest. msb hands the guest the HOST's resolvers, but a
-# corporate/VPN resolver (e.g. 172.16.x, Zscaler) is typically unreachable from
-# the microVM's network namespace — so the guest cannot resolve even the
-# allow-listed kit hosts (api.gsa.usai.gov, github.com), and every outbound
-# request fails with "Could not resolve host". A public resolver reachable from
-# the microVM fixes it (verified: with --dns-nameserver 1.1.1.1 the models API
-# resolves + returns 401/200 and github returns 200). Override with a resolver
-# reachable from your environment, or set to empty to skip and use msb's default
-# (only if the host resolver IS reachable from the guest). Uses `-` (not `:-`)
-# so an explicitly-empty value disables the flag rather than re-defaulting.
-ACQ_MSB_DNS_NAMESERVER="${ACQ_MSB_DNS_NAMESERVER-1.1.1.1}"
+# Guest DNS. msb forwards guest queries from its HOST-SIDE network stack to the
+# host's resolvers, so a corporate/tunnel resolver (Zscaler's 100.64.0.x) is
+# reachable and answers exactly what the host sees. That matters for
+# split-horizon names: on a ZPA host, gitlab.login.gov and api.gsa.usai.gov
+# resolve to private 100.64.x addresses that ride the tunnel's allow-listed
+# path, while a public resolver returns the public load balancer, which rejects
+# the flow (403) or has no route. Earlier acq versions pinned 1.1.1.1 on the
+# assumption the host resolver was unreachable from the microVM; that predates
+# the host-side stack (verified on msb 0.6.16). Leave empty to use the host's
+# resolvers; set to force a specific resolver.
+ACQ_MSB_DNS_NAMESERVER="${ACQ_MSB_DNS_NAMESERVER:-}"
+
+# msb's DNS rebind protection drops answers that point at private ranges,
+# which is exactly what split-horizon/ZPA names resolve to (100.64.x), so the
+# name silently resolves to nothing. acq turns it off by default. What the
+# protection guards: msb maps a kit's allow@host rule onto the resolved IP, and
+# without it an allowed domain whose DNS an attacker influences could steer the
+# guest at private space (other tunnel app segments, the msb gateway) under
+# that rule. Mitigations that remain: only named kit hosts are allowed under
+# strict/balanced, answers come from the host's corporate resolver over the
+# tunnel, IP-group rules (allow@public) never admit private addresses, and
+# injected secrets are bound to the upstream TLS identity so a rebound endpoint
+# cannot receive them. Set to 1/true/on to keep the protection at the cost of
+# every tunnel-only host. Normalized like the other toggles.
+ACQ_MSB_DNS_REBIND_PROTECTION="${ACQ_MSB_DNS_REBIND_PROTECTION:-}"
+case "$(printf '%s' "$ACQ_MSB_DNS_REBIND_PROTECTION" | tr '[:upper:]' '[:lower:]')" in
+  1|true|yes|on) ACQ_MSB_DNS_REBIND_PROTECTION="1" ;;
+  *)             ACQ_MSB_DNS_REBIND_PROTECTION="" ;;
+esac
 
 # ---------------------------------------------------------------------------
 # TLS-interception UPSTREAM trust (corporate MITM proxy, e.g. Zscaler)
@@ -2715,13 +2733,12 @@ EOF
     [ "${#_upstream_ca[@]}" -gt 0 ] && create_flags+=("${_upstream_ca[@]}")
   fi
 
-  # Guest DNS: use a resolver reachable from the microVM. The host's resolvers
-  # (often a corporate/VPN/Zscaler IP) are typically unreachable from the guest,
-  # so without this the guest can't resolve even allow-listed hosts. See the
-  # ACQ_MSB_DNS_NAMESERVER note above.
+  # Guest DNS: host resolvers unless overridden, rebind protection off unless
+  # kept. See the ACQ_MSB_DNS_NAMESERVER / ACQ_MSB_DNS_REBIND_PROTECTION notes.
   if [ -n "$ACQ_MSB_DNS_NAMESERVER" ]; then
     create_flags+=(--dns-nameserver "$ACQ_MSB_DNS_NAMESERVER")
   fi
+  [ -n "$ACQ_MSB_DNS_REBIND_PROTECTION" ] || create_flags+=(--no-dns-rebind-protection)
 
   # Guest RAM / vCPU. msb defaults to 512 MiB / 1 vCPU — too small for a Node.js
   # agent TUI (opencode), which the guest OOM-kills on launch (prints "Killed";

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -217,9 +217,9 @@ ELB) or is unreachable. acq therefore leaves the resolver at msb's default, and
 on such a host passes `--no-dns-rebind-protection`, because msb's rebind
 protection would drop those private-range answers.
 
-**Detection rule.** At `msb create`, acq reads the host's resolver list (the
-same one msb's stack forwards to: `scutil --dns` on macOS, `/etc/resolv.conf`
-elsewhere). If any resolver sits in `100.64.0.0/10`, the CGNAT range ZPA uses
+**Detection rule.** At `msb create`, acq reads the host's resolver list from
+`/etc/resolv.conf`, which on macOS mirrors the global DNS state msb itself
+reads. If any resolver sits in `100.64.0.0/10`, the CGNAT range ZPA uses
 for both its resolvers and its synthetic app addresses, acq disables rebind
 protection and prints one line saying so. A host with no such resolver keeps
 msb's default (protection on) and sees no change. `ACQ_MSB_DNS_REBIND_PROTECTION`
@@ -230,6 +230,7 @@ takes three values:
 | unset / empty | auto: off on a host with a `100.64/10` resolver, on otherwise |
 | `1` / `true` / `on` | always keep the protection (tunnel-only names then fail to resolve) |
 | `0` / `false` / `off` | always disable it |
+| anything else | warns and falls back to auto |
 
 This is decided at create time; an existing sandbox keeps whatever it was
 created with until it is recreated. If the tunnel was down when the sandbox was

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -193,7 +193,7 @@ Tunables:
 | `ACQ_MSB_MEMORY` | `4G` | Guest RAM at create (`-m`); `4G`/`4096`/`512M` (bare = MiB). Set empty to use msb's 512 MiB default |
 | `ACQ_MSB_CPUS` | `2` | Guest vCPU count at create (`-c`); set empty to use msb's 1-vCPU default |
 | `ACQ_MSB_DNS_NAMESERVER` | (host resolvers) | Force a guest DNS resolver (`--dns-nameserver`); empty uses the host's resolvers via msb's default |
-| `ACQ_MSB_DNS_REBIND_PROTECTION` | (off) | Set `1` to keep msb's DNS rebind protection; off by default so split-horizon/ZPA names that resolve to private `100.64.x` addresses still resolve |
+| `ACQ_MSB_DNS_REBIND_PROTECTION` | (auto) | msb's DNS rebind protection at create. Empty = auto: off when a host resolver is in `100.64.0.0/10` (ZPA), so split-horizon names that resolve to private `100.64.x` addresses still resolve; on everywhere else. `1` always keeps it; `0` always disables it (escape hatch when detection misses) |
 | `ACQ_MSB_KIT_CACHE` | `$XDG_CACHE_HOME/acq/kits` | where fetched neutral kits are materialized |
 | `ACQ_MSB_EXEC_READY_TIMEOUT` | `60` | Seconds to wait for a freshly-created sandbox to accept `msb exec` (create starts asynchronously) |
 | `ACQ_MSB_SSH_DIR` | `$XDG_STATE_HOME/acq/ssh` | Directory holding acq's managed SSH key for post-hoc port publishing (ADR-0015) |
@@ -213,21 +213,41 @@ split-horizon names on a corporate tunnel. On a Zscaler/ZPA host,
 `gitlab.login.gov` and `api.gsa.usai.gov` resolve to private `100.64.x`
 addresses that ride the tunnel's allow-listed path; a public resolver returns
 the public load balancer instead, which either rejects the flow (`403` from the
-ELB) or is unreachable. acq therefore leaves the resolver at msb's default and
-passes `--no-dns-rebind-protection`, because msb's rebind protection would drop
-those private-range answers.
+ELB) or is unreachable. acq therefore leaves the resolver at msb's default, and
+on such a host passes `--no-dns-rebind-protection`, because msb's rebind
+protection would drop those private-range answers.
+
+**Detection rule.** At `msb create`, acq reads the host's resolver list (the
+same one msb's stack forwards to: `scutil --dns` on macOS, `/etc/resolv.conf`
+elsewhere). If any resolver sits in `100.64.0.0/10`, the CGNAT range ZPA uses
+for both its resolvers and its synthetic app addresses, acq disables rebind
+protection and prints one line saying so. A host with no such resolver keeps
+msb's default (protection on) and sees no change. `ACQ_MSB_DNS_REBIND_PROTECTION`
+takes three values:
+
+| Value | Behavior |
+| --- | --- |
+| unset / empty | auto: off on a host with a `100.64/10` resolver, on otherwise |
+| `1` / `true` / `on` | always keep the protection (tunnel-only names then fail to resolve) |
+| `0` / `false` / `off` | always disable it |
+
+This is decided at create time; an existing sandbox keeps whatever it was
+created with until it is recreated. If the tunnel was down when the sandbox was
+created, detection misses and tunnel-only names fail later; recreate with
+`ACQ_MSB_DNS_REBIND_PROTECTION=0` to force it off.
 
 Security trade-off: msb maps a kit's `allow@host` rule onto the resolved IP, and
 rebind protection is what stops that mapping from admitting a private address.
 With it off, an allowed domain whose DNS an attacker can influence could steer
 the guest at private space (other tunnel app segments, the msb gateway) under
-that rule. The exposure is bounded: only named kit hosts are allowed under
-strict/balanced, their answers come from the host's corporate resolver over the
-tunnel, IP-group rules (`allow@public`) never admit private addresses, and
-injected secrets are bound to the upstream TLS identity, so a rebound endpoint
-cannot receive them. Set `ACQ_MSB_DNS_REBIND_PROTECTION=1` to keep the
-protection at the cost of every tunnel-only host. `ACQ_MSB_DNS_NAMESERVER`
-forces a specific resolver if the host's cannot be used.
+that rule. The guard is relaxed only on hosts whose resolvers already return
+private answers for the names the kits allow, and the exposure is bounded:
+only named kit hosts are allowed under strict/balanced, their answers come from
+the host's corporate resolver over the tunnel, IP-group rules (`allow@public`)
+never admit private addresses, and injected secrets are bound to the upstream
+TLS identity, so a rebound endpoint cannot receive them.
+`ACQ_MSB_DNS_NAMESERVER` forces a specific resolver if the host's cannot be
+used.
 
 ### Network egress tiers (`ACQ_NETWORK_TIER`)
 

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -192,7 +192,8 @@ Tunables:
 | `ACQ_MSB_WORKSPACE` | (first workspace) | Agent's **starting directory** (`-w`) on attach. Does NOT change the mount, which is always host-path:host-path; overrides only where the agent starts. |
 | `ACQ_MSB_MEMORY` | `4G` | Guest RAM at create (`-m`); `4G`/`4096`/`512M` (bare = MiB). Set empty to use msb's 512 MiB default |
 | `ACQ_MSB_CPUS` | `2` | Guest vCPU count at create (`-c`); set empty to use msb's 1-vCPU default |
-| `ACQ_MSB_DNS_NAMESERVER` | `1.1.1.1` | Guest DNS resolver (set empty to use msb's default) |
+| `ACQ_MSB_DNS_NAMESERVER` | (host resolvers) | Force a guest DNS resolver (`--dns-nameserver`); empty uses the host's resolvers via msb's default |
+| `ACQ_MSB_DNS_REBIND_PROTECTION` | (off) | Set `1` to keep msb's DNS rebind protection; off by default so split-horizon/ZPA names that resolve to private `100.64.x` addresses still resolve |
 | `ACQ_MSB_KIT_CACHE` | `$XDG_CACHE_HOME/acq/kits` | where fetched neutral kits are materialized |
 | `ACQ_MSB_EXEC_READY_TIMEOUT` | `60` | Seconds to wait for a freshly-created sandbox to accept `msb exec` (create starts asynchronously) |
 | `ACQ_MSB_SSH_DIR` | `$XDG_STATE_HOME/acq/ssh` | Directory holding acq's managed SSH key for post-hoc port publishing (ADR-0015) |
@@ -206,15 +207,27 @@ Tunables:
 
 ### DNS / name resolution
 
-msb hands the guest the **host's** DNS resolvers, but a corporate/VPN resolver
-(e.g. a `172.16.x` or Zscaler address) is typically **unreachable from the
-microVM's network namespace** — so the guest can't resolve even the
-allow-listed kit hosts (`api.gsa.usai.gov`, `github.com`) and every outbound
-request fails with `Could not resolve host`. The msb backend therefore passes
-`--dns-nameserver` (default `1.1.1.1`, a public resolver reachable from the
-microVM) to `msb create`. Override `ACQ_MSB_DNS_NAMESERVER` if `1.1.1.1` is
-blocked in your environment, or set it empty to fall back to msb's default (only
-if your host resolver is reachable from the guest).
+msb forwards guest DNS from its host-side network stack to the **host's**
+resolvers, so the guest resolves names exactly as the host does — including
+split-horizon names on a corporate tunnel. On a Zscaler/ZPA host,
+`gitlab.login.gov` and `api.gsa.usai.gov` resolve to private `100.64.x`
+addresses that ride the tunnel's allow-listed path; a public resolver returns
+the public load balancer instead, which either rejects the flow (`403` from the
+ELB) or is unreachable. acq therefore leaves the resolver at msb's default and
+passes `--no-dns-rebind-protection`, because msb's rebind protection would drop
+those private-range answers.
+
+Security trade-off: msb maps a kit's `allow@host` rule onto the resolved IP, and
+rebind protection is what stops that mapping from admitting a private address.
+With it off, an allowed domain whose DNS an attacker can influence could steer
+the guest at private space (other tunnel app segments, the msb gateway) under
+that rule. The exposure is bounded: only named kit hosts are allowed under
+strict/balanced, their answers come from the host's corporate resolver over the
+tunnel, IP-group rules (`allow@public`) never admit private addresses, and
+injected secrets are bound to the upstream TLS identity, so a rebound endpoint
+cannot receive them. Set `ACQ_MSB_DNS_REBIND_PROTECTION=1` to keep the
+protection at the cost of every tunnel-only host. `ACQ_MSB_DNS_NAMESERVER`
+forces a specific resolver if the host's cannot be used.
 
 ### Network egress tiers (`ACQ_NETWORK_TIER`)
 

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1317,7 +1317,7 @@ which one you have before acting.
 | Signature (from inside the guest) | Cause | Fix |
 |---|---|---|
 | **Broad** `curl (56) unexpected eof` / HTTP `000` on **multiple** hosts at once (USAi *and* GitHub *and* npm) | Corrupted / stale **msb state** (not a clean-install behavior) | **Wipe msb data + reinstall, then `msb doctor`** (below) |
-| **USAi only** fails with `NXDOMAIN` / `curl rc=6` (or `rc=35` if a public address is pinned), while GitHub + npm work fine | **Split-horizon DNS** — the USAi host resolves to an internal, tunnel-only address the guest's public resolver can't see | Try pointing the guest at a resolver that can reach the internal USAi zone (`ACQ_MSB_DNS_NAMESERVER`) — but the internal resolver may itself not be routable from the guest; verify guest→resolver reachability and coordinate with your network team if it isn't |
+| **USAi only** fails with `NXDOMAIN` / `curl rc=6` (or a WAF-gated API such as GitLab's `/api/v4/*` returns `403` from `awselb/2.0`), while GitHub + npm work fine | **Split-horizon DNS** — the host resolves the name to a private tunnel address (`100.64.x` on ZPA); a public resolver returns the public endpoint, which the WAF rejects, and msb's rebind protection drops the private answer | Let the guest follow the host's resolvers with rebind protection off (acq's defaults): unset `ACQ_MSB_DNS_NAMESERVER` and `ACQ_MSB_DNS_REBIND_PROTECTION` (below) |
 | A **genuinely intercepted** endpoint fails its TLS handshake behind a corporate proxy that terminates it | The proxy's **root CA** isn't trusted on msb's upstream (proxy→server) leg | acq passes it via `--tls-upstream-ca-cert` (defense-in-depth; below) |
 
 Probe from inside the sandbox to read the signature — the curl exit code is the
@@ -1365,38 +1365,41 @@ If a broad `unexpected eof` **recurs on a clean install**, that would be new
 evidence of an msb bug — capture the `diagnose-*` output and reopen
 [superradcompany/microsandbox#1344](https://github.com/superradcompany/microsandbox/issues/1344).
 
-### Signature 2 — USAi-only NXDOMAIN (split-horizon DNS)
+### Signature 2 — split-horizon DNS (USAi NXDOMAIN, GitLab API 403)
 
-On a clean msb install on a GFE/Zscaler host, GitHub and npm resolve and return
-`200` from the guest, but `api.gsa.usai.gov` fails to **resolve** (`curl rc=6` /
-NXDOMAIN); pinning its public address instead fails to connect (`rc=35`). USAi is
-a **split-horizon** name — the host resolves it to an *internal* address reachable
-only over the corporate tunnel, and the guest's default public resolver
-(`ACQ_MSB_DNS_NAMESERVER=1.1.1.1`) cannot see that zone. A msb data wipe does not
-fix this; a key rotation does not fix this.
+On a GFE/Zscaler host, GitHub and npm resolve and return `200` from the guest,
+but `api.gsa.usai.gov` fails to **resolve** (`curl rc=6`), or a WAF-gated API
+behind the same tunnel (GitLab's `/api/v4/*`) answers `403` from `awselb/2.0`
+while its git endpoints work. Both are the same mechanism. The host's Zscaler
+resolvers answer these names with **private ZPA addresses** (`100.64.x`) that
+ride the tunnel's allow-listed path; a public resolver answers the public load
+balancer, which the WAF rejects. And even with the host resolver, msb's DNS
+rebind protection drops private-range answers, so the name resolves to nothing.
 
-`acq` now reports this distinctly ("did not RESOLVE … likely a split-horizon
-name") rather than as a generic network cut or a bad key.
-
-**Try this — but it is not a guaranteed fix:** point the guest at a resolver that
-can reach the internal USAi zone:
+acq's defaults handle this: the guest follows the host's resolvers (no
+`--dns-nameserver`) and msb is created with `--no-dns-rebind-protection`. If you
+see this signature, check that neither knob is overriding the defaults:
 
 ```bash
-export ACQ_MSB_DNS_NAMESERVER=<a-resolver-that-can-reach-the-internal-USAi-zone>
+unset ACQ_MSB_DNS_NAMESERVER          # a forced public resolver reintroduces the 403/NXDOMAIN
+unset ACQ_MSB_DNS_REBIND_PROTECTION   # =1 drops the private tunnel answers
 ```
 
-**Important:** the internal resolver may not itself be routable from the guest.
-Measured on GFE, the internal resolver was not reachable from the guest, and even
-pinning USAi's public address still failed to connect (`rc=35`) — the endpoint
-appeared reachable only via the corporate tunnel. So setting
-`ACQ_MSB_DNS_NAMESERVER` is worth trying, but it is not a "set this and it works"
-fix. **Verify guest→resolver reachability first** (e.g. with
-`./scripts/diagnose-host-egress-diff`), and if the resolver (or USAi itself) is
-not routable from the guest, **coordinate with your network team** — the guest
-may need tunnel access it does not currently have.
+Re-enabling rebind protection is a deliberate trade: it stops a kit-allowed
+domain from being resolved into private space by an attacker-influenced DNS
+answer, and it also stops every tunnel-only host from resolving at all. See the
+DNS section of `docs/BACKEND_GUIDE.md` for the mitigations that remain with it
+off.
 
-(See the `ACQ_MSB_DNS_NAMESERVER` notes in `docs/BACKEND_GUIDE.md` and the
-README's msb DNS section.)
+Verified on msb 0.6.16: from the guest, `gitlab.login.gov` resolves to its ZPA
+address, `/api/v4/user` with the bound token returns `200`, and the USAi models
+endpoint returns `401` (reachable) instead of failing to resolve. The guest's
+public egress IP is unchanged (still the Zscaler cloud). Earlier text here
+reported the internal resolver as unreachable from the guest; that predates
+msb's host-side network stack and no longer applies.
+
+`acq` reports this distinctly ("did not RESOLVE … likely a split-horizon name")
+rather than as a generic network cut or a bad key.
 
 ### Signature 3 — genuine TLS interception (upstream CA trust, defense-in-depth)
 

--- a/docs/KNOWN_FAILURE_MODES.md
+++ b/docs/KNOWN_FAILURE_MODES.md
@@ -1317,7 +1317,7 @@ which one you have before acting.
 | Signature (from inside the guest) | Cause | Fix |
 |---|---|---|
 | **Broad** `curl (56) unexpected eof` / HTTP `000` on **multiple** hosts at once (USAi *and* GitHub *and* npm) | Corrupted / stale **msb state** (not a clean-install behavior) | **Wipe msb data + reinstall, then `msb doctor`** (below) |
-| **USAi only** fails with `NXDOMAIN` / `curl rc=6` (or a WAF-gated API such as GitLab's `/api/v4/*` returns `403` from `awselb/2.0`), while GitHub + npm work fine | **Split-horizon DNS** — the host resolves the name to a private tunnel address (`100.64.x` on ZPA); a public resolver returns the public endpoint, which the WAF rejects, and msb's rebind protection drops the private answer | Let the guest follow the host's resolvers with rebind protection off (acq's defaults): unset `ACQ_MSB_DNS_NAMESERVER` and `ACQ_MSB_DNS_REBIND_PROTECTION` (below) |
+| **USAi only** fails with `NXDOMAIN` / `curl rc=6` (or a WAF-gated API such as GitLab's `/api/v4/*` returns `403` from `awselb/2.0`), while GitHub + npm work fine | **Split-horizon DNS** — the host resolves the name to a private tunnel address (`100.64.x` on ZPA); a public resolver returns the public endpoint, which the WAF rejects, and msb's rebind protection drops the private answer | Let the guest follow the host's resolvers with rebind protection off, which acq does automatically on a host whose resolvers are in `100.64/10`: unset `ACQ_MSB_DNS_NAMESERVER` and `ACQ_MSB_DNS_REBIND_PROTECTION`, or set the latter to `0` if the sandbox was created while the tunnel was down (below) |
 | A **genuinely intercepted** endpoint fails its TLS handshake behind a corporate proxy that terminates it | The proxy's **root CA** isn't trusted on msb's upstream (proxy→server) leg | acq passes it via `--tls-upstream-ca-cert` (defense-in-depth; below) |
 
 Probe from inside the sandbox to read the signature — the curl exit code is the
@@ -1377,19 +1377,24 @@ balancer, which the WAF rejects. And even with the host resolver, msb's DNS
 rebind protection drops private-range answers, so the name resolves to nothing.
 
 acq's defaults handle this: the guest follows the host's resolvers (no
-`--dns-nameserver`) and msb is created with `--no-dns-rebind-protection`. If you
-see this signature, check that neither knob is overriding the defaults:
+`--dns-nameserver`), and when a host resolver is in `100.64/10` (the ZPA
+signature) msb is created with `--no-dns-rebind-protection`, with a one-line
+notice on stderr. If you see this signature, check that neither knob is
+overriding the defaults, and that the sandbox was not created while the tunnel
+was down (detection then sees no `100.64/10` resolver and keeps the protection):
 
 ```bash
-unset ACQ_MSB_DNS_NAMESERVER          # a forced public resolver reintroduces the 403/NXDOMAIN
-unset ACQ_MSB_DNS_REBIND_PROTECTION   # =1 drops the private tunnel answers
+unset ACQ_MSB_DNS_NAMESERVER            # a forced public resolver reintroduces the 403/NXDOMAIN
+unset ACQ_MSB_DNS_REBIND_PROTECTION     # =1 drops the private tunnel answers
+ACQ_MSB_DNS_REBIND_PROTECTION=0 acq …   # recreate: force it off if detection missed
 ```
 
-Re-enabling rebind protection is a deliberate trade: it stops a kit-allowed
+The setting is applied at create time; recreate the sandbox after changing it.
+Keeping rebind protection on is a deliberate trade: it stops a kit-allowed
 domain from being resolved into private space by an attacker-influenced DNS
 answer, and it also stops every tunnel-only host from resolving at all. See the
-DNS section of `docs/BACKEND_GUIDE.md` for the mitigations that remain with it
-off.
+DNS section of `docs/BACKEND_GUIDE.md` for the detection rule and the
+mitigations that remain with it off.
 
 Verified on msb 0.6.16: from the guest, `gitlab.login.gov` resolves to its ZPA
 address, `/api/v4/user` with the bound token returns `200`, and the USAi models

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -149,9 +149,10 @@ the neutral `hybrid/v1` kits, JSON schema, and registry) lands separately in
   absolute path in the guest** (sbx-parity; see the workspace-mount note below) —
   an earlier revision remapped to a fixed `/home/agent/workspace`, which failed
   because `msb create` mounts before the `agent` user/home exist.
-  It leaves guest DNS on the **host's resolvers** and passes
-  `--no-dns-rebind-protection`, so split-horizon names on a corporate tunnel
-  resolve to the same private addresses the host uses (an earlier revision
+  It leaves guest DNS on the **host's resolvers** and, when a host resolver is
+  in `100.64.0.0/10` (ZPA), passes `--no-dns-rebind-protection`, so
+  split-horizon names on a corporate tunnel resolve to the same private
+  addresses the host uses while other hosts keep msb's guard (an earlier revision
   pinned `1.1.1.1`, assuming the host resolver was unreachable from the
   microVM; msb's host-side network stack made that moot and the public answer
   is the wrong one for tunnel-gated hosts).

--- a/docs/adr/0011-msb-backend-and-neutral-kits.md
+++ b/docs/adr/0011-msb-backend-and-neutral-kits.md
@@ -149,9 +149,12 @@ the neutral `hybrid/v1` kits, JSON schema, and registry) lands separately in
   absolute path in the guest** (sbx-parity; see the workspace-mount note below) —
   an earlier revision remapped to a fixed `/home/agent/workspace`, which failed
   because `msb create` mounts before the `agent` user/home exist.
-  It passes **`--dns-nameserver`** (default `1.1.1.1`) because msb hands the
-  guest the host's resolvers, which for a corporate/VPN resolver are unreachable
-  from the microVM (otherwise the guest can't resolve even allow-listed hosts).
+  It leaves guest DNS on the **host's resolvers** and passes
+  `--no-dns-rebind-protection`, so split-horizon names on a corporate tunnel
+  resolve to the same private addresses the host uses (an earlier revision
+  pinned `1.1.1.1`, assuming the host resolver was unreachable from the
+  microVM; msb's host-side network stack made that moot and the public answer
+  is the wrong one for tunnel-gated hosts).
   It treats a sandbox that is **not exec-ready** after create as a HARD failure:
   `msb create` returns 0 even when the guest fails to START (async boot), so the
   only reliable readiness signal is that `msb exec` works.

--- a/docs/howto/msb.md
+++ b/docs/howto/msb.md
@@ -246,6 +246,11 @@ msb doctor            # then msb doctor --fix
 # resolvers by default; force one only if those cannot be used):
 export ACQ_MSB_DNS_NAMESERVER=<reachable-resolver>
 
+# Tunnel-only names (ZPA) fail in a sandbox created while the tunnel was down:
+# acq relaxes msb's DNS rebind protection only when it sees 100.64/10 resolvers
+# at create time. Recreate with it forced off:
+ACQ_MSB_DNS_REBIND_PROTECTION=0 acq run opencode .
+
 # A locally-built image won't pull (registry-less reference)
 msb image load -i image.tar -t localhost/my-image:tag
 ACQ_MSB_PULL=never acq run --image localhost/my-image:tag opencode .

--- a/docs/howto/msb.md
+++ b/docs/howto/msb.md
@@ -242,8 +242,8 @@ A few quick msb pointers:
 # Host not ready / boot fails
 msb doctor            # then msb doctor --fix
 
-# Guest can't resolve allow-listed hosts (corporate/VPN resolver unreachable)
-# acq defaults --dns-nameserver 1.1.1.1; override if 1.1.1.1 is blocked:
+# Guest can't resolve allow-listed hosts (the guest follows the host's
+# resolvers by default; force one only if those cannot be used):
 export ACQ_MSB_DNS_NAMESERVER=<reachable-resolver>
 
 # A locally-built image won't pull (registry-less reference)

--- a/test/bats/76-msb-dns.bats
+++ b/test/bats/76-msb-dns.bats
@@ -2,15 +2,21 @@
 #
 # 76-msb-dns.bats — bats port of scripts/test-acq.d/76-msb-dns.sh (ADR-0019/0025)
 #
-# msb provision must leave guest DNS on the host's resolvers with msb's rebind
-# protection off (split-horizon/ZPA answers are private-range), pass a generous
-# default --memory/--cpus (msb's 512MiB/1vCPU OOM-kills a Node TUI), and honor /
-# validate the ACQ_MSB_* overrides. Each case
-# runs a real acq_backend_provision in an isolated subshell and inspects $CALLS.
+# msb provision must leave guest DNS on the host's resolvers, turn msb's rebind
+# protection off only when the host's own resolvers sit in 100.64/10 (ZPA, whose
+# split-horizon answers are private-range), pass a generous default
+# --memory/--cpus (msb's 512MiB/1vCPU OOM-kills a Node TUI), and honor /
+# validate the ACQ_MSB_* overrides. Each case runs a real acq_backend_provision
+# in an isolated subshell and inspects $CALLS. The host resolver listing is fed
+# from a fixture (ACQ_TEST_HOST_RESOLVERS) so no case depends on the machine
+# running the suite.
 #
 # shellcheck shell=bats
 
-setup() { acq_setup_stubs; }
+setup() {
+  acq_setup_stubs
+  printf 'nameserver 192.168.0.1\nnameserver 8.8.8.8\n' > "$STUBDIR/resolvers-public"
+}
 teardown() { acq_teardown_stubs; }
 
 load 'helper'
@@ -30,6 +36,7 @@ _provision() { # NAME ENV_ASSIGNMENTS...
     mkdir -p "'"$STUBDIR"'/nokit"
     printf "schemaVersion: \"hybrid/v1\"\nkind: mixin\nname: x\ndisplayName: X\ndescription: x\n" > "'"$STUBDIR"'/nokit/spec.yaml"
     _acq_msb_fetch_kit() { printf "%s\n" "'"$STUBDIR"'/nokit"; }
+    _acq_msb_host_resolver_lines() { cat "${ACQ_TEST_HOST_RESOLVERS:-'"$STUBDIR"'/resolvers-public}"; }
     acq_backend_provision "$name" shell /tmp 2>&1 >/dev/null
   ' _ "$name" "$@"
 }
@@ -40,17 +47,55 @@ _provision() { # NAME ENV_ASSIGNMENTS...
   refute_output --partial '--dns-nameserver'
 }
 
-@test "msb #439: provision disables msb DNS rebind protection by default" {
-  _provision rebindbox
+_rebind_note='host resolvers are in 100.64/10 (ZPA); disabling guest DNS rebind protection'
+
+@test "msb #439: auto disables rebind protection when a host resolver is in 100.64/10 (scutil format)" {
+  printf '  nameserver[0] : 100.64.0.1\n  nameserver[1] : 100.64.0.2\n' > "$STUBDIR/resolvers-zpa"
+  _provision rebindbox ACQ_TEST_HOST_RESOLVERS="$STUBDIR/resolvers-zpa"
+  assert_output --partial "$_rebind_note"
   run cat "$CALLS"
   assert_output --partial '--no-dns-rebind-protection'
 }
 
-@test "msb #439: ACQ_MSB_DNS_REBIND_PROTECTION=1 keeps msb's rebind protection" {
-  _provision rebind2box ACQ_MSB_DNS_REBIND_PROTECTION=1
+@test "msb #439: auto keeps rebind protection on a host without CGNAT resolvers" {
+  _provision rebind2box
+  refute_output --partial "$_rebind_note"
   run cat "$CALLS"
   refute_output --partial '--no-dns-rebind-protection'
-  _provision rebind3box ACQ_MSB_DNS_REBIND_PROTECTION=off
+}
+
+@test "msb #439: auto matches any CGNAT resolver in a mixed list (resolv.conf format)" {
+  printf 'nameserver 192.168.0.1\nnameserver 100.64.0.1\n' > "$STUBDIR/resolvers-mixed"
+  _provision rebind3box ACQ_TEST_HOST_RESOLVERS="$STUBDIR/resolvers-mixed"
+  run cat "$CALLS"
+  assert_output --partial '--no-dns-rebind-protection'
+}
+
+@test "msb #439: auto matches 100.64.0.0/10 exactly, not all of 100/8" {
+  printf 'nameserver 100.128.0.1\nnameserver 100.63.255.1\n' > "$STUBDIR/resolvers-near"
+  _provision rebind4box ACQ_TEST_HOST_RESOLVERS="$STUBDIR/resolvers-near"
+  run cat "$CALLS"
+  refute_output --partial '--no-dns-rebind-protection'
+  printf 'nameserver 100.127.255.254\n' > "$STUBDIR/resolvers-edge"
+  _provision rebind5box ACQ_TEST_HOST_RESOLVERS="$STUBDIR/resolvers-edge"
+  run cat "$CALLS"
+  assert_output --partial '--no-dns-rebind-protection'
+}
+
+@test "msb #439: ACQ_MSB_DNS_REBIND_PROTECTION=1 keeps the protection even with a CGNAT resolver" {
+  printf 'nameserver 100.64.0.1\n' > "$STUBDIR/resolvers-zpa"
+  _provision rebind6box ACQ_MSB_DNS_REBIND_PROTECTION=1 ACQ_TEST_HOST_RESOLVERS="$STUBDIR/resolvers-zpa"
+  refute_output --partial "$_rebind_note"
+  run cat "$CALLS"
+  refute_output --partial '--no-dns-rebind-protection'
+}
+
+@test "msb #439: ACQ_MSB_DNS_REBIND_PROTECTION=0 forces the protection off without a CGNAT resolver" {
+  _provision rebind7box ACQ_MSB_DNS_REBIND_PROTECTION=0
+  refute_output --partial "$_rebind_note"
+  run cat "$CALLS"
+  assert_output --partial '--no-dns-rebind-protection'
+  _provision rebind8box ACQ_MSB_DNS_REBIND_PROTECTION=off
   run cat "$CALLS"
   assert_output --partial '--no-dns-rebind-protection'
 }

--- a/test/bats/76-msb-dns.bats
+++ b/test/bats/76-msb-dns.bats
@@ -2,9 +2,10 @@
 #
 # 76-msb-dns.bats — bats port of scripts/test-acq.d/76-msb-dns.sh (ADR-0019/0025)
 #
-# msb provision must pass --dns-nameserver (the guest can't reach the host's
-# corporate resolver), a generous default --memory/--cpus (msb's 512MiB/1vCPU
-# OOM-kills a Node TUI), and honor / validate the ACQ_MSB_* overrides. Each case
+# msb provision must leave guest DNS on the host's resolvers with msb's rebind
+# protection off (split-horizon/ZPA answers are private-range), pass a generous
+# default --memory/--cpus (msb's 512MiB/1vCPU OOM-kills a Node TUI), and honor /
+# validate the ACQ_MSB_* overrides. Each case
 # runs a real acq_backend_provision in an isolated subshell and inspects $CALLS.
 #
 # shellcheck shell=bats
@@ -33,10 +34,25 @@ _provision() { # NAME ENV_ASSIGNMENTS...
   ' _ "$name" "$@"
 }
 
-@test "msb: provision sets --dns-nameserver 1.1.1.1 by default" {
+@test "msb #439: provision leaves guest DNS on the host resolvers by default (no --dns-nameserver)" {
   _provision dnsbox
   run cat "$CALLS"
-  assert_output --partial '--dns-nameserver 1.1.1.1'
+  refute_output --partial '--dns-nameserver'
+}
+
+@test "msb #439: provision disables msb DNS rebind protection by default" {
+  _provision rebindbox
+  run cat "$CALLS"
+  assert_output --partial '--no-dns-rebind-protection'
+}
+
+@test "msb #439: ACQ_MSB_DNS_REBIND_PROTECTION=1 keeps msb's rebind protection" {
+  _provision rebind2box ACQ_MSB_DNS_REBIND_PROTECTION=1
+  run cat "$CALLS"
+  refute_output --partial '--no-dns-rebind-protection'
+  _provision rebind3box ACQ_MSB_DNS_REBIND_PROTECTION=off
+  run cat "$CALLS"
+  assert_output --partial '--no-dns-rebind-protection'
 }
 
 @test "msb: ACQ_MSB_DNS_NAMESERVER override is honored; empty omits the flag" {

--- a/test/bats/76-msb-dns.bats
+++ b/test/bats/76-msb-dns.bats
@@ -49,8 +49,8 @@ _provision() { # NAME ENV_ASSIGNMENTS...
 
 _rebind_note='host resolvers are in 100.64/10 (ZPA); disabling guest DNS rebind protection'
 
-@test "msb #439: auto disables rebind protection when a host resolver is in 100.64/10 (scutil format)" {
-  printf '  nameserver[0] : 100.64.0.1\n  nameserver[1] : 100.64.0.2\n' > "$STUBDIR/resolvers-zpa"
+@test "msb #439: auto disables rebind protection when a host resolver is in 100.64/10" {
+  printf 'search gsa.gov\nnameserver 100.64.0.1\nnameserver 100.64.0.2\n' > "$STUBDIR/resolvers-zpa"
   _provision rebindbox ACQ_TEST_HOST_RESOLVERS="$STUBDIR/resolvers-zpa"
   assert_output --partial "$_rebind_note"
   run cat "$CALLS"
@@ -64,7 +64,7 @@ _rebind_note='host resolvers are in 100.64/10 (ZPA); disabling guest DNS rebind 
   refute_output --partial '--no-dns-rebind-protection'
 }
 
-@test "msb #439: auto matches any CGNAT resolver in a mixed list (resolv.conf format)" {
+@test "msb #439: auto matches any CGNAT resolver in a mixed list" {
   printf 'nameserver 192.168.0.1\nnameserver 100.64.0.1\n' > "$STUBDIR/resolvers-mixed"
   _provision rebind3box ACQ_TEST_HOST_RESOLVERS="$STUBDIR/resolvers-mixed"
   run cat "$CALLS"
@@ -86,6 +86,13 @@ _rebind_note='host resolvers are in 100.64/10 (ZPA); disabling guest DNS rebind 
   printf 'nameserver 100.64.0.1\n' > "$STUBDIR/resolvers-zpa"
   _provision rebind6box ACQ_MSB_DNS_REBIND_PROTECTION=1 ACQ_TEST_HOST_RESOLVERS="$STUBDIR/resolvers-zpa"
   refute_output --partial "$_rebind_note"
+  run cat "$CALLS"
+  refute_output --partial '--no-dns-rebind-protection'
+}
+
+@test "msb #439: an invalid ACQ_MSB_DNS_REBIND_PROTECTION warns and falls back to auto" {
+  _provision rebind9box ACQ_MSB_DNS_REBIND_PROTECTION=maybe
+  assert_output --partial 'invalid ACQ_MSB_DNS_REBIND_PROTECTION=maybe'
   run cat "$CALLS"
   refute_output --partial '--no-dns-rebind-protection'
 }


### PR DESCRIPTION
## Problem

On a Zscaler/ZPA host, WAF-gated APIs that work from sbx sandboxes (GitLab's `/api/v4/*`) return `403` from the ELB on msb, and `api.gsa.usai.gov` fails to resolve (KNOWN_FAILURE_MODES §30). Live probes on the issue showed msb traffic already rides the host tunnel; the gap is name resolution:

- The host's Zscaler resolvers answer these names with private ZPA addresses (`100.64.x`) that ride the tunnel's allow-listed path.
- acq pinned the guest resolver to `1.1.1.1`, which answers the public endpoint instead.
- Even with the host resolver, msb's DNS rebind protection drops the private-range answer.

## Fix

Two `msb create` flags acq already controls:

- **`ACQ_MSB_DNS_NAMESERVER`** no longer defaults to `1.1.1.1`. Empty means msb's default, the host's resolvers, which msb's host-side network stack can reach. The "corporate resolver unreachable from the microVM" rationale predates that stack. Setting the knob still forces a resolver.
- **`ACQ_MSB_DNS_REBIND_PROTECTION`** (new) decides whether acq passes `--no-dns-rebind-protection`:

  | Value | Behavior |
  | --- | --- |
  | unset / empty | **auto**: off only when a host resolver sits in `100.64.0.0/10`, on otherwise |
  | `1` / `true` / `on` | always keep msb's protection |
  | `0` / `false` / `off` | always disable it (escape hatch for a sandbox created while the tunnel was down) |

  Auto reads the host's resolver list at create time from `/etc/resolv.conf`, which on macOS mirrors the global DNS state msb reads. `100.64.0.0/10` is the CGNAT range ZPA uses for both its resolvers and its synthetic app addresses. When the check fires, acq prints one stderr line saying so. Hosts without such a resolver keep msb's default and see no change.

Both are create-time flags: an existing sandbox keeps its DNS config until recreated.

## Security considerations

**What rebind protection guards.** msb maps a kit's `allow@host` rule onto the resolved IP; rebind protection stops that mapping from admitting a private address. With it off, an allowed domain whose DNS an attacker can influence could steer the guest at private space (other tunnel app segments, the msb gateway) under that rule. This is inherent to the fix: the legitimate ZPA destinations are private, so no IP-range rule can tell them from a rebinding pivot.

sbx already behaves this way: its proxy resolves on the host and connects wherever the host's resolver points, ZPA addresses included, with no rebind check. This default puts msb on the same footing as sbx rather than a weaker one.

**Risk mitigation.**

- **Scoped to the hosts that need it.** The guard is relaxed only where the host's own resolvers already return private answers for these names. A non-tunnel host keeps msb's protection and sees no change.
- **Only named kit hosts are allowed** under strict/balanced; every other destination stays deny-by-default, and a resolved private address with no domain rule is still RST'd.
- **Stronger DNS trust than before.** Answers now come from the host's corporate resolver over the tunnel rather than a public resolver.
- **IP-group rules never admit private addresses.** `allow@public` is unchanged, so the open tier gains no new pivot.
- **Secrets are bound to the upstream TLS identity** (`require_tls_identity`), so a rebound endpoint cannot receive an injected token.
- **Visible and reversible.** Auto prints a one-line notice when it relaxes the guard. `ACQ_MSB_DNS_REBIND_PROTECTION=1` keeps it on regardless; rollback to the previous behavior is `ACQ_MSB_DNS_NAMESERVER=1.1.1.1 ACQ_MSB_DNS_REBIND_PROTECTION=1`.

**Secondary effects.** The guest can now resolve internal names it previously could not (reaching them still needs an allow rule), and corporate DNS logging sees sandbox queries.

**Blast radius.** Two create-time flags, msb only, new sandboxes only, and the rebind relaxation only on hosts with a `100.64/10` resolver. No behavior change for sbx.

## Docs

- `docs/BACKEND_GUIDE.md`: knob table and DNS section (three values, detection rule, tunnel-down caveat).
- `docs/KNOWN_FAILURE_MODES.md` §30: triage row and the split-horizon entry rewritten around the verified mechanism; the old "internal resolver unreachable from the guest" measurement is retracted.
- `docs/howto/msb.md` snippet, ADR-0011's DNS sentence, and the in-tool USAi "did not RESOLVE" guidance.

## Tests

`76-msb-dns.bats`, with the host resolver listing fed from fixtures so no case depends on the machine running the suite:

- no `--dns-nameserver` by default; override still honored
- auto passes `--no-dns-rebind-protection` and prints the notice with a `100.64/10` resolver (anywhere in a mixed list)
- auto passes nothing on a public-only list, or on `100.128.x` / `100.63.x` (outside the /10)
- `1` keeps the protection even on a ZPA host; `0` disables it even without one
- an invalid value warns and falls back to auto

## Live verification

msb 0.6.16 with the new defaults and the team kit: from the guest `gitlab.login.gov` resolves to its ZPA address, `/api/v4/user` with the bound token returns 200, and the USAi models endpoint returns 401 (reachable) instead of failing to resolve. Egress IP unchanged (still the Zscaler cloud).

Fixes GSA-TTS/agentic-coding-quickstart#439

---

AI-assisted: drafted with Claude Code; reviewed and directed by a human.

