### PR TITLE
fix(install): keep curl | sh stdin intact and tap msb formula first

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -556,13 +556,19 @@ if [ "$INSTALL_MSB" -eq 1 ]; then
           printf '  [dry-run] curl -fsSL https://install.microsandbox.dev | sh\n'
         else
           # Fetch to a variable then pipe to sh, so the nested installer does not
-          # fight this script for the `curl | sh` stdin pipe (fd 0).
-          msb_installer="$(curl -fsSL https://install.microsandbox.dev)" \
-            && printf '%s' "$msb_installer" | sh \
-            || warn "  microsandbox install script failed; install msb manually (see below)."
+          # fight this script for the `curl | sh` stdin pipe (fd 0). On download
+          # failure, fall through to the same skip guidance the decline path prints.
+          if msb_installer="$(curl -fsSL https://install.microsandbox.dev)"; then
+            printf '%s' "$msb_installer" | sh
+          else
+            INSTALL_MSB=0
+          fi
         fi
       fi
     else
+      INSTALL_MSB=0
+    fi
+    if [ "$INSTALL_MSB" -eq 0 ]; then
       warn "  Skipping msb. Install it later with one of:"
       info  "    brew install superradcompany/tap/microsandbox"
       info  "    curl -fsSL https://install.microsandbox.dev | sh"

--- a/install.sh
+++ b/install.sh
@@ -86,8 +86,8 @@ warn()  { printf '%s%s%s\n' "$YEL" "$*" "$R" >&2; }
 ok()    { printf '%s%s%s\n' "$GRN" "$*" "$R"; }
 die()   { printf '%serror:%s %s\n' "$RED" "$R" "$*" >&2; exit 1; }
 
-# In dry-run, show what would run; otherwise run it. Child stdin is detached
-# (`</dev/null`) so a child never consumes the `curl | sh` script pipe (fd 0).
+# In dry-run, show what would run; otherwise run it. Child stdin is detached so
+# a child never consumes the `curl | sh` script pipe (fd 0).
 run() {
   if [ "$DRY_RUN" -eq 1 ]; then
     printf '  [dry-run] %s\n' "$*"
@@ -545,8 +545,7 @@ if [ "$INSTALL_MSB" -eq 1 ]; then
     if confirm "  Install msb now?"; then
       if command -v brew >/dev/null 2>&1; then
         info "  Installing via Homebrew..."
-        # Tap first: a fresh host has not tapped superradcompany/tap, so a bare
-        # `brew install superradcompany/tap/microsandbox` fails with "No available formula".
+        # Tap first: a fresh host has not tapped superradcompany/tap.
         run brew tap superradcompany/tap
         run brew install superradcompany/tap/microsandbox
       else
@@ -555,9 +554,7 @@ if [ "$INSTALL_MSB" -eq 1 ]; then
         if [ "$DRY_RUN" -eq 1 ]; then
           printf '  [dry-run] curl -fsSL https://install.microsandbox.dev | sh\n'
         else
-          # Fetch to a variable then pipe to sh, so the nested installer does not
-          # fight this script for the `curl | sh` stdin pipe (fd 0). On download
-          # failure, fall through to the same skip guidance the decline path prints.
+          # Fetch then pipe, so the child does not read the curl | sh script pipe (fd 0).
           if msb_installer="$(curl -fsSL https://install.microsandbox.dev)"; then
             printf '%s' "$msb_installer" | sh
           else

--- a/install.sh
+++ b/install.sh
@@ -86,12 +86,13 @@ warn()  { printf '%s%s%s\n' "$YEL" "$*" "$R" >&2; }
 ok()    { printf '%s%s%s\n' "$GRN" "$*" "$R"; }
 die()   { printf '%serror:%s %s\n' "$RED" "$R" "$*" >&2; exit 1; }
 
-# In dry-run, show what would run; otherwise run it.
+# In dry-run, show what would run; otherwise run it. Child stdin is detached
+# (`</dev/null`) so a child never consumes the `curl | sh` script pipe (fd 0).
 run() {
   if [ "$DRY_RUN" -eq 1 ]; then
     printf '  [dry-run] %s\n' "$*"
   else
-    "$@"
+    "$@" </dev/null
   fi
 }
 
@@ -544,6 +545,9 @@ if [ "$INSTALL_MSB" -eq 1 ]; then
     if confirm "  Install msb now?"; then
       if command -v brew >/dev/null 2>&1; then
         info "  Installing via Homebrew..."
+        # Tap first: a fresh host has not tapped superradcompany/tap, so a bare
+        # `brew install superradcompany/tap/microsandbox` fails with "No available formula".
+        run brew tap superradcompany/tap
         run brew install superradcompany/tap/microsandbox
       else
         info "  Homebrew not found; using the microsandbox install script."
@@ -551,7 +555,11 @@ if [ "$INSTALL_MSB" -eq 1 ]; then
         if [ "$DRY_RUN" -eq 1 ]; then
           printf '  [dry-run] curl -fsSL https://install.microsandbox.dev | sh\n'
         else
-          curl -fsSL https://install.microsandbox.dev | sh
+          # Fetch to a variable then pipe to sh, so the nested installer does not
+          # fight this script for the `curl | sh` stdin pipe (fd 0).
+          msb_installer="$(curl -fsSL https://install.microsandbox.dev)" \
+            && printf '%s' "$msb_installer" | sh \
+            || warn "  microsandbox install script failed; install msb manually (see below)."
         fi
       fi
     else

--- a/test/bats/05-install.bats
+++ b/test/bats/05-install.bats
@@ -80,6 +80,29 @@ STUB
   chmod +x "$STUBDIR/bin/brew"
 }
 
