### PR TITLE
fix(msb): translate kit wildcard network rules

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -1106,7 +1106,7 @@ _acq_msb_fetch_kit() {
 # validated to look like a DNS name/wildcard BEFORE it reaches eval, so a
 # malformed or malicious spec value can't smuggle shell metacharacters in.
 _acq_msb_net_rules_into() {
-  local _arr="$1" _spec="$2" _host
+  local _arr="$1" _spec="$2" _host _target
   eval "$_arr=()"
   while IFS= read -r _host; do
     [ -n "$_host" ] || continue
@@ -1117,24 +1117,19 @@ _acq_msb_net_rules_into() {
     # a real multi-label FQDN like api.gsa.usai.gov is unambiguous as a bare domain,
     # so no `domain=` prefix is needed — and using one can break DNS resolution.)
     # Strip any :port the neutral spec carries (msb keys on the domain; the daemon
-    # handles ports/DNS for the allowed host).
+    # handles ports/DNS for the allowed host), then reuse the balanced-egress target
+    # normalizer so per-kit `**.host` wildcards get the same msb suffix form.
     _host="${_host%%:*}"
-    # Reject anything that isn't a plausible hostname/wildcard, so a malformed or
-    # malicious spec value can't smuggle characters through the eval below.
-    case "$_host" in
-      ""|*[!A-Za-z0-9.*_-]*)
-        echo "acq(msb): warning: skipping non-hostname net-allow entry: $_host" >&2
-        continue
-        ;;
-    esac
-    eval "$_arr+=(--net-rule \"allow@\${_host}\")"
+    _target=$(_acq_msb_balanced_target "$_host" "kit net-allow entry") || continue
+    eval "$_arr+=(--net-rule \"allow@\${_target}\")"
   done <<EOF
 $(kit_spec_net_allow "$_spec")
 EOF
 }
 
-# _acq_msb_balanced_target HOST — echo the msb `--net-rule` TARGET for one sbx
-# "balanced" host token, or nothing (rc 1) if it must be dropped. Translates the
+# _acq_msb_balanced_target HOST [CONTEXT] — echo the msb `--net-rule` TARGET for
+# one host token, or nothing (rc 1) if it must be dropped. CONTEXT labels warnings
+# and defaults to "balanced entry" for the baseline caller. Translates the
 # wildcard forms (ADR-0018):
 #   - `**.h`  (sbx multi-label glob) -> msb suffix `*.h` (apex + any depth)
 #   - `crl*.h` (intra-label glob msb can't express) -> broadened to `*.<parent>`;
@@ -1144,7 +1139,7 @@ EOF
 # (which msb rejects for blast radius) are dropped, so the value is safe to place
 # in an argv via the caller's eval-by-name append (SI-10).
 _acq_msb_balanced_target() {
-  local _host="$1" _target
+  local _host="$1" _context="${2:-balanced entry}" _target
   case "$_host" in
     "**."*)   _target="*.${_host#**.}" ;;
     "crl*."*) _target="*.${_host#crl*.}" ;;
@@ -1154,7 +1149,7 @@ _acq_msb_balanced_target() {
   # Charset-guard the FINAL target (defense-in-depth before any eval append).
   case "$_target" in
     ""|*[!A-Za-z0-9.*_-]*)
-      echo "acq(msb): warning: skipping non-hostname balanced entry: ${_host}" >&2
+      echo "acq(msb): warning: skipping non-hostname ${_context}: ${_host}" >&2
       return 1
       ;;
   esac
@@ -1166,7 +1161,7 @@ _acq_msb_balanced_target() {
       case "${_target#*.}" in
         *.*) : ;;  # two+ labels after `*.` -> OK
         *)
-          echo "acq(msb): warning: skipping single-label suffix (msb rejects it): ${_target}" >&2
+          echo "acq(msb): warning: skipping single-label suffix ${_context} (msb rejects it): ${_target}" >&2
           return 1
           ;;
       esac

--- a/test/bats/110-volumes.bats
+++ b/test/bats/110-volumes.bats
@@ -238,7 +238,7 @@ SPEC
   assert_output --partial 'CREATE time only'
 }
 
-@test "msb: net-rule uses a bare FQDN target, strips :port, avoids domain= / domain: forms" {
+@test "msb: net-rule normalizes kit hosts and wildcard targets" {
   run bash -c '
     . "'"$REPO_ROOT"'/acq.backends/kit-translate.sh"
     . "'"$REPO_ROOT"'/acq.backends/msb.sh" 2>/dev/null
@@ -254,11 +254,14 @@ caps:
     allow:
       - api.gsa.usai.gov
       - github.com:443
+      - "**.cloud.gov:443"
 SPEC
     arr=(); _acq_msb_net_rules_into arr "$nkit/spec.yaml"; printf "%s\n" "${arr[@]}"
   '
   assert_output --partial 'allow@api.gsa.usai.gov'
   assert_output --partial 'allow@github.com'
+  assert_output --partial 'allow@*.cloud.gov'
+  refute_output --partial 'allow@**.cloud.gov'
   refute_output --partial 'allow@domain='
   refute_output --partial 'allow@domain:'
 }


### PR DESCRIPTION
## Summary
- Normalize per-kit `caps.network.allow` wildcard entries in the msb adapter.
- Translate neutral `**.host` kit entries into msb-compatible `*.host` rules.
- Add a regression test covering `**.cloud.gov:443` -> `allow@*.cloud.gov`.

## Context
This unblocks neutral acq kits that need all subdomains for a service, such as the cloud.gov kit in `GSA-TTS/agentic-coding-patterns#408`. The previous msb adapter path normalized balanced-egress wildcard hosts, but per-kit allow entries were emitted directly.

## Verification
- Passed: `./scripts/test-acq-bats test/bats/110-volumes.bats test/bats/111-balanced-egress.bats`
- Passed: `bash -n acq.backends/msb.sh`
- Passed: `git diff --check`
- Passed: `shellcheck --severity=warning acq.backends/msb.sh test/bats/110-volumes.bats`
- Full suite run: `./scripts/test-acq-bats`
  - New/related msb network tests passed.
  - Existing unrelated environment-sensitive failures remained in git identity / sbx heal tests.

## Security Impact
- Keeps existing hostname validation by reusing the msb target normalizer.
- Does not broaden egress beyond what the kit already declares; it only maps the neutral wildcard syntax into msb's supported suffix form.
- No secrets, auth flows, or persistence behavior changed.

## Rollback
Revert this commit to restore the prior direct per-kit msb net-rule emission behavior.

## AI Assistance
AI-assisted implementation and verification.