### PR TITLE
fix(msb): refresh ssh authorization for port publish

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -4483,19 +4483,18 @@ _acq_msb_ssh_key_ensure() {
   return 0
 }
 
-# _acq_msb_ssh_authorize — seat the acq public key via `msb ssh authorize` once.
-# Authorizing twice is harmless; a marker guards against re-running each publish.
+# _acq_msb_ssh_authorize — seat the acq public key via `msb ssh authorize`.
+#
+# Do this on every post-hoc publish instead of trusting a private marker file:
+# msb's host-scoped authorized_keys can disappear independently of acq state
+# (e.g. msb data reset/reinstall), and `msb ssh serve` then fails immediately.
+# Authorizing an already-present key is harmless and keeps the path self-healing.
 _acq_msb_ssh_authorize() {
-  local marker="${ACQ_MSB_SSH_DIR}/.authorized"
-  if [ -f "$marker" ]; then
-    return 0
-  fi
   if ! msb ssh authorize --file "${ACQ_MSB_SSH_KEY}.pub" >/dev/null 2>&1; then
     echo "acq(msb): ports: 'msb ssh authorize' failed for the acq tunnel key." >&2
     return 1
   fi
-  : >"$marker" 2>/dev/null || true
-  acq_debug "msb ports: authorized acq tunnel public key (once)"
+  acq_debug "msb ports: authorized acq tunnel public key"
   return 0
 }
 

--- a/docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md
+++ b/docs/adr/0015-msb-post-hoc-port-publish-via-ssh.md
@@ -60,10 +60,13 @@ something on msb instead of printing "re-create the sandbox."
 **Chosen: Option 1.** Wire `acq_backend_ports` on msb to the SSH-tunnel path and
 flip `ACQ_BACKEND_SUPPORTS_PORT_FORWARD=1`. Sketch:
 