+# Logs each brew invocation's argv (one per line) so tests can assert ordering.
+_write_brew_logging_stub() {
+  cat >"$STUBDIR/bin/brew" <<'STUB'
+#!/usr/bin/env sh
+printf '%s\n' "$*" >>"${BREW_STUB_LOG:?}"
+exit 0
+STUB
+  chmod +x "$STUBDIR/bin/brew"
+}
+
+# Reads one stdin line and records it; empty marker `ate:[]` proves run()
+# detached child stdin from the `curl | sh` script pipe.
+_write_stdin_eating_brew_stub() {
+  cat >"$STUBDIR/bin/brew" <<'STUB'
+#!/usr/bin/env bash
+line=""
+IFS= read -r line || true
+printf 'ate:[%s]\n' "$line" >>"${BREW_STUB_LOG:?}"
+exit 0
+STUB
+  chmod +x "$STUBDIR/bin/brew"
+}
+
 _write_npm_stub() {
   cat >"$STUBDIR/bin/npm" <<'STUB'
 #!/usr/bin/env sh
@@ -281,4 +304,40 @@ _no_package_manager_path() {
   assert_success
   assert_output --partial "verified HEAD matches pinned commit $release_sha"
   assert_regex "$(cat "$GIT_STUB_LOG")" "fetch --unshallow --tags origin"
+}
+
+# --- msb Homebrew path: tap before install, on a fresh host ----------------
+
+@test "install: msb via brew taps superradcompany/tap before installing" {
+  export BREW_STUB_LOG="$BATS_TEST_TMPDIR/brew.log"
+  _write_brew_logging_stub
+  _write_npm_stub
+  run env PATH="$STUBDIR/bin:$(_acq_coreutils_path)" \
+    sh "$REPO_ROOT/install.sh" --method npm --yes
+
+  assert_success
+  assert_regex "$(cat "$BREW_STUB_LOG")" "tap superradcompany/tap"
+  tap_line=$(grep -n 'tap superradcompany/tap' "$BREW_STUB_LOG" | head -1 | cut -d: -f1)
+  install_line=$(grep -n 'install superradcompany/tap/microsandbox' "$BREW_STUB_LOG" | head -1 | cut -d: -f1)
+  [ -n "$tap_line" ] && [ -n "$install_line" ]
+  [ "$tap_line" -lt "$install_line" ]
+}
+
+@test "install: run() detaches child stdin so piped script tail survives" {
+  export BREW_STUB_LOG="$BATS_TEST_TMPDIR/brew.log"
+  _write_stdin_eating_brew_stub
+  _write_npm_stub
+
+  # Pipe the installer plus a trailing marker to `sh` (fd 0 = script bytes), the
+  # exact `curl | sh` shape; a leaky child would steal the marker line.
+  installer="$(cat "$REPO_ROOT/install.sh"; printf 'echo STOLEN_TAIL_BYTES\n')"
+
+  run env PATH="$STUBDIR/bin:$(_acq_coreutils_path)" \
+    BREW_STUB_LOG="$BREW_STUB_LOG" \
+    sh -c 'printf "%s" "$1" | sh -s -- --method npm --yes' _ "$installer"
+
+  assert_success
+  run cat "$BREW_STUB_LOG"
+  assert_output --partial "ate:[]"
+  refute_output --partial "STOLEN"
 }

--- a/test/bats/05-install.bats
+++ b/test/bats/05-install.bats
@@ -90,8 +90,7 @@ STUB
   chmod +x "$STUBDIR/bin/brew"
 }
 
