### PR TITLE
fix(ci): bump js-yaml to 4.3.2 to clear a high-severity CPU-DoS advisory

### DIFF
--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -10,7 +10,7 @@
     "markdownlint-cli2": "0.22.1"
   },
   "overrides": {
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "markdown-it": "14.2.0",
     "linkify-it": "5.0.2"
   }


### PR DESCRIPTION
## Summary

The Markdown Lint CI job runs `npm audit --audit-level=high` after `npm ci` in `.github/linters/`, and a newly-disclosed high-severity advisory in `js-yaml` (GHSA-2883-xcg3-v3hh / CVE-2026-84375, published 2026-09-08) started failing that audit on **every open PR**, regardless of the PR's actual content — blocking auto-merge across the board.

## Root cause

`js-yaml 4.0.0–4.3.1` doesn't count empty merge-source mappings toward `maxTotalMergeKeys`, so a crafted YAML document with repeated empty-mapping merges can consume disproportionate CPU without tripping the configured limit. `js-yaml` is a transitive dependency of `markdownlint-cli2` (via `markdown-it`'s YAML front-matter parsing), pinned in `.github/linters/package.json` through an `overrides` entry for supply-chain reproducibility — that pin was on `4.3.1`, one patch version short of the fix.

## Fix

Bumped the override to `4.3.2` (the patched version cited directly in the advisory), and regenerated the lockfile via `npm install` (not hand-edited). Deliberately **not** `npm audit fix --force`, which would also force an unrelated breaking upgrade of `markdownlint-cli2` itself (0.22.1 → 0.23.2) just to clear this one transitive advisory.

## Verification

- `npm install` in `.github/linters/` now reports **0 vulnerabilities** (was 2 high).
- Ran `markdownlint-cli2` against this repo's own docs at the same tool version (0.22.1, unchanged) — still 0 errors, confirming no behavioral change from the bump.

## Note for reviewers

This same `js-yaml` pin pattern exists identically in the sibling `agentic-coding-playbook` and `agentic-coding-patterns` repos' `.github/linters/package.json` — companion fixes are being opened there too, since all three share the same CI linter setup and are all equally affected.

Co-authored-by: OpenCode Agent <agent@gsa.gov>