-- **Key authorization (once per host).** `msb ssh authorize` seats a public key
+- **Key authorization (self-healing).** `msb ssh authorize` seats a public key
   in `<MSB_HOME>/ssh/authorized_keys`. acq uses a dedicated, non-interactive
   key it manages under its own state dir (not the user's personal key), created
-  on first use.
+  on first use. acq refreshes authorization on each publish because msb's
+  host-scoped `authorized_keys` can disappear independently of acq state (for
+  example, after an msb data reset/reinstall), and re-authorizing an existing key
+  is harmless.
 - **Serve + forward.** For `acq ports <sandbox> --publish H:G`, acq starts
   `msb ssh serve <sandbox> --host 127.0.0.1 --port <ephemeral>` and then
   `ssh -p <ephemeral> -L 127.0.0.1:H:127.0.0.1:G <sandbox-host>`, backgrounded.

--- a/scripts/probe-msb-posthoc-ports
+++ b/scripts/probe-msb-posthoc-ports
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# probe-msb-posthoc-ports - host-side diagnostic for msb post-hoc port publish.
+#
+# This probes the raw msb SSH serving primitive underneath:
+#   acq --backend msb ports SANDBOX --publish HOST:GUEST
+#
+# It is designed for the failure where acq reports:
+#   'msb ssh serve' on 127.0.0.1:PORT exited immediately
+#
+# Safety:
+# - Does not print environment variables or secret values.
+# - Starts only transient loopback listeners and kills them before exit.
+# - Runs the final acq publish probe only when --acq-publish is supplied.
+#
+# Usage:
+#   ./scripts/probe-msb-posthoc-ports [SANDBOX] [HOST:GUEST] [--acq-publish]
+#
+# Defaults:
+#   SANDBOX    opencode-scanning-service
+#   HOST:GUEST 6769:6767
+#   --acq-publish is off by default so the diagnostic does not leave a tunnel.
+set -u
+
+SANDBOX="opencode-scanning-service"
+MAPPING="6769:6767"
+RUN_ACQ_PUBLISH=""
+TMPDIR_PROBE=""
+PIDS=""
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+ACQ="$SCRIPT_DIR/acq"
+
+PASS=0
+FAIL=0
+INFO=0
+
+ok() { PASS=$((PASS + 1)); printf '  ok   %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  BAD  %s\n' "$1"; [ -n "${2:-}" ] && printf '       %s\n' "$2"; }
+note() { INFO=$((INFO + 1)); printf '  info %s\n' "$1"; }
+section() { printf '\n== %s ==\n' "$1"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+usage() {
+  sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+cleanup() {
+  local pid
+  trap - EXIT INT TERM
+  for pid in $PIDS; do
+    kill "$pid" >/dev/null 2>&1 || true
+    wait "$pid" >/dev/null 2>&1 || true
+  done
+  [ -n "$TMPDIR_PROBE" ] && rm -rf "$TMPDIR_PROBE" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+parse_args() {
+  local positional=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --acq-publish)
+        RUN_ACQ_PUBLISH=1
+        ;;
+      --no-acq-publish)
+        RUN_ACQ_PUBLISH=""
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --*)
+        echo "unknown option: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+      *)
+        positional=$((positional + 1))
+        case "$positional" in
+          1) SANDBOX="$1" ;;
+          2) MAPPING="$1" ;;
+          *)
+            echo "unexpected extra argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+        esac
+        ;;
+    esac
+    shift
+  done
+}
+
+valid_mapping() {
+  local m="$1" h g p
+  case "$m" in *:*) ;; *) return 1 ;; esac
+  h="${m%%:*}"
+  g="${m#*:}"
+  for p in "$h" "$g"; do
+    case "$p" in ""|*[!0-9]*) return 1 ;; esac
+    [ "$p" -ge 1 ] && [ "$p" -le 65535 ] || return 1
+  done
+  return 0
+}
+
+print_file_indented() {
+  local file="$1"
+  if [ -s "$file" ]; then
+    sed 's/^/       | /' "$file"
+  else
+    printf '       | (no output)\n'
+  fi
+}
+
+run_cmd() {
+  local label="$1" outfile rc
+  shift
+  outfile="$TMPDIR_PROBE/${label//[^A-Za-z0-9_.-]/_}.out"
+  printf '  $'
+  printf ' %q' "$@"
+  printf '\n'
+  "$@" >"$outfile" 2>&1
+  rc=$?
+  printf '  rc=%s\n' "$rc"
+  print_file_indented "$outfile"
+  return "$rc"
+}
+
+summarize_inspect_json() {
+  local json="$1"
+  if [ ! -s "$json" ]; then
+    bad "msb inspect produced no JSON"
+    return 1
+  fi
+  if ! have jq; then
+    note "jq not found; skipping structured inspect summary"
+    return 0
+  fi
+  jq -r '
+    def cfg: (.active_config // .config // .);
+    "  name: " + ((.name // cfg.name // "?")|tostring),
+    "  status: " + ((.status // .state // .runtime.status // "?")|tostring),
+    "  image: " + ((cfg.image.Oci.reference // cfg.image.oci.reference // cfg.image // "?")|tostring),
+    "  network.enabled: " + ((cfg.network.enabled // "?")|tostring),
+    "  default_egress: " + ((cfg.network.policy.default_egress // "?")|tostring),
+    "  default_ingress: " + ((cfg.network.policy.default_ingress // "?")|tostring),
+    "  env keys: " + ((cfg.env // [] | map(.key // empty) | join(", "))),
+    "  mounts: " + ((cfg.mounts // [] | length)|tostring),
+    "  create-time ports:",
+    ((cfg.network.ports // [])[]? | "    sandbox " + ((.guest_port // .guestPort // .guest // .container)|tostring) + " -> host " + ((.host_bind // "127.0.0.1")|tostring) + ":" + ((.host_port // .hostPort // .host)|tostring) + " (" + ((.protocol // "tcp")|tostring) + ")")
+  ' "$json" 2>/dev/null || note "jq could not summarize inspect JSON"
+}
+
+port_is_busy() {
+  local port="$1"
+  if have lsof; then
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1 && return 0
+  fi
+  if have nc; then
+    nc -z 127.0.0.1 "$port" >/dev/null 2>&1 && return 0
+  fi
+  return 1
+}
+
+pick_probe_ports() {
+  local base p count=0
+  base=$(( 23000 + (($$ + $(date +%s 2>/dev/null || printf 0)) % 20000) ))
+  while [ "$count" -lt 3 ]; do
+    p=$(( base + count ))
+    if [ "$p" -gt 65500 ]; then p=$(( 23000 + count )); fi
+    printf '%s\n' "$p"
+    count=$((count + 1))
+  done
+}
+
+probe_serve_port() {
+  local port="$1" out pid rc=0
+  out="$TMPDIR_PROBE/msb-ssh-serve-${port}.out"
+  section "direct msb ssh serve on 127.0.0.1:${port}"
+  if port_is_busy "$port"; then
+    bad "host port $port is already in use" "This would make msb ssh serve fail before acq reaches ssh -L."
+    return 1
+  fi
+  printf '  $ msb ssh serve %q --host 127.0.0.1 --port %q\n' "$SANDBOX" "$port"
+  msb ssh serve "$SANDBOX" --host 127.0.0.1 --port "$port" >"$out" 2>&1 &
+  pid=$!
+  sleep 1
+  if kill -0 "$pid" >/dev/null 2>&1; then
+    ok "msb ssh serve stayed alive for 1s"
+    PIDS="${PIDS:+$PIDS }$pid"
+  else
+    wait "$pid" >/dev/null 2>&1
+    rc=$?
+    bad "msb ssh serve exited immediately (rc=$rc)"
+    print_file_indented "$out"
+    return 1
+  fi
+  print_file_indented "$out"
+  return 0
+}
+
+probe_guest_port() {
+  local gport="$1" script
+  section "guest-side checks for port ${gport}"
+  script="gp=${gport}; echo \"user=\$(id -un 2>/dev/null || true)\"; echo \"ssh=\$(command -v ssh 2>/dev/null || true)\"; echo \"curl=\$(command -v curl 2>/dev/null || true)\"; hex=\$(printf \"%04X\" \"\$gp\" 2>/dev/null || true); if [ -r /proc/net/tcp ]; then grep -i \":\$hex\" /proc/net/tcp 2>/dev/null | sed \"s/^/proc-net-tcp: /\" || true; fi; if command -v curl >/dev/null 2>&1; then curl -sS -m 3 -o /dev/null -w \"curl-http=%{http_code} size=%{size_download}\\n\" \"http://127.0.0.1:\$gp/\"; rc=\$?; echo \"curl-exit=\$rc\"; else echo \"curl=missing\"; fi"
+  run_cmd "guest-port" "$ACQ" --backend msb exec "$SANDBOX" -- sh -lc "$script" || true
+}
+
+main() {
+  parse_args "$@"
+  if ! valid_mapping "$MAPPING"; then
+    echo "invalid HOST:GUEST mapping: $MAPPING" >&2
+    exit 2
+  fi
+  TMPDIR_PROBE=$(mktemp -d "${TMPDIR:-/tmp}/acq-msb-ports-probe.XXXXXX") || exit 1
+  local hport gport inspect_json port serve_ok=0
+  hport="${MAPPING%%:*}"
+  gport="${MAPPING#*:}"
+
+  section "probe configuration"
+  printf '  sandbox: %s\n' "$SANDBOX"
+  printf '  requested publish: host 127.0.0.1:%s -> sandbox 127.0.0.1:%s\n' "$hport" "$gport"
+  printf '  temp dir: %s\n' "$TMPDIR_PROBE"
+
+  section "host prerequisites"
+  if have msb; then ok "msb on PATH ($(command -v msb))"; else bad "msb not on PATH"; exit 1; fi
+  if [ -x "$ACQ" ]; then ok "repo acq found ($ACQ)"; else bad "repo acq not executable ($ACQ)"; exit 1; fi
+  have ssh && ok "ssh on PATH ($(command -v ssh))" || bad "ssh missing"
+  have jq && ok "jq on PATH ($(command -v jq))" || note "jq missing; JSON summaries will be limited"
+  run_cmd "msb-version" msb --version || true
+  run_cmd "acq-version" "$ACQ" version || true
+
+  section "msb ssh serve CLI shape"
+  run_cmd "msb-ssh-serve-help" msb ssh serve --help || true
+
+  section "sandbox inspect summary"
+  inspect_json="$TMPDIR_PROBE/inspect.json"
+  if msb inspect "$SANDBOX" --format json >"$inspect_json" 2>"$TMPDIR_PROBE/inspect.err"; then
+    ok "msb inspect --format json returned 0"
+    summarize_inspect_json "$inspect_json"
+  else
+    bad "msb inspect --format json failed"
+    print_file_indented "$TMPDIR_PROBE/inspect.err"
+  fi
+
+  section "acq ports list"
+  run_cmd "acq-ports-list" "$ACQ" --backend msb ports "$SANDBOX" || true
+
+  section "basic msb ssh connectivity"
+  run_cmd "msb-ssh-true" msb ssh "$SANDBOX" -- true || true
+
+  probe_guest_port "$gport"
+
+  section "requested host publish port occupancy"
+  if port_is_busy "$hport"; then
+    bad "host 127.0.0.1:${hport} appears busy" "The later ssh -L step would fail even if msb ssh serve works."
+  else
+    ok "host 127.0.0.1:${hport} does not appear busy"
+  fi
+
+  for port in $(pick_probe_ports); do
+    if probe_serve_port "$port"; then
+      serve_ok=1
+      break
+    fi
+  done
+
+  if [ -n "$RUN_ACQ_PUBLISH" ]; then
+    section "acq publish probe"
+    run_cmd "acq-publish" "$ACQ" --backend msb ports "$SANDBOX" --publish "$MAPPING" || true
+    note "If acq publish succeeded, tear it down later with: $ACQ --backend msb stop $SANDBOX"
+  else
+    note "skipped acq publish probe; pass --acq-publish to run the real publish path"
+  fi
+
+  section "interpretation"
+  if [ "$serve_ok" -eq 0 ]; then
+    bad "all raw msb ssh serve probes exited immediately" "The captured stderr is raw-msb evidence. The fixed acq path refreshes authorization before serve; pass --acq-publish to test that full path."
+  else
+    ok "raw msb ssh serve can start"
+    note "If acq publish still fails, compare the acq publish output with the raw serve port that worked."
+  fi
+  printf '\n  passed: %d   failed: %d   info: %d\n' "$PASS" "$FAIL" "$INFO"
+  [ "$FAIL" -eq 0 ]
+}
+
+main "$@"

--- a/test/bats/112-msb-ports.bats
+++ b/test/bats/112-msb-ports.bats
@@ -62,7 +62,7 @@ load 'helper'
   assert [ ! -f "$STUBDIR/state/ports/pbox.pids" ]
 }
 
-@test "msb ports: a second publish reuses the key (no re-keygen/re-authorize) but opens its own tunnel" {
+@test "msb ports: a second publish reuses the key, refreshes auth, and opens its own tunnel" {
   run bash -c '
     . "'"$REPO_ROOT"'/acq.backends/msb.sh"
     acq_backend_ports pbox --publish 8080:3000 >/dev/null 2>&1
@@ -73,8 +73,20 @@ load 'helper'
   '
   local log; log=$(cat "$CALLS")
   refute_regex "$log" 'ssh-keygen'
-  refute_regex "$log" 'msb ssh authorize'
+  assert_regex "$log" 'msb ssh authorize'
   assert_regex "$log" -- '-L 127.0.0.1:9090:127.0.0.1:4000'
+}
+
+@test "msb ports: stale acq authorization marker does not skip msb authorize" {
+  mkdir -p "$STUBDIR/state/ssh"
+  : > "$STUBDIR/state/ssh/.authorized"
+  run bash -c '
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    acq_backend_ports pbox --publish 8080:3000 >/dev/null 2>&1
+    wait
+  '
+  local log; log=$(cat "$CALLS")
+  assert_regex "$log" 'msb ssh authorize'
 }
 
 @test "msb ports: two publishes in one process get distinct serve ports" {


### PR DESCRIPTION
## Context

Fixes msb post-hoc port publishing when acq's local authorization marker is stale but msb's host-scoped authorized_keys has disappeared. In that state, `acq ports <sandbox> --publish H:G` skipped `msb ssh authorize`, then `msb ssh serve` exited immediately with `SSH authorized keys not found`.

This was reproduced on msb 0.6.16 with `opencode-scanning-service`: the diagnostic showed normal sandbox health, working `msb ssh`, a healthy guest listener, and raw `msb ssh serve` failing only because `~/.microsandbox/ssh/authorized_keys` was absent.

AI-assisted: yes.

## Plan / Changes

- Refresh the acq-managed msb SSH authorization on every `acq ports --publish` instead of trusting acq's private `.authorized` marker.
- Keep key generation idempotent; only authorization is refreshed.
- Add a focused regression test for a stale acq authorization marker.
- Update ADR-0015 to document self-healing authorization.
- Add `scripts/probe-msb-posthoc-ports`, a host-side diagnostic for the raw msb serve path and optional full acq publish path.

## Adversarial Review Response

A sub-agent review found issues in the diagnostic script before commit. Addressed findings:

- Removed mutation of the user's default SSH `known_hosts`.
- Made the real `acq ports --publish` probe opt-in via `--acq-publish` so the script does not leave a tunnel by default.
- Stopped printing response body bytes from the guest service probe; it now reports status and size only.
- Reworded raw `msb ssh serve` output so it is not confused with the fixed acq self-healing path.
- Updated ADR-0015 and added a stale-marker regression test.

## Verification

Post-rebase on `origin/main`:

```text
$ bash -n acq acq.backends/*.sh scripts/probe-msb-posthoc-ports
# pass; no output
```

```text
$ shellcheck --severity=warning acq.backends/msb.sh test/bats/112-msb-ports.bats scripts/probe-msb-posthoc-ports
# pass; no output
```

```text
$ ./scripts/test-acq-bats test/bats/112-msb-ports.bats
1..15
ok 1 msb ports: publish generates+authorizes the acq key once, serves, and opens the -L tunnel
ok 2 msb ports(S2): a serve that dies immediately fails the publish, no state recorded
ok 3 msb ports(S2): a forward that dies immediately fails the publish, no state recorded
ok 4 msb ports: a second publish reuses the key, refreshes auth, and opens its own tunnel
ok 5 msb ports: stale acq authorization marker does not skip msb authorize
ok 6 msb ports: two publishes in one process get distinct serve ports
ok 7 msb ports: invalid --publish values are rejected before any ssh/serve/keygen
ok 8 msb: SUPPORTS_PORT_FORWARD is 1 (post-hoc publish wired)
ok 9 msb ports: rm and stop tear down recorded port state; un-published teardown is a no-op
ok 10 msb ports: an unsafe sandbox name cannot escape the state dir on record/teardown
ok 11 msb ports: LIST mode surfaces create-time + post-hoc ports without host_bind junk
ok 12 msb ports: LIST mode with zero ports exits 0 (empty list, not an error)
ok 13 msb ports: LIST degrades gracefully when the JSON has no recognizable port field
ok 14 msb ports: LIST exits 0 under set -euo pipefail with empty ports (live-host regression)
ok 15 msb ports: a genuinely bad arg (--frobnicate) still errors, not swallowed by LIST mode
```

```text
$ git diff --check
# pass; no output
```

Host live confirmation from the reported environment after the fix:

```text
$ acq ports opencode-scanning-service
sandbox 6767 -> host 127.0.0.1:6767 (create-time -p)
sandbox 6767 -> host 127.0.0.1:6769 (post-hoc ssh -L)
```

Full offline suite note:

```text
$ env -u EMAIL ./scripts/test-acq-bats
# The full suite still has unrelated existing command-shape failures outside this change:
# - test/bats/30-dispatch-routing.bats: expects no EMAIL env injection
# - test/bats/70-msb-backend.bats: expects no EMAIL env injection
# - test/bats/90-sbx-startup-kit.bats: existing sbx heal expectation mismatch
```

## Rollback

Revert this commit. The previous behavior will return: acq may skip `msb ssh authorize` based on its private marker, so port publishing can fail again after msb authorized_keys is reset.

## Security Impact

Low. This does not add credentials or broaden network exposure. It re-runs `msb ssh authorize` for the existing acq-managed public key before opening a loopback-only SSH serve listener. The diagnostic script avoids printing secrets and does not run the real publish path unless explicitly requested with `--acq-publish`.
