### PR TITLE
fix(secret): reject multiline test secret values

### DIFF
--- a/acq.backends/secret-store.sh
+++ b/acq.backends/secret-store.sh
@@ -130,6 +130,17 @@ _acq_secret_security_i_quote() {
   printf '"%s"' "$s"
 }
 
+_acq_secret_value_is_storable() {
+  local value="$1" nl tab
+  nl=$(printf '\n_'); nl=${nl%_}
+  tab=$(printf '\t')
+  case "$value" in
+    *"$nl"*) return 1 ;;
+    *"$tab"*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 _acq_secret_store_keychain_macos() {
   local key="$1" value="$2" cmd security_bin
   security_bin=$(_acq_secret_security_bin)
@@ -735,6 +746,11 @@ acq_secret_set_interactive() {
 
   if [ -n "${ACQ_SECRET_TEST_VALUE:-}" ]; then
     value="$ACQ_SECRET_TEST_VALUE"
+    if ! _acq_secret_value_is_storable "$value"; then
+      echo "acq: refusing '$service' — ACQ_SECRET_TEST_VALUE contains a newline or tab, which the acq secret store cannot store intact." >&2
+      value=""
+      return 1
+    fi
   elif [ ! -t 0 ]; then
     IFS= read -r value || true
   else

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -643,7 +643,11 @@ store at provision:
 The store lives in the host OS keychain when available (macOS `security -i`,
 Linux `secret-tool`) with a `0600` file fallback under
 `$XDG_DATA_HOME/acq/secrets/` when no keychain backend is available. macOS writes
-use `security -i` so the value travels on stdin, not process argv. Existing
+use `security -i` so the value travels on stdin, not process argv. The macOS
+read path uses `security find-generic-password -w`, whose output formatting can
+be lossy for control characters and non-ASCII bytes even when the Keychain write
+stored the bytes correctly. `acq` secrets are expected to be single-line API
+tokens; do not use this store for arbitrary binary or multi-line values. Existing
 legacy macOS file-backed entries are still read as a fallback until they are
 re-saved or removed. Entries are keyed `acq.<service>` (global) or
 `acq.<sandbox>.<service>` (sandbox-scoped); a sandbox-scoped key takes precedence

--- a/docs/adr/0026-installation-and-distribution.md
+++ b/docs/adr/0026-installation-and-distribution.md
@@ -319,9 +319,9 @@ as issues):
   succeeds and prints "verified HEAD matches"; a well-formed but absent SHA
   fails closed and cleans up).
 - **release-please version sync:** `release-please-config.json` carries an
-  `extra-files` entry (`type: json`, `jsonpath: $.version`) so the next release
-  bumps `package.json`'s `version`; `npm pack --dry-run` reports the manifest
-  version (`2.0.0`) rather than a placeholder. A generic extra-file marker keeps
+  `extra-files` entry (`type: json`, `jsonpath: $.version`) so each release bumps
+  `package.json`'s `version`; `npm pack --dry-run` reports the current manifest
+  version rather than a placeholder. A generic extra-file marker keeps
   `install.sh`'s `DEFAULT_RELEASE_VERSION` aligned with the release version.
 - **Release assets:** on release creation, `.github/workflows/release.yml` checks
   out the release commit, copies `install.sh`, injects that exact commit into the

--- a/test/bats/71b-msb-secret-store-backends.bats
+++ b/test/bats/71b-msb-secret-store-backends.bats
@@ -199,6 +199,26 @@ _provision() { # NAME PRE_SNIPPET WS_ARGS...
   refute_regex "$(cat "$CALLS")" '^security -i$'
 }
 
+@test "keychain-macos: ACQ_SECRET_TEST_VALUE rejects newline before security -i" {
+  _plant_security_stub
+  run bash -c '
+    export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/km-test-value-secrets"
+    export STUBDIR="'"$STUBDIR"'"
+    export ACQ_SECRET_SECURITY_BIN="'"$STUBDIR"'/security"
+    . "'"$REPO_ROOT"'/acq.backends/secret-store.sh"
+    unset ACQ_SECRET_FORCE_FILE
+    _acq_secret_backend() { printf "keychain-macos\n"; }
+    ACQ_SECRET_TEST_VALUE=$'"'"'FIRST\nSECOND'"'"' acq_secret_set_interactive usai "" 2>&1 && printf "stored\n" || printf "refused\n"
+    acq_secret_has usai && printf "has-secret=yes\n" || printf "has-secret=no\n"
+  '
+  assert_output --partial 'ACQ_SECRET_TEST_VALUE contains a newline or tab'
+  assert_output --partial 'refused'
+  assert_output --partial 'has-secret=no'
+  refute_output --partial 'FIRST'
+  refute_output --partial 'SECOND'
+  refute_regex "$(cat "$CALLS")" '^security -i$'
+}
+
 @test "file ls: a stored secret lists (no value); an empty store lists nothing" {
   run bash -c '
     export ACQ_SECRET_STORE_DIR="'"$STUBDIR"'/file-ls-secrets"


### PR DESCRIPTION
Summary
- Reject ACQ_SECRET_TEST_VALUE values containing newlines or tabs before any secret-store write path, including macOS Keychain security -i.
- Document the macOS Keychain read-back limitation for control/non-ASCII values and clarify that acq secrets are single-line API tokens.
- Make ADR-0026 npm package-version validation wording version-agnostic while preserving that the baked release SHA only applies to clone fallback installs.

Related issues
Closes GSA-TTS/agentic-coding-quickstart#440
Closes GSA-TTS/agentic-coding-quickstart#441

Related ADRs
- docs/adr/0026-installation-and-distribution.md

AI attribution
- AI-assisted by OpenCode [gpt_5_5_default_v2]; changes require human review before merge.

Security impact
- Follow-up hardening and documentation only. Prevents the test-only ACQ_SECRET_TEST_VALUE escape hatch from reaching Keychain write paths with values that the single-line secret store cannot round-trip intact.
- No authentication, authorization, production data, or external service behavior changes.

Verification transcript
- PASS: shellcheck --severity=warning acq.backends/secret-store.sh test/bats/71b-msb-secret-store-backends.bats
- PASS: npm run lint:md
- PASS: git diff --check
- PASS: ./scripts/test-acq-bats test/bats/71b-msb-secret-store-backends.bats
- BLOCKED: gitleaks detect --source . (gitleaks not installed); fallback diff scan run with rg for secret/token/password patterns, reviewed intentional placeholders/docs only.

Rollback
- Revert commit 63686b760d79c8e38938d13e01b4f58ac12f8eb7 to restore the prior behavior and documentation.