### PR TITLE
fix(msb): warn on broadened kit wildcard rules

### DIFF
--- a/acq.backends/msb.sh
+++ b/acq.backends/msb.sh
@@ -1157,7 +1157,7 @@ _acq_msb_fetch_kit() {
 # validated to look like a DNS name/wildcard BEFORE it reaches eval, so a
 # malformed or malicious spec value can't smuggle shell metacharacters in.
 _acq_msb_net_rules_into() {
-  local _arr="$1" _spec="$2" _host _target
+  local _arr="$1" _spec="$2" _host _target _warned_crl=0
   eval "$_arr=()"
   while IFS= read -r _host; do
     [ -n "$_host" ] || continue
@@ -1171,6 +1171,15 @@ _acq_msb_net_rules_into() {
     # handles ports/DNS for the allowed host), then reuse the balanced-egress target
     # normalizer so per-kit `**.host` wildcards get the same msb suffix form.
     _host="${_host%%:*}"
+    case "$_host" in
+      "crl*."*)
+        if [ "$_warned_crl" -eq 0 ]; then
+          echo "acq(msb): note: broadening 'crl*.' kit net-allow entries to parent domains" >&2
+          echo "acq(msb):   suffixes (msb has no intra-label glob; widens vs. sbx wildcard)." >&2
+          _warned_crl=1
+        fi
+        ;;
+    esac
     _target=$(_acq_msb_balanced_target "$_host" "kit net-allow entry") || continue
     eval "$_arr+=(--net-rule \"allow@\${_target}\")"
   done <<EOF

--- a/test/bats/110-volumes.bats
+++ b/test/bats/110-volumes.bats
@@ -255,12 +255,15 @@ caps:
       - api.gsa.usai.gov
       - github.com:443
       - "**.cloud.gov:443"
+      - crl*.example.gov:80
 SPEC
     arr=(); _acq_msb_net_rules_into arr "$nkit/spec.yaml"; printf "%s\n" "${arr[@]}"
   '
+  assert_output --partial "broadening 'crl*.' kit net-allow entries"
   assert_output --partial 'allow@api.gsa.usai.gov'
   assert_output --partial 'allow@github.com'
   assert_output --partial 'allow@*.cloud.gov'
+  assert_output --partial 'allow@*.example.gov'
   refute_output --partial 'allow@**.cloud.gov'
   refute_output --partial 'allow@domain='
   refute_output --partial 'allow@domain:'


### PR DESCRIPTION
## Summary
- Emit a one-time warning when a kit `caps.network.allow` entry uses an intra-label `crl*.` wildcard.
- Keep the existing broadened msb translation to the parent suffix rule.
- Extend the msb net-rule regression test to cover the warning and translated target.

## Context
Follow-up to `GSA-TTS/agentic-coding-quickstart#451`: per-kit wildcard normalization now reuses the balanced-egress target helper, but the per-kit caller did not emit the same widening note for `crl*.` patterns that msb cannot represent exactly.

## Verification
- Passed: `./scripts/test-acq-bats test/bats/110-volumes.bats test/bats/111-balanced-egress.bats`
- Passed: `bash -n acq.backends/msb.sh`
- Passed: `git diff --check`
- Passed: `shellcheck --severity=warning acq.backends/msb.sh test/bats/110-volumes.bats`

## Security Impact
- No new egress is declared by acq itself.
- The change makes an existing msb widening behavior visible for kit-provided intra-label globs.
- No secrets, auth flows, or persistence behavior changed.

## Rollback
Revert this commit to remove the per-kit `crl*.` widening warning while keeping the previously merged wildcard translation behavior.

## AI Assistance
AI-assisted implementation and verification.