-# Reads one stdin line and records it; empty marker `ate:[]` proves run()
-# detached child stdin from the `curl | sh` script pipe.
+# Records one stdin line; empty marker `ate:[]` proves run() detached child stdin.
 _write_stdin_eating_brew_stub() {
   cat >"$STUBDIR/bin/brew" <<'STUB'
 #!/usr/bin/env bash
@@ -306,8 +305,6 @@ _no_package_manager_path() {
   assert_regex "$(cat "$GIT_STUB_LOG")" "fetch --unshallow --tags origin"
 }
 
-# --- msb Homebrew path: tap before install, on a fresh host ----------------
-
 @test "install: msb via brew taps superradcompany/tap before installing" {
   export BREW_STUB_LOG="$BATS_TEST_TMPDIR/brew.log"
   _write_brew_logging_stub
@@ -328,8 +325,8 @@ _no_package_manager_path() {
   _write_stdin_eating_brew_stub
   _write_npm_stub
 
-  # Pipe the installer plus a trailing marker to `sh` (fd 0 = script bytes), the
-  # exact `curl | sh` shape; a leaky child would steal the marker line.
+  # Pipe the installer plus a trailing marker (fd 0 = script bytes); a leaky
+  # child would steal the marker line.
   installer="$(cat "$REPO_ROOT/install.sh"; printf 'echo STOLEN_TAIL_BYTES\n')"
 
   run env PATH="$STUBDIR/bin:$(_acq_coreutils_path)" \


### PR DESCRIPTION
## Context

Running the documented one-line installer on a fresh macOS host —
`curl -fsSL https://github.com/GSA-TTS/agentic-coding-quickstart/releases/download/v3.1.0/install.sh | sh` —
produced a corrupted run: `acq` installed, but the optional msb step printed the
installer's own raw source into the terminal (a garbled line like
`curl -fsSL https:/🍺  /opt/homebrew/Cellar/acq/3.1.0: …`) and the msb Homebrew
install failed with `No available formula with the name "superradcompany/tap/microsandbox"`.

Two independent defects, both specific to the `curl … | sh` entry point:

### 1. Children inherited the `curl | sh` script pipe as stdin

Under `curl … | sh`, the shell reads the script itself from fd 0 (the pipe).
Any child process the installer spawned inherited that same fd 0 and, if it read
stdin, consumed the not-yet-parsed tail of the script. `sh` then parsed a
truncated/garbled remainder — which is exactly the leaked msb source text
observed in the terminal.

Fix:
- `run()` now invokes every external command with `"$@" </dev/null`, so a child
  can never consume the script pipe.
- The `brew`-absent microsandbox fallback fetches the installer into a variable
  and pipes *that* to `sh` (`printf '%s' "$msb_installer" | sh`) instead of
  chaining a second raw `curl … | sh` over the same stdin.

### 2. msb Homebrew install assumed the tap was already present

On a host that had never tapped `superradcompany/tap`,
`brew install superradcompany/tap/microsandbox` fails with "No available
formula". (Manually running `brew tap` / `brew install` afterward succeeds,
which is why the retry appeared to work.)

Fix: the msb Homebrew path runs `brew tap superradcompany/tap` before the
install.

The existing check-then-consent flow is unchanged: the installer still checks
`command -v msb`, prompts via `confirm()`, and only taps/installs inside the
approved yes-branch. `confirm()` still fails closed (declines) when no terminal
is reachable.

A failed microsandbox download now falls through to the **same** "Skipping msb.
Install it later with…" guidance the decline path already prints (reusing the
existing message rather than introducing a new one), instead of aborting.

## Verification

Offline bats suite (stubbed brew/npm/git, no network), run with the pinned
vendored bats:

```
$ ACQ_BATS_JOBS=1 ./test/vendor/bats-core/bin/bats test/bats/05-install.bats
1..14
ok 1 install: source default targets release tag without a pinned sha
...
ok 13 install: msb via brew taps superradcompany/tap before installing
ok 14 install: run() detaches child stdin so piped script tail survives
```

Full suite: 464 tests, all `ok`. `sh -n install.sh` passes.

Two new regression tests in `test/bats/05-install.bats`:
- **tap-before-install** — asserts `brew tap superradcompany/tap` is logged and
  ordered before `brew install …/microsandbox`.
- **piped-stdin safety** — drives the installer through a real
  `printf … | sh` pipe with a trailing marker line and a stdin-reading brew
  stub; asserts the child reads EOF (`ate:[]`) and never steals the marker.

Both were confirmed to fail against the pre-fix behavior (reverting the two
changes makes each test fail).

## Rollback

Revert this commit. Changes are confined to `install.sh` and
`test/bats/05-install.bats`; no runtime/config/state changes.

## Security Impact

No change to authentication, authorization, or data handling. Reduces attack
surface slightly by not letting child processes read the piped-script stdin.
The consent gate before any install is preserved and still fails closed.

---

AI-assisted: authored with OpenCode; reviewed by the PR author.

