### PR TITLE
fix(msb): point the --clone scratch's origin at the source checkout's remote

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -2420,7 +2420,7 @@ _acq_msb_clone_setup() {
     rm -rf "$dir"
     return 1
   fi
-  _acq_msb_clone_copy_identity "$ws_canon" "$scratch"
+  _acq_msb_clone_copy_config "$ws_canon" "$scratch"
   # Fetch-back remote in the host checkout (replace a stale same-name remote —
   # its scratch dir was just verified absent, so it cannot hold unfetched work).
   git -C "$ws_canon" remote remove "sandbox-${name}" >/dev/null 2>&1 || true
@@ -2434,21 +2434,28 @@ _acq_msb_clone_setup() {
   return 0
 }
 
-# _acq_msb_clone_copy_identity SRC SCRATCH — write SRC's EFFECTIVE git
-# identity (user.name/user.email) repo-locally into the scratch. A clone drops
-# .git/config, and a per-forge identity often lives only there or behind a
-# gitdir-scoped includeIf; the guest's synced global tier cannot express a
-# per-repo value, so without this the first in-guest commit fails with "Author
-# identity unknown". `git -C SRC config --get` resolves the value exactly as
-# the user's own commits do. Running git inside the scratch is safe HERE only:
-# acq just created it and it is not yet guest-exposed (see the rm-time rule in
-# _acq_msb_clone_warn_unfetched). Unlike the global-identity forwarder in
-# common.sh there is no control-character filter: the values go through `git
-# config`, which escapes on write, never onto a command line. Best-effort,
-# always returns 0.
-_acq_msb_clone_copy_identity() {
+# _acq_msb_clone_copy_config SRC SCRATCH — write the few repo-local config
+# values a clone drops but the guest needs, from SRC into the scratch:
+#   - user.name/user.email (#438): SRC's EFFECTIVE identity. A per-forge
+#     identity often lives only in .git/config or behind a gitdir-scoped
+#     includeIf; the guest's synced global tier cannot express a per-repo value,
+#     so without this the first in-guest commit fails with "Author identity
+#     unknown". `git -C SRC config --get` resolves it exactly as the user's own
+#     commits do.
+#   - remote.origin.url/remote.origin.pushurl (#453): `git clone <host path>`
+#     points the scratch's origin at the host checkout path, and the scratch is
+#     mounted AT that path in the guest — so origin resolves to the scratch
+#     itself (fetch is a no-op, push cannot reach the real remote). Copy the
+#     RAW values (`config --get`, not `remote get-url`) so host insteadOf
+#     rewrites are not baked in; the guest's global tier applies its own.
+# Running git inside the scratch is safe HERE only: acq just created it and it
+# is not yet guest-exposed (see the rm-time rule in _acq_msb_clone_warn_unfetched).
+# Unlike the global-identity forwarder in common.sh there is no
+# control-character filter: the values go through `git config`, which escapes
+# on write, never onto a command line. Best-effort, always returns 0.
+_acq_msb_clone_copy_config() {
   local src="$1" scratch="$2" key val
-  for key in user.name user.email; do
+  for key in user.name user.email remote.origin.url remote.origin.pushurl; do
     val=$(git -C "$src" config --get "$key" 2>/dev/null) || continue
     [ -n "$val" ] || continue
     git -C "$scratch" config "$key" "$val" >/dev/null 2>&1 \

--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -2435,19 +2435,22 @@ _acq_msb_clone_setup() {
 }
 
 # _acq_msb_clone_copy_config SRC SCRATCH — write the few repo-local config
-# values a clone drops but the guest needs, from SRC into the scratch:
-#   - user.name/user.email (#438): SRC's EFFECTIVE identity. A per-forge
-#     identity often lives only in .git/config or behind a gitdir-scoped
-#     includeIf; the guest's synced global tier cannot express a per-repo value,
-#     so without this the first in-guest commit fails with "Author identity
-#     unknown". `git -C SRC config --get` resolves it exactly as the user's own
-#     commits do.
-#   - remote.origin.url/remote.origin.pushurl (#453): `git clone <host path>`
-#     points the scratch's origin at the host checkout path, and the scratch is
+# values a clone drops but the guest needs, from SRC into the scratch (see
+# ADR-0027 for what a clone carries and why):
+#   - user.name/user.email: SRC's EFFECTIVE identity. A per-forge identity
+#     often lives only in .git/config or behind a gitdir-scoped includeIf; the
+#     guest's synced global tier cannot express a per-repo value, so without
+#     this the first in-guest commit fails with "Author identity unknown".
+#     `git -C SRC config --get` resolves it exactly as the user's own commits do.
+#   - remote.origin.url/remote.origin.pushurl: `git clone <host path>` points
+#     the scratch's origin at the host checkout path, and the scratch is
 #     mounted AT that path in the guest — so origin resolves to the scratch
 #     itself (fetch is a no-op, push cannot reach the real remote). Copy the
-#     RAW values (`config --get`, not `remote get-url`) so host insteadOf
-#     rewrites are not baked in; the guest's global tier applies its own.
+#     RAW values (`config --get`, not `remote get-url`): that is what
+#     .git/config holds and what sbx carries, and a host insteadOf rewrite is
+#     host policy the guest never receives (an https->ssh rewrite would hand the
+#     guest a transport it has no key for). A credential embedded in the URL
+#     travels with it, exactly as it does in a direct mount of the checkout.
 # Running git inside the scratch is safe HERE only: acq just created it and it
 # is not yet guest-exposed (see the rm-time rule in _acq_msb_clone_warn_unfetched).
 # Unlike the global-identity forwarder in common.sh there is no

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -396,11 +396,14 @@ msb has no native clone mode, so the neutral `--clone`
 committed state only. Gitignored/untracked files (sbx copies these — the known
 host-build-state contamination trap) and uncommitted edits to tracked files do
 **not** enter the sandbox; `acq` prints a notice when the host tree is dirty.
-Commit first, or copy specific files in with `acq cp`. One exception is
-deliberate: the source checkout's effective git identity
-(`user.name`/`user.email`) is written into the scratch as repo-local config, so
-a per-forge identity kept in `.git/config` or a gitdir-scoped include still
-authors the sandbox's commits. See ADR-0027 for the rationale.
+Commit first, or copy specific files in with `acq cp`. Two exceptions are
+deliberate, both written into the scratch as repo-local config: the source
+checkout's effective git identity (`user.name`/`user.email`), so a per-forge
+identity kept in `.git/config` or a gitdir-scoped include still authors the
+sandbox's commits; and the source's `remote.origin.url` (and `pushurl`), so
+`origin` in the guest is the real remote rather than the host checkout path,
+which the guest would resolve to the scratch itself. See ADR-0027 for the
+rationale.
 
 The scratch clone lives on host disk (unlike sbx's in-guest clone), confined to
 the acq-managed state dir — disposable by construction and never executed by

--- a/docs/adr/0027-neutral-clone-option.md
+++ b/docs/adr/0027-neutral-clone-option.md
@@ -131,14 +131,18 @@ on purpose, written repo-locally into the scratch:
   that very path in the guest, so `origin` would resolve to the scratch itself:
   `git fetch origin` a no-op, `git push origin` unable to reach the real
   remote, and anything that identifies the repo by its origin URL misled. The
-  raw configured values are copied (not `git remote get-url`'s expansion), so
-  host `insteadOf` rewrites are not baked in; the guest's global tier applies
-  its own. Remote-tracking refs (`origin/*`) still reflect the host's local
-  branches at clone time until the first `git fetch --prune`.
+  raw configured values are copied, not `git remote get-url`'s expansion: a
+  host `insteadOf` rewrite is host policy that the guest never receives (only
+  `user.*` is synced into its global tier), and an https-to-ssh rewrite would
+  hand the guest a transport it has no key for. A credential embedded in the
+  URL travels with it, exactly as it does when the checkout's own `.git/config`
+  is mounted in a non-clone run. Remote-tracking refs (`origin/*`) still
+  reflect the host's local branches at clone time until the first
+  `git fetch --prune`.
 
 sbx carries both incidentally by copying `.git` wholesale. Propagating only
-these inert values is the minimized form of that, without the credential
-helpers, hooks, and URL rewrites that ride along with a wholesale copy.
+these values is the minimized form of that, without the credential helpers,
+hooks, and URL rewrites that ride along with a wholesale copy.
 
 ### Trade-off stated openly
 

--- a/docs/adr/0027-neutral-clone-option.md
+++ b/docs/adr/0027-neutral-clone-option.md
@@ -116,17 +116,29 @@ A git clone carries **committed state only**:
   dirty working tree; the msb emulation does not. Create prints a notice when
   the host tree is dirty: commit first, or `acq cp` the files in.
 
-Unlike the two divergences above, one piece of uncommitted state is carried on
-purpose: the source checkout's **effective git identity**
-(`user.name`/`user.email`), resolved on the host as the user's own commits
-resolve it, is written repo-locally into the scratch. A clone drops
-`.git/config`, and per-forge identities commonly live only there or in a
-gitdir-scoped include. Without the copy, the first in-sandbox commit fails with
-"Author identity unknown"; the guest's global tier cannot express a per-repo
-value. sbx carries identity incidentally by copying `.git` wholesale.
-Propagating only the two inert `user.*` values is the minimized form of that,
-without the credential helpers, hooks, and URL rewrites that ride along with a
-wholesale copy.
+Unlike the two divergences above, two pieces of `.git/config` state are carried
+on purpose, written repo-locally into the scratch:
+
+- The source checkout's **effective git identity** (`user.name`/`user.email`),
+  resolved on the host as the user's own commits resolve it. A clone drops
+  `.git/config`, and per-forge identities commonly live only there or in a
+  gitdir-scoped include. Without the copy, the first in-sandbox commit fails
+  with "Author identity unknown"; the guest's global tier cannot express a
+  per-repo value.
+- The source checkout's **origin URL** (`remote.origin.url`, plus
+  `remote.origin.pushurl` when set). `git clone <host path>` points the
+  scratch's `origin` at the host checkout path, and the scratch is mounted at
+  that very path in the guest, so `origin` would resolve to the scratch itself:
+  `git fetch origin` a no-op, `git push origin` unable to reach the real
+  remote, and anything that identifies the repo by its origin URL misled. The
+  raw configured values are copied (not `git remote get-url`'s expansion), so
+  host `insteadOf` rewrites are not baked in; the guest's global tier applies
+  its own. Remote-tracking refs (`origin/*`) still reflect the host's local
+  branches at clone time until the first `git fetch --prune`.
+
+sbx carries both incidentally by copying `.git` wholesale. Propagating only
+these inert values is the minimized form of that, without the credential
+helpers, hooks, and URL rewrites that ride along with a wholesale copy.
 
 ### Trade-off stated openly
 

--- a/test/bats/116-clone-option.bats
+++ b/test/bats/116-clone-option.bats
@@ -282,3 +282,37 @@ _msb_clone_isolated() { # ARGS...
   run git config --file "$scratch/.git/config" user.email
   assert_failure
 }
+
+@test "clone(msb #453): the scratch's origin is the source checkout's origin URL, not the host path" {
+  git -C "$CLONEPROJ" remote add origin https://github.com/example/cloneproj.git
+  _msb_clone_isolated create shell --clone "$CLONEPROJ"
+  local scratch="$STUBDIR/state/clones/shell-cloneproj/cloneproj"
+  [ "$(git config --file "$scratch/.git/config" remote.origin.url)" = "https://github.com/example/cloneproj.git" ]
+  # The fetch-back remote on the host still points at the scratch.
+  [ "$(canonicalize_path "$(git -C "$CLONEPROJ" remote get-url sandbox-shell-cloneproj)")" = "$(canonicalize_path "$scratch")" ]
+}
+
+@test "clone(msb #453): a separate push URL on the source origin is carried too" {
+  git -C "$CLONEPROJ" remote add origin https://github.com/example/cloneproj.git
+  git -C "$CLONEPROJ" remote set-url --push origin git@github.com:example/cloneproj.git
+  _msb_clone_isolated create shell --clone "$CLONEPROJ"
+  local scratch="$STUBDIR/state/clones/shell-cloneproj/cloneproj"
+  [ "$(git config --file "$scratch/.git/config" remote.origin.url)" = "https://github.com/example/cloneproj.git" ]
+  [ "$(git config --file "$scratch/.git/config" remote.origin.pushurl)" = "git@github.com:example/cloneproj.git" ]
+}
+
+@test "clone(msb #453): the origin URL is carried raw; host insteadOf rewrites are not baked in" {
+  git -C "$CLONEPROJ" remote add origin https://github.com/example/cloneproj.git
+  git -C "$CLONEPROJ" config url.git@github.com:.insteadOf https://github.com/
+  _msb_clone_isolated create shell --clone "$CLONEPROJ"
+  local scratch="$STUBDIR/state/clones/shell-cloneproj/cloneproj"
+  [ "$(git config --file "$scratch/.git/config" remote.origin.url)" = "https://github.com/example/cloneproj.git" ]
+}
+
+@test "clone(msb #453): a source with no origin leaves the clone's remote untouched" {
+  _msb_clone_isolated create shell --clone "$CLONEPROJ"
+  local scratch="$STUBDIR/state/clones/shell-cloneproj/cloneproj"
+  [ "$(git config --file "$scratch/.git/config" remote.origin.url)" = "$(canonicalize_path "$CLONEPROJ")" ]
+  run git config --file "$scratch/.git/config" remote.origin.pushurl
+  assert_failure
+}


### PR DESCRIPTION
## Problem

On msb, `--clone` creates the scratch with `git clone --no-hardlinks <host path>`, so the scratch's `remote.origin.url` is the host checkout directory. The scratch is then mounted in the guest at that same path, so `origin` points at the scratch itself. In the guest:

- `git ls-remote origin` returns the clone-time snapshot
- `git fetch origin` is a silent no-op
- `git push origin <branch>` cannot reach the real remote
- kit steps that identify the repo by its origin URL are misled

sbx does not have this gap because its native `--clone` copies `.git` wholesale.

## Fix

The clone-setup helper that already carries the source checkout's effective git identity now also carries `remote.origin.url` and `remote.origin.pushurl`.

- Values are read raw with `git config --get`, not `git remote get-url`. Raw is what `.git/config` holds and what sbx carries, and a host `insteadOf` rewrite is host policy the guest never receives.
- A credential embedded in the URL travels with it, as it does in a non-clone mount of the checkout.
- A source with no `origin` leaves the clone as git made it.
- The host-side `sandbox-<name>` fetch-back remote is unchanged.
- Remote-tracking refs (`origin/*`) still reflect the host's local branches at clone time until the first `git fetch --prune`. The docs say so.

ADR-0027 and the backend guide now list both carried items.

## Tests

Four new cases in `116-clone-option.bats`, three of which failed before the fix:

- origin URL lands in the scratch, and the host fetch-back remote still points at the scratch
- a separate push URL is carried
- a host `insteadOf` rewrite is not expanded into the scratch
- a source with no origin is left untouched

## Verification

A fresh `--clone` sandbox of this repo on msb reports the GitHub URL for `git remote get-url origin` in the guest.

Pushing over an SSH origin still needs a key in the guest. That is the pre-existing SSH limitation, not this bug.

Fixes GSA-TTS/agentic-coding-quickstart#453

---

AI-assisted: drafted with Claude Code; reviewed and directed by a human.
