### PR TITLE
fix(msb): warn when ssh-agent route is missing

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -3787,7 +3787,20 @@ _acq_msb_ensure_ssh_agent_forward() {
   # The --vsock route is create-time only. If this sandbox was created WITHOUT
   # it, a socat bridge would be inert and the marker would falsely advertise a
   # working agent, so require the route to actually be present before wiring.
-  _acq_msb_has_ssh_agent_vsock_route "$name" || return 0
+  # Do not fail silently, though: a valid host SSH_AUTH_SOCK means the user opted
+  # into signing support, and a missing route is the exact shape produced by a
+  # same-name sandbox recreated outside this create path (or after wiping msb
+  # state but keeping acq's expectations around the name). Recreate through acq
+  # with SSH_AUTH_SOCK set so the create-time route is recorded.
+  if ! _acq_msb_has_ssh_agent_vsock_route "$name"; then
+    echo "acq(msb): warning: host SSH_AUTH_SOCK is set, but existing sandbox '$name'" \
+         "has no ssh-agent --vsock route. The route is create-time only, so" \
+         "SSH_AUTH_SOCK will not be set in the guest and git signing will fail." >&2
+    echo "acq(msb):   If this sandbox was recreated with the same name after wiping" \
+         "msb state, remove it with 'acq rm $name' and re-run 'acq run …' with" \
+         "SSH_AUTH_SOCK set so acq can create the route. See ADR-0021." >&2
+    return 0
+  fi
 
   # From here, treat forwarding as active: point the bridge starter at the guest
   # sock constant (not the possibly-empty marker) and gate on socat as provision

--- a/test/bats/115-ssh-agent-forward.bats
+++ b/test/bats/115-ssh-agent-forward.bats
@@ -356,6 +356,26 @@ s.bind(sys.argv[1])' "$1" >/dev/null 2>&1 && [ -S "$1" ]
   refute_regex "$(cat "$CALLS")" 'socat UNIX-LISTEN'
 }
 
+@test "vsock(10c17b): re-attach warns when host agent is set but no route exists" {
+  _mk_unix_socket "$STUBDIR/agent17b.sock" || skip "python3 AF_UNIX socket unavailable"
+  printf 'rbox\n' >"$STUBDIR/.msb_sandbox_list"
+  printf 'rbox\n' >"$STUBDIR/.msb_running_list"
+  printf '{"active_config":{"network":{}}}\n' >"$STUBDIR/.msb_inspect_json"
+  : > "$CALLS"
+  run bash -c '
+    export SSH_AUTH_SOCK="'"$STUBDIR"'/agent17b.sock" STUB_MSB_VERSION=0.6.9
+    . "'"$REPO_ROOT"'/acq.backends/common.sh"
+    . "'"$REPO_ROOT"'/acq.backends/msb.sh"
+    _acq_msb_ensure_ssh_agent_forward rbox 2>&1
+    wait
+  '
+  assert_success
+  assert_output --partial 'has no ssh-agent --vsock route'
+  assert_output --partial 'SSH_AUTH_SOCK will not be set in the guest'
+  assert_output --partial 'same name after wiping msb state'
+  refute_regex "$(cat "$CALLS")" 'socat UNIX-LISTEN'
+}
+
 @test "vsock(10c18): the route probe matches the real msb 0.6.12 vsock shape" {
   # The real shape (confirmed on msb 0.6.12) is
   #   "vsock":{"routes":[{"host_socket":"…/Listeners","port":3552}]}


### PR DESCRIPTION
## Context

This fixes a silent failure mode on MSB re-attach: if the host has SSH_AUTH_SOCK set but an existing/recreated sandbox lacks the create-time ssh-agent --vsock route, acq could attach without SSH_AUTH_SOCK in the guest. That breaks git commit signing and is especially confusing after MSB state is wiped while acq-side expectations about the sandbox name remain.

## Changes

- Detect the re-attach mismatch where host SSH_AUTH_SOCK is available but the existing sandbox has no ssh-agent --vsock route.
- Emit a targeted warning explaining that SSH_AUTH_SOCK will not be set in the guest and that the sandbox must be recreated through acq with SSH_AUTH_SOCK set.
- Add a Bats regression covering the missing-route warning path.

## Verification

- PASS: shellcheck --severity=warning acq.backends/msb.sh
- PASS: shellcheck --severity=warning test/bats/115-ssh-agent-forward.bats
- PASS: ./scripts/test-acq-bats test/bats/115-ssh-agent-forward.bats
  - 25 tests passed, including vsock(10c17b): re-attach warns when host agent is set but no route exists

## Rollback

Revert commit 0b595fa. The previous behavior would return: re-attaching to an existing sandbox with no ssh-agent --vsock route would silently omit SSH_AUTH_SOCK.

## Security Impact

No new credential exposure. This only adds a warning for a missing create-time route. It does not print key material or host socket values and does not expand the sandbox trust boundary.