### PR TITLE
feat(acq): export ACQ_WORKSPACE and ACQ_CLONE into the guest on both backends

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -2946,6 +2946,18 @@ EOF
     ACQ_MSB_GUEST_WORKSPACE="$_first_guest"
   fi
 
+  # Guest-visible workspace markers (GSA-TTS/agentic-coding-quickstart#456).
+  # ACQ_WORKSPACE names the primary's guest path; ACQ_CLONE=1 marks it as the
+  # disposable clone. A kit that must write into the clone and never the real
+  # checkout keys on these instead of a mount-type heuristic (which the
+  # emulation above defeats by design: the scratch mounts exactly like a
+  # passthrough). `msb create --env` reaches every exec/attach session and
+  # survives a native restart (verified msb 0.6.17), so no kit-env plumbing.
+  if [ -n "$_first_guest" ]; then
+    create_flags+=(--env "ACQ_WORKSPACE=${_first_guest}")
+    [ -n "$_clone_src" ] && create_flags+=(--env ACQ_CLONE=1)
+  fi
+
   # Host ssh-agent / socket forwarding (ADR-0021). Translate the neutral
   # host-socket forwards into msb `--vsock HOST:PORT/KIND` create flags. Gated on
   # msb >= 0.6.9; a lower version warns once and skips (forwarding is opt-in

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -469,9 +469,11 @@ acq_backend_provision() {
   # sbx mounts the primary at its LOGICAL absolute host path (`.` resolves to
   # $PWD-form, not realpath; verified sbx 0.42.1), so resolve the same way or
   # `cd "$ACQ_WORKSPACE"` misses the mount on a symlinked path like /tmp.
+  # CDPATH is cleared so a relative workspace resolves against $PWD only (a
+  # CDPATH hit would both pick another directory and echo it into the value).
   local _ef=() _primary_ws
   _primary_ws=$(workspace_path "$@")
-  [ -n "$_primary_ws" ] && { _primary_ws=$(cd "$_primary_ws" 2>/dev/null && pwd) || _primary_ws=""; }
+  [ -n "$_primary_ws" ] && { _primary_ws=$(CDPATH='' cd -- "$_primary_ws" 2>/dev/null && pwd) || _primary_ws=""; }
   if [ -n "$_primary_ws" ]; then
     _ef=(--env "ACQ_WORKSPACE=${_primary_ws}")
     [ "${ACQ_CLONE:-0}" = "1" ] && _ef+=(--env ACQ_CLONE=1)
@@ -485,11 +487,7 @@ acq_backend_provision() {
 
   acq_debug "sbx create --name $name ${_cf[*]:-} ${_ef[*]:-} ${_tf[*]:-} ${kf[*]} ${_stripped[*]:-}"
   acq_spin_start "Creating sandbox '$name'"
-  if [ "${#_stripped[@]}" -gt 0 ]; then
-    sbx create --name "$name" ${_cf[@]+"${_cf[@]}"} ${_ef[@]+"${_ef[@]}"} ${_tf[@]+"${_tf[@]}"} "${kf[@]}" "${_stripped[@]}"
-  else
-    sbx create --name "$name" ${_cf[@]+"${_cf[@]}"} ${_tf[@]+"${_tf[@]}"} "${kf[@]}"
-  fi
+  sbx create --name "$name" ${_cf[@]+"${_cf[@]}"} ${_ef[@]+"${_ef[@]}"} ${_tf[@]+"${_tf[@]}"} "${kf[@]}" ${_stripped[@]+"${_stripped[@]}"}
   local _rc=$?
   acq_spin_stop "Creating sandbox '$name'"
   # Record host-side bundle provenance ONLY after a successful create — a failed

--- a/acq.backends/sbx.sh
+++ b/acq.backends/sbx.sh
@@ -464,16 +464,29 @@ acq_backend_provision() {
   local _cf=()
   [ "${ACQ_CLONE:-0}" = "1" ] && _cf=(--clone)
 
+  # Guest-visible workspace markers (GSA-TTS/agentic-coding-quickstart#456),
+  # same contract as msb: ACQ_WORKSPACE always, ACQ_CLONE=1 under --clone.
+  # sbx mounts the primary at its LOGICAL absolute host path (`.` resolves to
+  # $PWD-form, not realpath; verified sbx 0.42.1), so resolve the same way or
+  # `cd "$ACQ_WORKSPACE"` misses the mount on a symlinked path like /tmp.
+  local _ef=() _primary_ws
+  _primary_ws=$(workspace_path "$@")
+  [ -n "$_primary_ws" ] && { _primary_ws=$(cd "$_primary_ws" 2>/dev/null && pwd) || _primary_ws=""; }
+  if [ -n "$_primary_ws" ]; then
+    _ef=(--env "ACQ_WORKSPACE=${_primary_ws}")
+    [ "${ACQ_CLONE:-0}" = "1" ] && _ef+=(--env ACQ_CLONE=1)
+  fi
+
   local kf=()
   while IFS= read -r line; do kf+=("$line"); done < <(_acq_sbx_kit_flags)
   local _git_identity_kit=""
   _git_identity_kit=$(_acq_sbx_git_identity_kit)
   [ -n "$_git_identity_kit" ] && kf+=(--kit "$_git_identity_kit")
 
-  acq_debug "sbx create --name $name ${_cf[*]:-} ${_tf[*]:-} ${kf[*]} ${_stripped[*]:-}"
+  acq_debug "sbx create --name $name ${_cf[*]:-} ${_ef[*]:-} ${_tf[*]:-} ${kf[*]} ${_stripped[*]:-}"
   acq_spin_start "Creating sandbox '$name'"
   if [ "${#_stripped[@]}" -gt 0 ]; then
-    sbx create --name "$name" ${_cf[@]+"${_cf[@]}"} ${_tf[@]+"${_tf[@]}"} "${kf[@]}" "${_stripped[@]}"
+    sbx create --name "$name" ${_cf[@]+"${_cf[@]}"} ${_ef[@]+"${_ef[@]}"} ${_tf[@]+"${_tf[@]}"} "${kf[@]}" "${_stripped[@]}"
   else
     sbx create --name "$name" ${_cf[@]+"${_cf[@]}"} ${_tf[@]+"${_tf[@]}"} "${kf[@]}"
   fi

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -1023,7 +1023,7 @@ present in every exec/attach session and survive a native restart:
 
 | Variable | When | Value |
 |----------|------|-------|
-| `ACQ_WORKSPACE` | any create with a workspace | guest path of the **primary** workspace (the agent's starting directory) |
+| `ACQ_WORKSPACE` | any create with a workspace | guest path of the **primary** (first) workspace's mount root. Not necessarily the agent's cwd: on msb, `ACQ_MSB_WORKSPACE` moves only the start dir, and the marker stays on the primary mount so a `--clone` kit always writes into the clone |
 | `ACQ_CLONE` | `--clone` / `ACQ_CLONE=1` only | `1` — the primary is a disposable clone ([ADR-0027](adr/0027-neutral-clone-option.md)) |
 
 They are the kit-facing contract for "act on the clone, never on the real

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -1012,6 +1012,29 @@ reported by `acq kit validate`); values are plain strings. It maps to sbx-v2
 **Secrets do NOT go here** — use the credential/secret path (`acq secret …`);
 the kit spec never carries a secret value.
 
+**acq-set guest variables.** Independently of any kit, acq sets two guest
+environment variables at create on both backends, through the backend's native
+create-time env flag (`msb create --env`, `sbx create --env`), so they are
+present in every exec/attach session and survive a native restart:
+
+| Variable | When | Value |
+|----------|------|-------|
+| `ACQ_WORKSPACE` | any create with a workspace | guest path of the **primary** workspace (the agent's starting directory) |
+| `ACQ_CLONE` | `--clone` / `ACQ_CLONE=1` only | `1` — the primary is a disposable clone ([ADR-0027](adr/0027-neutral-clone-option.md)) |
+
+They are the kit-facing contract for "act on the clone, never on the real
+checkout": a startup step that writes agent instructions or a repo-local
+permission gate into the workspace should key on them rather than on a
+mount-type heuristic (the msb emulation mounts the scratch exactly like a
+passthrough, so `findmnt`-style probes cannot tell the two apart):
+
+```sh
+[ "${ACQ_CLONE:-0}" = 1 ] && ws="$ACQ_WORKSPACE"
+```
+
+The guard fails closed on both backends. `ACQ_WORKSPACE` is absent on a
+workspace-less create; `ACQ_CLONE` is never set to any value but `1`.
+
 > **Note (cross-repo, satisfied):** the authoritative `environment` schema
 > property and its field-level validator live in the patterns repo
 > (`schemas/kit-hybrid-v1.schema.json`, `validate-kits.py`), shipped in patterns

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -88,7 +88,10 @@ unaffected. Like the mounts themselves, `--clone` applies **at creation only**.
 A clone carries **committed state only** — no gitignored/untracked files and no
 uncommitted edits; commit first, or copy specific files in with `acq cp` (e.g.
 a needed `.env`). Removing the sandbox (`acq rm`) discards the clone, with a
-warning if it still holds commits you have not fetched. See
+warning if it still holds commits you have not fetched. Inside the sandbox,
+`ACQ_CLONE=1` and `ACQ_WORKSPACE` tell kits and scripts that the primary is a
+disposable clone and where it is (see the `environment` section of
+[BACKEND_GUIDE](BACKEND_GUIDE.md)). See
 [ADR-0027](adr/0027-neutral-clone-option.md) for the design and the per-backend
 mechanics.
 

--- a/docs/adr/0027-neutral-clone-option.md
+++ b/docs/adr/0027-neutral-clone-option.md
@@ -152,7 +152,9 @@ verified to reach every exec/attach session and to survive a native restart):
 - `ACQ_WORKSPACE=<guest path of the primary>` on any create with a workspace.
   On msb this is the canonical host path the primary mounts at; on sbx it is
   the logical absolute path sbx itself mounts at (sbx resolves `.` to the
-  `$PWD` form, not `realpath`).
+  `$PWD` form, not `realpath`). It names the primary's mount root, not the
+  agent's cwd: `ACQ_MSB_WORKSPACE` relocates only the start dir, and following
+  it would let `ACQ_CLONE=1` sit next to a secondary passthrough's real path.
 - `ACQ_CLONE=1` only when the primary is the disposable clone.
 
 The two facts are kept separate so a non-clone kit gets a neutral workspace

--- a/docs/adr/0027-neutral-clone-option.md
+++ b/docs/adr/0027-neutral-clone-option.md
@@ -135,6 +135,35 @@ agent writes land on the host — but confined to the acq-managed directory,
 which is disposable by construction and never executed by the host's git (a
 fetch transfers objects, not hooks or config).
 
+### Guest-visible markers (amended 2026-09-09)
+
+Mounting the scratch at the original path makes the clone indistinguishable
+from a passthrough mount **by design**, which is right for the agent but left
+kits with no honest signal for "write into the clone, never into the real
+checkout". Kits fell back to backend accidents (`findmnt -t ext4`, sbx's
+`WORKSPACE_DIR`) that the msb emulation does not reproduce, so such a step was
+a silent no-op on the default backend
+([GSA-TTS/agentic-coding-quickstart#456](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/456)).
+
+Both backends therefore set two neutral guest variables at create, via their
+native create-time env flag (`msb create --env`, `sbx create --env`; both
+verified to reach every exec/attach session and to survive a native restart):
+
+- `ACQ_WORKSPACE=<guest path of the primary>` on any create with a workspace.
+  On msb this is the canonical host path the primary mounts at; on sbx it is
+  the logical absolute path sbx itself mounts at (sbx resolves `.` to the
+  `$PWD` form, not `realpath`).
+- `ACQ_CLONE=1` only when the primary is the disposable clone.
+
+The two facts are kept separate so a non-clone kit gets a neutral workspace
+path for free, and because the workspace path alone must never be read as a
+clone signal: msb already records the primary's path at
+`/var/lib/acq/workspace` (root-written, for name-only re-attach) on every
+create, clone or not, and a kit that keyed on it wrote its files into a real
+checkout through a passthrough mount. A marker file inside the scratch was
+also rejected: it needs a `.git/info/exclude` entry and a post-create write on
+sbx's native clone.
+
 ## Consequences
 
 - **Positive:** disposable-primary workflows work identically on both backends;
@@ -152,3 +181,6 @@ fetch transfers objects, not hooks or config).
   than complicating the claim into an atomic `mkdir` with EEXIST handling.
 - **Scope:** applies at sandbox **creation** only; `acq stop`/restart preserve
   the scratch and remote; only `acq rm` (or a failed create) cleans them up.
+- **Kit contract:** `ACQ_WORKSPACE` / `ACQ_CLONE` (above) are documented in
+  `docs/BACKEND_GUIDE.md` and are the only supported way for a kit to detect
+  the clone; mount-type or origin-URL heuristics are not.

--- a/test/bats/116-clone-option.bats
+++ b/test/bats/116-clone-option.bats
@@ -329,11 +329,15 @@ _msb_clone_isolated() { # ARGS...
   assert_regex "$line" '--env ACQ_CLONE=1( |$)'
 }
 
-@test "clone(sbx #456): a relative workspace resolves to the logical absolute path, no ACQ_CLONE" {
+@test "clone(sbx #456): a relative workspace resolves against PWD (CDPATH ignored) to the logical path, no ACQ_CLONE" {
   printf 'sk-test\n' | env ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
   seed_sbx_usai_proxy_fixture
-  (cd "$CLONEPROJ" && env ACQ_BACKEND=sbx "$ACQ" create opencode . >/dev/null 2>&1)
+  # CDPATH points at a decoy holding a same-named dir: the marker must still
+  # resolve the relative workspace against $PWD, as sbx does, on one line.
+  mkdir -p "$STUBDIR/decoy/cloneproj"
+  (cd "$STUBDIR" && CDPATH="$STUBDIR/decoy" env ACQ_BACKEND=sbx "$ACQ" create opencode cloneproj >/dev/null 2>&1)
   local line logical; line=$(_create_line sbx); logical=$(cd "$CLONEPROJ" && pwd)
-  assert_regex "$line" "--env ACQ_WORKSPACE=${logical}( |\$)"
+  assert_regex "$line" "--env ACQ_WORKSPACE=${logical} "
+  refute_regex "$line" 'decoy'
   refute_regex "$line" 'ACQ_CLONE'
 }

--- a/test/bats/116-clone-option.bats
+++ b/test/bats/116-clone-option.bats
@@ -282,3 +282,58 @@ _msb_clone_isolated() { # ARGS...
   run git config --file "$scratch/.git/config" user.email
   assert_failure
 }
+
+# --- Guest-visible workspace markers (GSA-TTS/agentic-coding-quickstart#456) ---
+# A kit that must act only on the disposable clone (write agent instructions,
+# install a repo-local permission gate) and never on the real checkout needs a
+# deliberate, backend-neutral signal: ACQ_WORKSPACE (guest path of the primary)
+# on every create with a workspace, ACQ_CLONE=1 only under --clone. Both ride
+# the backend's native create-time --env flag, which reaches every exec/attach
+# session and survives a native restart (verified msb 0.6.17, sbx 0.42.1).
+
+@test "clone(msb #456): the guest gets ACQ_WORKSPACE and ACQ_CLONE=1 via create --env" {
+  _msb_clone -- create shell --clone "$CLONEPROJ"
+  load_acq
+  local repo line; repo=$(canonicalize_path "$CLONEPROJ"); line=$(_create_line msb)
+  assert_regex "$line" "--env ACQ_WORKSPACE=${repo}( |\$)"
+  assert_regex "$line" '--env ACQ_CLONE=1( |$)'
+}
+
+@test "clone(msb #456): a non-clone create exports ACQ_WORKSPACE but never ACQ_CLONE" {
+  _msb_clone -- create shell "$CLONEPROJ"
+  load_acq
+  local repo line; repo=$(canonicalize_path "$CLONEPROJ"); line=$(_create_line msb)
+  assert_regex "$line" "--env ACQ_WORKSPACE=${repo}( |\$)"
+  refute_regex "$line" 'ACQ_CLONE'
+}
+
+@test "clone(msb #456): a workspace-less create exports neither marker" {
+  _msb_clone -- create shell
+  assert_regex "$(cat "$CALLS")" 'msb create'
+  refute_regex "$(_create_line msb)" 'ACQ_WORKSPACE|ACQ_CLONE'
+}
+
+@test "clone(sbx #456): the guest gets ACQ_WORKSPACE and ACQ_CLONE=1 via create --env" {
+  printf 'sk-test\n' | env ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
+  seed_sbx_usai_proxy_fixture
+  env ACQ_BACKEND=sbx "$ACQ" create opencode --clone "$CLONEPROJ" >/dev/null 2>&1
+  local line logical; line=$(_create_line sbx); logical=$(cd "$CLONEPROJ" && pwd)
+  # sbx mounts the primary at its LOGICAL absolute host path (not realpath;
+  # on macOS the bats tmpdir is /var/..., a symlink to /private/var), so the
+  # marker must match that form for `cd "$ACQ_WORKSPACE"` to land.
+  assert_regex "$line" "--env ACQ_WORKSPACE=${logical}( |\$)"
+  local real; real=$(canonicalize_path "$CLONEPROJ")
+  if [ "$real" != "$logical" ]; then
+    refute_regex "$line" "ACQ_WORKSPACE=${real}( |\$)"
+  fi
+  assert_regex "$line" '--env ACQ_CLONE=1( |$)'
+}
+
+@test "clone(sbx #456): a relative workspace resolves to the logical absolute path, no ACQ_CLONE" {
+  printf 'sk-test\n' | env ACQ_BACKEND=sbx "$ACQ" secret set -g usai >/dev/null 2>&1 || true
+  seed_sbx_usai_proxy_fixture
+  (cd "$CLONEPROJ" && env ACQ_BACKEND=sbx "$ACQ" create opencode . >/dev/null 2>&1)
+  local line logical; line=$(_create_line sbx); logical=$(cd "$CLONEPROJ" && pwd)
+  assert_regex "$line" "--env ACQ_WORKSPACE=${logical}( |\$)"
+  refute_regex "$line" 'ACQ_CLONE'
+}

--- a/test/bats/116-clone-option.bats
+++ b/test/bats/116-clone-option.bats
@@ -307,6 +307,18 @@ _msb_clone_isolated() { # ARGS...
   refute_regex "$line" 'ACQ_CLONE'
 }
 
+@test "clone(msb #456): ACQ_MSB_WORKSPACE moves the start dir but ACQ_WORKSPACE stays on the clone's mount root" {
+  # The override relocates only where the agent starts. The marker must keep
+  # naming the primary mount, or a --clone kit would read ACQ_CLONE=1 next to
+  # a path that is not the clone and write into the wrong tree.
+  _msb_clone ACQ_MSB_WORKSPACE=/tmp/elsewhere -- create shell --clone "$CLONEPROJ"
+  load_acq
+  local repo line; repo=$(canonicalize_path "$CLONEPROJ"); line=$(_create_line msb)
+  assert_regex "$line" "--env ACQ_WORKSPACE=${repo}( |\$)"
+  refute_regex "$line" 'ACQ_WORKSPACE=/tmp/elsewhere'
+  assert_regex "$line" '--env ACQ_CLONE=1( |$)'
+}
+
 @test "clone(msb #456): a workspace-less create exports neither marker" {
   _msb_clone -- create shell
   assert_regex "$(cat "$CALLS")" 'msb create'


### PR DESCRIPTION
## Problem

A kit startup step that must act only on a `--clone` workspace (write agent instructions, install a repo-local permission gate) had no deliberate way to tell the disposable clone from a passthrough mount of the real host checkout. Kits keyed on backend accidents (`findmnt -t ext4`, sbx's `WORKSPACE_DIR`) that the msb emulation (ADR-0027) does not reproduce, so the step was a silent no-op on the default backend. GSA-TTS/agentic-coding-quickstart#453 removes the last accidental signal, the scratch's origin URL.

The msb-side `/var/lib/acq/workspace` file is not a substitute: it is written on every create, clone or not, and a kit that read it as a clone signal wrote into a real checkout through a passthrough mount.

## Fix

Both backends set two neutral guest variables at create through their native create-time env flag (`msb create --env`, `sbx create --env`):

- `ACQ_WORKSPACE=<guest path of the primary>` on any create with a workspace. On msb this is the canonical host path the primary mounts at. On sbx it is the logical absolute path sbx itself mounts at, since sbx resolves `.` to the `$PWD` form rather than `realpath`, and a canonical path would miss the mount under a symlinked directory like `/tmp`.
- `ACQ_CLONE=1` only when the primary is the disposable clone.

The two facts stay separate so a non-clone kit gets a neutral workspace path for free and the path can never be mistaken for a clone signal. A kit then uses:

```sh
[ "${ACQ_CLONE:-0}" = 1 ] && ws="$ACQ_WORKSPACE"
```

No kit-env plumbing is involved. The create-time flag reaches every exec/attach session and survives a native restart on both backends, so the startup script (which runs via `msb exec`, ADR-0017) sees it too.

The backend guide gains the kit-facing contract, ADR-0027 an amendment, CONCEPTS a pointer.

## Tests

Five new cases in `116-clone-option.bats`, four of which failed before the fix:

- msb: `--clone` create carries `--env ACQ_WORKSPACE=<path>` and `--env ACQ_CLONE=1`
- msb: a non-clone create carries `ACQ_WORKSPACE` but never `ACQ_CLONE`
- msb: a workspace-less create carries neither
- sbx: `--clone` create carries both, with the logical (not realpath) form asserted where the two differ
- sbx: a relative workspace resolves to the logical absolute path, no `ACQ_CLONE`

Full bats suite 465/465, shellcheck and markdownlint clean.

## Verification

Probed on throwaway sandboxes before choosing the mechanism:

- msb 0.6.17: `msb create --env` is visible to the agent user, root, exec with extra `-e`, and login shells, and is still present after `msb stop` + `msb start`.
- sbx 0.42.1: `sbx create --env` is visible in exec and login shells; `sbx create shell .` from `/tmp/x` reports `WORKSPACE_DIR=/tmp/x`, not `/private/tmp/x`.

## Sequencing

Lands after GSA-TTS/agentic-coding-quickstart#455 (fixes #453); both touch the msb clone setup in `acq.backends/msb.sh`.

Closes GSA-TTS/agentic-coding-quickstart#456

AI-assisted: yes.
