### PR TITLE
fix(ci): bump smol-toml to 1.7.1 to clear an infinite-loop DoS advisory

### DIFF
--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -12,6 +12,7 @@
   "overrides": {
     "js-yaml": "4.3.2",
     "markdown-it": "14.2.0",
-    "linkify-it": "5.0.2"
+    "linkify-it": "5.0.2",
+    "smol-toml": "1.7.1"
   }
 }


### PR DESCRIPTION
## Summary

A second, newly-disclosed advisory (published/reviewed 2026-09-09, hours after GSA-TTS/agentic-coding-quickstart#454 merged) started failing the same `npm audit --audit-level=high` step in `.github/linters/`, re-blocking Markdown Lint on every open PR.

## Root cause

`smol-toml <=1.7.0` has [GHSA-7w5x-hrqm-74c2](https://github.com/advisories/GHSA-7w5x-hrqm-74c2) / CVE-2026-85730: `parse()` can be forced into an infinite loop (CPU pinned at 100%, never returns) by a value inside an array or inline table followed by a comment with no trailing newline — e.g. `parse('a=[1 #')` hangs forever. `markdownlint-cli2@0.22.1` declares `smol-toml@1.6.1` directly (a separate transitive dep from the `js-yaml`/`markdown-it`/`linkify-it` overrides already pinned here).

## Fix

Added `"smol-toml": "1.7.1"` to the same `overrides` block (the patched version per the advisory).

## Verification

- `npm install` now reports **0 vulnerabilities**.
- `markdownlint-cli2` stays at the same pinned version (0.22.1); a real lint pass against this repo's own docs still reports 0 errors — no behavioral change.

## Note

Companion fix needed identically in `agentic-coding-playbook` and `agentic-coding-patterns`, which share this same linter setup.

Co-authored-by: OpenCode Agent <agent@gsa.gov>