### PR TITLE
fix(ci): bump smol-toml to 1.7.1 to clear a high-severity DoS advisory

### DIFF
--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -12,6 +12,7 @@
   "overrides": {
     "js-yaml": "4.3.2",
     "markdown-it": "14.2.0",
-    "linkify-it": "5.0.2"
+    "linkify-it": "5.0.2",
+    "smol-toml": "1.7.1"
   }
 }


### PR DESCRIPTION
## Problem

The Markdown Lint job fails on every PR since 2026-09-09T18:07Z, when GHSA-7w5x-hrqm-74c2 (smol-toml <= 1.7.0, high severity, denial of service via malformed TOML) was published. The job runs `npm audit --audit-level=high` after installing the pinned linter dependencies in `.github/linters/`, and smol-toml is a transitive dependency of markdownlint-cli2. `main` and GSA-TTS/agentic-coding-quickstart#455 passed only because their runs predate the advisory; GSA-TTS/agentic-coding-quickstart#457 hit it first.

## Fix

Add an npm `overrides` entry pinning smol-toml to 1.7.1, the first patched version the advisory cites, and regenerate the lockfile (three lines). This is the same shape as the js-yaml override in GSA-TTS/agentic-coding-quickstart#454. `npm audit fix --force` was rejected because it would force-downgrade markdownlint-cli2 to 0.21.0.

## Verification

- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm ls smol-toml`: 1.7.1 overridden
- markdownlint-cli2 at the same tool version (0.22.1) against this repo's docs: 0 errors across 47 files

No behavioral change to linting; pure dependency bump.

AI-assisted: yes.
